### PR TITLE
ci: enable gofmt formatter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,3 +4,7 @@ linters:
   disable:
     - errcheck
     - staticcheck
+
+formatters:
+  enable:
+    - gofmt

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -831,5 +831,3 @@ func (a *Agent) ProcessDirect(ctx context.Context, content string) (string, erro
 	}
 	return resp.Content, nil
 }
-
-


### PR DESCRIPTION
## Problem

`golangci-lint` 默认不检查代码格式（空行、空白等），导致 `make fmt` 有差异但 `make lint` 通过，CI 无法发现格式问题。

## Solution

- `.golangci.yml` 新增 `formatters.enable: [gofmt]`，让 lint 同时检查代码格式
- 修复 `agent/agent.go` 末尾多余空行

## Changes

| 文件 | 变更 |
|------|------|
| `.golangci.yml` | 启用 gofmt formatter |
| `agent/agent.go` | 去掉末尾多余空行 |