### PR TITLE
fix: subagent timeout handling and graceful degradation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -835,7 +835,7 @@ func (a *Agent) RunSubAgent(ctx context.Context, parentAgentID string, task stri
 	}).Info("SubAgent started")
 
 	// 子 Agent 迭代循环（与主 Agent 的 runLoop 类似，但使用独立工具集）
-	maxIter := 10                  // SubAgent 最大 10 轮（不用 a.maxIterations）
+	maxIter := 100                 // SubAgent 最大 100 轮（不用 a.maxIterations）
 	llmTimeout := 3 * time.Minute  // 单轮 LLM 超时
 	toolTimeout := 2 * time.Minute // 单个工具超时
 	var toolsUsed []string


### PR DESCRIPTION
## Problem

SubAgent 工具调用被外层 `executeTool` 的 120s 超时包裹，但 SubAgent 内部有多轮 LLM + 工具调用迭代，120s 远远不够，导致 SubAgent 经常超时中断、返回空结果。

## Changes

- **移除外层超时**：SubAgent 调用不再受 `executeTool` 的 120s 超时限制，使用父 context 直接传递
- **内部分层超时**：
  - 单轮 LLM 调用：3 分钟超时
  - 单个工具执行：2 分钟超时
- **迭代上限**：SubAgent 固定 10 轮（不继承父 Agent 的 `maxIterations`）
- **优雅降级**：LLM 调用失败时，返回已有的中间结果（`lastContent`）而非直接报错

## Impact

- 1 file changed, +36/-7
- 仅影响 SubAgent 执行路径，不影响其他工具