### PR TITLE
feat: 添加 Notify 工具，支持长任务中间进度通知

### DIFF
--- a/tools/interface.go
+++ b/tools/interface.go
@@ -114,5 +114,6 @@ func DefaultRegistry() *Registry {
 	r.Register(NewWebSearchTool())
 	// r.Register(&SubAgentTool{})
 	r.Register(NewCronTool())
+	r.Register(&NotifyTool{})
 	return r
 }

--- a/tools/notify.go
+++ b/tools/notify.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"xbot/llm"
+)
+
+// NotifyTool 向用户发送中间通知，用于长时间任务的进度汇报
+type NotifyTool struct{}
+
+func (t *NotifyTool) Name() string {
+	return "Notify"
+}
+
+func (t *NotifyTool) Description() string {
+	return `Send a progress notification to the user during long-running tasks.
+Use this tool to keep the user informed about intermediate progress without waiting for the final response.
+Guidelines:
+  - Use when a task is expected to take more than 30 seconds
+  - Use between major steps of a multi-step task
+  - Do NOT overuse — avoid sending more than one notification per step
+Parameters (JSON):
+  - message: string, the notification content to send to the user
+Example: {"message": "已完成第1篇论文的下载，正在处理第2篇..."}`
+}
+
+func (t *NotifyTool) Parameters() []llm.ToolParam {
+	return []llm.ToolParam{
+		{Name: "message", Type: "string", Description: "The notification content to send to the user", Required: true},
+	}
+}
+
+func (t *NotifyTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, error) {
+	var params struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(input), &params); err != nil {
+		return nil, fmt.Errorf("invalid parameters: %w", err)
+	}
+
+	if params.Message == "" {
+		return nil, fmt.Errorf("message is required")
+	}
+
+	if toolCtx.SendFunc == nil {
+		return nil, fmt.Errorf("send function not available")
+	}
+
+	// 直接通过 SendFunc 发送消息给用户，不中断 Agent 循环
+	toolCtx.SendFunc(toolCtx.Channel, toolCtx.ChatID, params.Message)
+
+	return NewResult("Notification sent to user."), nil
+}


### PR DESCRIPTION
## 改动

新增 `Notify` 工具，让 Agent 在执行长时间任务时能主动向用户发送中间进度通知，而不必等到最终回复。

### 实现方式

- 新增 `tools/notify.go`：通过 `ToolContext.SendFunc` 直接向用户发送消息，不中断 Agent 循环
- 在 `DefaultRegistry()` 中注册

### 使用场景

- 预计耗时超过 30 秒的任务，先通知用户开始处理
- 多步骤任务（如批量下载论文），每完成一个关键阶段通知进度
- 避免用户长时间等待无反馈

### 工具参数

```json
{
  "message": "已完成第1篇论文的下载，正在处理第2篇..."
}
```

### 变更文件

- `tools/notify.go` — 新增 Notify 工具实现（+53 行）
- `tools/interface.go` — 注册到 DefaultRegistry（+1 行）

编译通过 ✅