### PR TITLE
perf: 优化上下文 KV-cache 命中率

### DIFF
--- a/agent/context.go
+++ b/agent/context.go
@@ -6,10 +6,10 @@ import (
 	"xbot/llm"
 )
 
+// defaultSystemPrompt 系统提示词模板
+// 注意：拼接顺序经过优化以最大化 KV-cache 命中率
+// 固定内容在前（Guidelines、Channels、WorkEnv），易变内容在后（Skills、Memory、Time）
 const defaultSystemPrompt = `You are xbot, a helpful AI assistant.
-
-## Current Time
-%s
 
 ## Guidelines
 - Be concise, accurate, and helpful
@@ -33,11 +33,18 @@ To recall past events, grep HISTORY.md in the working directory.
 `
 
 // BuildMessages 构建完整的 LLM 消息列表
+// 拼接顺序：固定提示词 → Skills → Memory → Time（易变内容在后，最大化 KV-cache 命中）
 func BuildMessages(history []llm.ChatMessage, userContent string, channel string, memory *MemoryStore, memoryDir string, workDir string, skillsPrompt string) []llm.ChatMessage {
 	now := time.Now().Format("2006-01-02 15:04:05 MST")
-	systemContent := fmt.Sprintf(defaultSystemPrompt, now, channel, workDir, memoryDir, memoryDir)
 
-	// 注入长期记忆
+	systemContent := fmt.Sprintf(defaultSystemPrompt, channel, workDir, memoryDir, memoryDir)
+
+	// 注入已激活的 skills（相对稳定，放在 Memory 之前）
+	if skillsPrompt != "" {
+		systemContent += "\n" + skillsPrompt
+	}
+
+	// 注入长期记忆（会随合并变化，放在 Skills 之后）
 	if memory != nil {
 		memCtx := memory.GetMemoryContext()
 		if memCtx != "" {
@@ -45,14 +52,15 @@ func BuildMessages(history []llm.ChatMessage, userContent string, channel string
 		}
 	}
 
-	// 注入已激活的 skills
-	if skillsPrompt != "" {
-		systemContent += "\n" + skillsPrompt
-	}
+	// 时间戳放在系统提示词最末尾（每次请求都变，放最后以最大化前缀缓存命中）
+	systemContent += fmt.Sprintf("\n## Current Time\n%s\n", now)
 
 	messages := make([]llm.ChatMessage, 0, len(history)+2)
 	messages = append(messages, llm.NewSystemMessage(systemContent))
 	messages = append(messages, history...)
-	messages = append(messages, llm.NewUserMessage(userContent))
+
+	// 用户消息中也注入时间戳，确保模型在近期注意力范围内感知当前时间
+	userMsg := fmt.Sprintf("[%s]\n%s", now, userContent)
+	messages = append(messages, llm.NewUserMessage(userMsg))
 	return messages
 }

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,21 @@
+You are xbot, a helpful AI assistant.
+
+## Guidelines
+- Be concise, accurate, and helpful
+- Use tools when needed to accomplish tasks
+- Explain what you're doing before taking actions
+- Ask for clarification when the request is ambiguous
+
+## Available Channels
+You are communicating through the "{{.Channel}}" channel. You shoud always respond in markdown format(e.g. *bold*, _italic_, [a](local/a.txt)).
+
+## Working Environment
+- Working directory: {{.WorkDir}} (Shell commands run here; use relative paths when possible)
+- Internal data: .xbot/ (session, skills — managed automatically)
+
+## Memory Files
+- Long-term memory: {{.MemoryDir}}/MEMORY.md (always loaded below)
+- History log: {{.MemoryDir}}/HISTORY.md (grep-searchable event log)
+
+When remembering something important, write to MEMORY.md in the working directory.
+To recall past events, grep HISTORY.md in the working directory.

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"sort"
 	"xbot/llm"
 )
 
@@ -69,21 +70,27 @@ func (r *Registry) Get(name string) (Tool, bool) {
 	return tool, ok
 }
 
-// List 列出所有工具
+// List 列出所有工具（按名称排序，保证顺序稳定以优化 KV-cache）
 func (r *Registry) List() []Tool {
 	tools := make([]Tool, 0, len(r.tools))
 	for _, tool := range r.tools {
 		tools = append(tools, tool)
 	}
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name() < tools[j].Name()
+	})
 	return tools
 }
 
-// AsDefinitions 转换为 LLM 工具定义列表
+// AsDefinitions 转换为 LLM 工具定义列表（按名称排序，保证顺序稳定以优化 KV-cache）
 func (r *Registry) AsDefinitions() []llm.ToolDefinition {
 	defs := make([]llm.ToolDefinition, 0, len(r.tools))
 	for _, tool := range r.tools {
 		defs = append(defs, tool)
 	}
+	sort.Slice(defs, func(i, j int) bool {
+		return defs[i].Name() < defs[j].Name()
+	})
 	return defs
 }
 


### PR DESCRIPTION
## 改动说明

对照 [Manus Context Engineering](https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus) 文章的最佳实践，优化 xbot 的上下文缓存命中率。

### 修复的问题

| 问题 | 修复方式 |
|------|----------|
| 时间戳在系统提示词开头，每次请求破坏整个前缀缓存 | 移到系统提示词**最末尾** |
| Memory 变化导致 Skills 缓存失效 | 调整拼接顺序：固定内容 → Skills → Memory → Time |
| 工具定义列表顺序不稳定（map 遍历随机） | `AsDefinitions()` 和 `List()` 按名称排序 |

### 用户消息时间戳

时间戳移出系统提示词开头后，在用户消息中注入 `[时间戳]` 前缀，确保模型在近期注意力范围内感知当前时间。

### 变更文件

- `agent/context.go` — 重构拼接顺序 + 时间戳末尾 + 用户消息注入时间戳
- `tools/interface.go` — 工具列表排序
- `prompt.md` — 模板同步移除时间戳

### 编译

✅ `go build ./...` 通过