### PR TITLE
feat: parallel read-only tool execution in runLoop

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -696,13 +696,17 @@ func (a *Agent) runLoop(ctx context.Context, messages []llm.ChatMessage, channel
 			}
 		}
 
-		// Phase 1: 只读操作并行执行
+		// Phase 1: 只读操作并行执行（限制并发数，避免资源耗尽）
 		if len(readOps) > 0 {
+			const maxParallel = 8
+			sem := make(chan struct{}, maxParallel)
 			var wg sync.WaitGroup
 			for _, entry := range readOps {
 				wg.Add(1)
+				sem <- struct{}{} // 获取信号量
 				go func(e toolCallEntry) {
 					defer wg.Done()
+					defer func() { <-sem }() // 释放信号量
 					execOne(e)
 				}(entry)
 			}
@@ -726,34 +730,42 @@ func (a *Agent) runLoop(ctx context.Context, messages []llm.ChatMessage, channel
 			r := execResults[idx]
 			content := r.content
 
-			// OAuth 自动触发
+			// OAuth 自动触发（已触发过则跳过，避免重复 OAuth 状态）
 			if r.err != nil && oauth.IsTokenNeededError(r.err) {
-				log.WithFields(log.Fields{
-					"tool":    tc.Name,
-					"elapsed": r.elapsed.Round(time.Millisecond),
-				}).Info("OAuth token needed, auto-triggering oauth_authorize tool")
-
-				if oauthTool, ok := a.tools.Get("oauth_authorize"); ok {
-					oauthInput := fmt.Sprintf(`{"provider": "feishu", "reason": "needed to access %s"}`, tc.Name)
-					oauthCtx := &tools.ToolContext{
-						Ctx:      ctx,
-						Channel:  channel,
-						ChatID:   chatID,
-						SenderID: senderID,
-						SendFunc: a.sendMessage,
-					}
-					oauthResult, oauthErr := oauthTool.Execute(oauthCtx, oauthInput)
-					if oauthErr == nil && oauthResult != nil {
-						content = oauthResult.Summary
-						a.sessionFinalSent.Store(sessionKey, true)
-						autoNotify = false
-						waitingUser = oauthResult.WaitingUser
-					} else {
-						content = "OAuth authorization required. Please configure OAUTH_ENABLE=true and OAUTH_BASE_URL in your environment."
-						log.WithError(oauthErr).Error("Failed to execute oauth_authorize tool")
-					}
+				if _, sent := a.sessionFinalSent.Load(sessionKey); sent {
+					log.WithFields(log.Fields{
+						"tool":   tc.Name,
+						"reason": "sessionFinalSent already set, skipping duplicate oauth_authorize",
+					}).Info("Skip duplicate OAuth auto-trigger")
+					content = "OAuth authorization already in progress."
 				} else {
-					content = "OAuth authorization required but oauth_authorize tool not found. Please enable OAuth in configuration."
+					log.WithFields(log.Fields{
+						"tool":    tc.Name,
+						"elapsed": r.elapsed.Round(time.Millisecond),
+					}).Info("OAuth token needed, auto-triggering oauth_authorize tool")
+
+					if oauthTool, ok := a.tools.Get("oauth_authorize"); ok {
+						oauthInput := fmt.Sprintf(`{"provider": "feishu", "reason": "needed to access %s"}`, tc.Name)
+						oauthCtx := &tools.ToolContext{
+							Ctx:      ctx,
+							Channel:  channel,
+							ChatID:   chatID,
+							SenderID: senderID,
+							SendFunc: a.sendMessage,
+						}
+						oauthResult, oauthErr := oauthTool.Execute(oauthCtx, oauthInput)
+						if oauthErr == nil && oauthResult != nil {
+							content = oauthResult.Summary
+							a.sessionFinalSent.Store(sessionKey, true)
+							autoNotify = false
+							waitingUser = oauthResult.WaitingUser
+						} else {
+							content = "OAuth authorization required. Please configure OAUTH_ENABLE=true and OAUTH_BASE_URL in your environment."
+							log.WithError(oauthErr).Error("Failed to execute oauth_authorize tool")
+						}
+					} else {
+						content = "OAuth authorization required but oauth_authorize tool not found. Please enable OAuth in configuration."
+					}
 				}
 			}
 


### PR DESCRIPTION
## 改动

将 `runLoop` 中的工具执行从全串行改为**只读并行 + 写操作串行**：

### 分组策略

| 类型 | 工具 | 执行方式 |
|------|------|---------|
| **只读** | Read, Grep, Glob, WebSearch, ChatHistory | 并行（goroutine） |
| **写操作** | Shell, Edit, DownloadFile, card_*, SubAgent, 其他 | 串行 |

### 执行流程

```
1. 所有工具的 ⏳ 进度行一次性展示
2. Phase 1: 只读操作并行执行 → 批量更新 ✅/❌
3. Phase 2: 写操作逐个串行执行 → 逐个更新 ✅/❌
4. 按原始顺序处理结果（OAuth、sessionFinalSent、tool messages）
```

### 并发安全

- 结果写入预分配 slice 的不同 index（无竞争）
- `progressLines` 的并发写入：每个 goroutine 写自己的 `progressStartIdx+entry.index`（不同位置，无竞争）
- `notifyProgress` 只在 Phase 1 完成后统一调用（不在 goroutine 内调用）

### 典型加速

LLM 同时调 3 个 Read + 1 个 Grep → 从 ~4s 降到 ~1s

---

**1 file changed, +119/-57**