### PR TITLE
feat: feishu file/image download support

### DIFF
--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -842,6 +842,21 @@ func (f *FeishuChannel) parseContent(msgType string, msg *larkim.EventMessage) s
 		}
 	case "post":
 		return f.extractPostText(contentJSON)
+	case "file":
+		fileKey, _ := contentJSON["file_key"].(string)
+		fileName, _ := contentJSON["file_name"].(string)
+		messageID := ""
+		if msg.MessageId != nil {
+			messageID = *msg.MessageId
+		}
+		return fmt.Sprintf(`<file name="%s" file_key="%s" message_id="%s" />`, fileName, fileKey, messageID)
+	case "image":
+		imageKey, _ := contentJSON["image_key"].(string)
+		messageID := ""
+		if msg.MessageId != nil {
+			messageID = *msg.MessageId
+		}
+		return fmt.Sprintf(`<image image_key="%s" message_id="%s" />`, imageKey, messageID)
 	default:
 		return fmt.Sprintf("[%s]", msgType)
 	}

--- a/tools/download.go
+++ b/tools/download.go
@@ -1,0 +1,174 @@
+package tools
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"xbot/llm"
+	log "xbot/logger"
+)
+
+// DownloadFileTool downloads files/images sent by users in chat.
+// Currently supports: feishu (via Message Resource API).
+type DownloadFileTool struct{}
+
+func (t *DownloadFileTool) Name() string {
+	return "DownloadFile"
+}
+
+func (t *DownloadFileTool) Description() string {
+	return `Download files/images sent by users in Feishu chat.
+Activate when: (1) user sends a file <file .../> or image <image .../> in chat, (2) user asks to download/save a file from the conversation. The message content will contain file_key/image_key as XML attributes.
+Parameters (JSON):
+  - message_id: string, the Feishu message ID containing the resource (from XML tag attribute)
+  - file_key: string, the file_key or image_key to download (from XML tag attribute)
+  - output_path: string, where to save the file (relative to working directory or absolute)
+  - type: string, optional, "file" (default) or "image"
+Example: {"message_id": "om_xxx", "file_key": "file_v3_xxx", "output_path": "downloads/report.pdf"}
+Example: {"message_id": "om_xxx", "file_key": "img_v3_xxx", "output_path": "downloads/photo.png", "type": "image"}`
+}
+
+func (t *DownloadFileTool) Parameters() []llm.ToolParam {
+	return []llm.ToolParam{
+		{Name: "message_id", Type: "string", Description: "The Feishu message ID containing the resource", Required: true},
+		{Name: "file_key", Type: "string", Description: "The file_key or image_key to download", Required: true},
+		{Name: "output_path", Type: "string", Description: "Where to save the file (relative to working directory or absolute)", Required: true},
+		{Name: "type", Type: "string", Description: "Resource type: \"file\" (default) or \"image\"", Required: false},
+	}
+}
+
+func (t *DownloadFileTool) Execute(ctx *ToolContext, input string) (*ToolResult, error) {
+	var params struct {
+		MessageID  string `json:"message_id"`
+		FileKey    string `json:"file_key"`
+		OutputPath string `json:"output_path"`
+		Type       string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(input), &params); err != nil {
+		return nil, fmt.Errorf("invalid parameters: %w", err)
+	}
+
+	if params.MessageID == "" {
+		return nil, fmt.Errorf("message_id is required")
+	}
+	if params.FileKey == "" {
+		return nil, fmt.Errorf("file_key is required")
+	}
+	if params.OutputPath == "" {
+		return nil, fmt.Errorf("output_path is required")
+	}
+	if params.Type == "" {
+		params.Type = "file"
+	}
+
+	// Resolve output path
+	outputPath := params.OutputPath
+	if !filepath.IsAbs(outputPath) && ctx != nil && ctx.WorkingDir != "" {
+		outputPath = filepath.Join(ctx.WorkingDir, outputPath)
+	}
+
+	switch ctx.Channel {
+	case "feishu":
+		return t.downloadFeishu(params.MessageID, params.FileKey, params.Type, outputPath)
+	default:
+		return nil, fmt.Errorf("file download not supported for channel: %s", ctx.Channel)
+	}
+}
+
+// downloadFeishu downloads a file/image from Feishu via Message Resource API.
+func (t *DownloadFileTool) downloadFeishu(messageID, fileKey, fileType, outputPath string) (*ToolResult, error) {
+	token, err := t.getFeishuTenantToken()
+	if err != nil {
+		return nil, fmt.Errorf("get tenant token: %w", err)
+	}
+
+	apiURL := fmt.Sprintf("https://open.feishu.cn/open-apis/im/v1/messages/%s/resources/%s?type=%s",
+		messageID, fileKey, fileType)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("feishu API error: HTTP %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return nil, fmt.Errorf("create output directory: %w", err)
+	}
+
+	outFile, err := os.Create(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("create output file: %w", err)
+	}
+	defer outFile.Close()
+
+	written, err := io.Copy(outFile, resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("write file: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"message_id":  messageID,
+		"file_key":    fileKey,
+		"output_path": outputPath,
+		"size":        written,
+	}).Info("File downloaded from Feishu")
+
+	return NewResult(fmt.Sprintf("Downloaded: %s (%d bytes)", outputPath, written)), nil
+}
+
+// getFeishuTenantToken obtains a tenant_access_token using app credentials from environment.
+func (t *DownloadFileTool) getFeishuTenantToken() (string, error) {
+	appID := os.Getenv("FEISHU_APP_ID")
+	appSecret := os.Getenv("FEISHU_APP_SECRET")
+	if appID == "" || appSecret == "" {
+		return "", fmt.Errorf("FEISHU_APP_ID and FEISHU_APP_SECRET must be set")
+	}
+
+	reqBody, _ := json.Marshal(map[string]string{
+		"app_id":     appID,
+		"app_secret": appSecret,
+	})
+
+	resp, err := http.Post(
+		"https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+		"application/json; charset=utf-8",
+		bytes.NewReader(reqBody),
+	)
+	if err != nil {
+		return "", fmt.Errorf("request tenant token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Code              int    `json:"code"`
+		Msg               string `json:"msg"`
+		TenantAccessToken string `json:"tenant_access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if result.Code != 0 {
+		return "", fmt.Errorf("tenant token API error: code=%d, msg=%s", result.Code, result.Msg)
+	}
+	if result.TenantAccessToken == "" {
+		return "", fmt.Errorf("empty tenant_access_token in response")
+	}
+
+	return result.TenantAccessToken, nil
+}

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -149,5 +149,6 @@ func DefaultRegistry() *Registry {
 	// r.Register(&NotifyTool{})
 	r.Register(&UserProfileTool{})
 	r.Register(&SelfProfileTool{})
+	r.Register(&DownloadFileTool{})
 	return r
 }


### PR DESCRIPTION
## Changes

### 1. New `DownloadFile` tool (`tools/download.go`)
- Generic file download tool dispatched by `ToolContext.Channel`
- **Feishu**: downloads via [Message Resource API](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message-resource/get), auto-obtains `tenant_access_token` from `FEISHU_APP_ID` / `FEISHU_APP_SECRET`
- Extensible: other channels can be added via `switch ctx.Channel`
- Registered in `DefaultRegistry` (`tools/interface.go`)

### 2. Parse file/image messages in `channel/feishu.go`
- **File messages** → `<file name="report.pdf" file_key="file_v3_xxx" message_id="om_xxx" />`
- **Image messages** → `<image image_key="img_v3_xxx" message_id="om_xxx" />`
- XML tags are self-contained: all parameters needed for download are embedded

### How it works
1. User sends a file in Feishu → bot sees `<file name="report.pdf" file_key="file_v3_xxx" message_id="om_xxx" />`
2. Agent calls `DownloadFile` tool with `message_id`, `file_key`, `output_path`
3. Tool detects `channel=feishu`, downloads via Feishu API, saves to disk
4. Returns `Downloaded: /path/to/file (12345 bytes)`

### Removed
- Deleted `feishu-file` skill (replaced by built-in tool)