### PR TITLE
feat: predefined-only SubAgent roles from .xbot/agents/*.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # 🤖 xbot
 
-一个可扩展的 AI Agent 助手，基于 Go 构建，采用消息总线 + 插件化架构。支持飞书等 IM 渠道接入，具备工具调用、长期记忆、技能系统和定时任务等能力。
+一个可扩展的 AI Agent 助手，基于 Go 构建，采用消息总线 + 插件化架构。支持飞书、QQ 等 IM 渠道接入，具备工具调用、可插拔记忆系统、技能系统和定时任务等能力。
 
 ## ✨ 特性
 
-- **多渠道接入** — 消息总线架构，目前支持飞书，易于扩展其他 IM 平台
-- **丰富的内置工具** — Shell 执行、文件读写编辑、Glob/Grep 搜索、Web 搜索、定时任务、飞书卡片构建
-- **技能系统 (Skills)** — 可热加载的 Markdown 技能包，动态扩展 Agent 能力
-- **双层记忆** — SQLite 持久化的长期记忆 + 可检索的事件日志，自动合并归档
+- **多渠道接入** — 消息总线架构，支持飞书（HTTP 回调）和 QQ（WebSocket），易于扩展
+- **丰富的内置工具** — Shell 执行、文件读写编辑、Glob/Grep 搜索、Web 搜索、定时任务、子代理、文件下载
+- **飞书深度集成** — 交互卡片构建、文档/知识库/多维表格读写、文件上传（基于 OAuth 用户授权）
+- **技能系统 (Skills)** — OpenClaw 风格的渐进式技能加载，Markdown 技能包按需注入
+- **可插拔记忆** — `MemoryProvider` 接口，当前实现 FlatMemory（全量注入），可扩展为分层/检索式记忆
 - **用户画像** — 自动记录用户偏好和沟通风格，跨会话持久化
 - **多租户** — 基于 channel + chatID 的租户隔离，支持多群组/多用户独立会话
-- **飞书交互卡片** — 渐进式卡片构建系统，支持表格、图表、表单、多列布局等丰富组件
-- **MCP 协议支持** — 通过 `mcp.json` 配置接入 [MCP](https://modelcontextprotocol.io/) 工具服务器
-- **提示词外置** — 系统提示词模板化（Go template），支持热加载，无需重启即可调整
+- **MCP 协议支持** — 全局配置 + 会话级懒加载，支持 stdio 和 HTTP 两种传输模式
+- **OAuth 框架** — 通用 OAuth 2.0 授权流程，支持飞书等第三方服务的用户级授权
+- **子代理 (SubAgent)** — 可委派独立任务给子代理执行，支持预定义角色（如 code-reviewer）
+- **提示词外置** — 系统提示词模板化（Go template），支持热加载
 - **KV-Cache 优化** — 精心设计的上下文拼接顺序，最大化 LLM 推理缓存命中率
 - **多 LLM 后端** — 支持 OpenAI 兼容 API（DeepSeek 等）及 CodeBuddy
 
@@ -25,15 +27,18 @@
 └─────────┘     └────────────┘     │       │     └─────────┘
                                    │       │
 ┌─────────┐                        │       │────▶ Tools
-│  更多    │                        │       │     ├─ Shell
-│ Channel  │                        │       │     ├─ Glob / Grep / Read / Edit
+│   QQ    │                        │       │     ├─ Shell / Read / Edit
+│ Channel  │                        │       │     ├─ Glob / Grep
 └─────────┘                        │       │     ├─ WebSearch
                                    │       │     ├─ Cron (定时任务)
-                                   │       │     ├─ Skill (技能管理)
-                                   │       │     ├─ Card (飞书卡片)
-                                   │       │     ├─ ChatHistory
+┌─────────┐                        │       │     ├─ SubAgent (子代理)
+│  更多    │                        │       │     ├─ DownloadFile
+│ Channel  │                        │       │     ├─ Card (飞书卡片)
+└─────────┘                        │       │     ├─ ChatHistory
                                    │       │     ├─ UserProfile / SelfProfile
+                                   │       │     ├─ OAuth (授权工具)
                                    │       │     ├─ ManageTools
+                                   │       │     ├─ Feishu MCP (文档/知识库)
                                    │       │     └─ MCP (外部工具)
                                    └───┬───┘
                                        │
@@ -43,6 +48,7 @@
                                │ Sessions      │
                                │ Memory        │
                                │ UserProfiles  │
+                               │ OAuth Tokens  │
                                └───────────────┘
 ```
 
@@ -57,9 +63,9 @@ xbot/
 ├── .github/workflows/ci.yml # GitHub Actions CI（lint + build + test）
 │
 ├── agent/                   # Agent 核心引擎
-│   ├── agent.go             # 主循环、工具调用迭代、消息发送
+│   ├── agent.go             # 主循环、工具调用（只读并行/写串行）、消息发送
 │   ├── context.go           # 上下文构建、提示词加载与渲染
-│   └── memory.go            # 记忆合并与归档
+│   └── skills.go            # 技能发现与加载（OpenClaw 风格渐进式）
 │
 ├── bus/                     # 消息总线
 │   └── bus.go               # Inbound / Outbound 消息通道
@@ -67,8 +73,9 @@ xbot/
 ├── channel/                 # IM 渠道
 │   ├── channel.go           # Channel 接口定义
 │   ├── dispatcher.go        # 消息分发器
-│   ├── feishu.go            # 飞书渠道实现（消息收发、卡片回调）
-│   └── feishu_token.go      # 飞书 Token 管理
+│   ├── feishu.go            # 飞书渠道（HTTP 回调、卡片回调、文件发送）
+│   ├── feishu_token.go      # 飞书 Token 管理
+│   └── qq.go                # QQ 渠道（WebSocket、支持私聊/群聊/频道）
 │
 ├── llm/                     # LLM 客户端
 │   ├── interface.go         # LLM 接口与类型定义
@@ -77,6 +84,11 @@ xbot/
 │   ├── types.go             # 消息、工具调用等数据结构
 │   └── mock.go              # 测试用 Mock 客户端
 │
+├── memory/                  # 可插拔记忆系统
+│   ├── memory.go            # MemoryProvider 接口定义
+│   └── flat/
+│       └── flat.go          # FlatMemory 实现（全量注入）
+│
 ├── tools/                   # 内置工具
 │   ├── interface.go         # Tool 接口、Registry 注册表
 │   ├── shell.go             # Shell 命令执行
@@ -84,28 +96,46 @@ xbot/
 │   ├── grep.go              # 文件内容 Grep 搜索
 │   ├── read.go              # 文件读取
 │   ├── edit.go              # 文件编辑（创建 / 替换 / 行编辑 / 正则）
+│   ├── download.go          # 飞书聊天文件/图片下载
 │   ├── web_search.go        # Web 搜索（Tavily API）
 │   ├── cron.go              # 定时任务调度
-│   ├── skill.go             # 技能管理工具
-│   ├── skill_store.go       # 技能存储与加载
+│   ├── subagent.go          # 子代理工具
+│   ├── subagent_roles.go    # 子代理预定义角色
 │   ├── card_builder.go      # 飞书卡片构建器（Session / Element 模型）
 │   ├── card_tools.go        # 卡片工具集（create / add / preview / send）
 │   ├── chat_history.go      # 聊天历史查询
 │   ├── user_profile.go      # 用户画像 & Bot 自画像
+│   ├── oauth.go             # OAuth 授权工具
 │   ├── manage_tools.go      # 动态工具 / MCP / 技能管理
-│   ├── mcp.go               # MCP 协议工具桥接
-│   ├── notify.go            # 进度通知（已由自动通知机制替代）
-│   └── subagent.go          # SubAgent 子代理
+│   ├── mcp.go               # MCP 协议工具桥接（全局）
+│   ├── mcp_common.go        # MCP 共享基础设施（配置、连接管理）
+│   ├── session_mcp.go       # 会话级 MCP 管理（懒加载、超时清理）
+│   └── feishu_mcp/          # 飞书工作台工具集
+│       ├── feishu_mcp.go    # 核心：OAuth 客户端获取、工具注册
+│       ├── docx.go          # 飞书文档读写（Markdown 互转）
+│       ├── wiki.go          # 知识库/多维表格操作
+│       ├── search.go        # 知识库搜索
+│       ├── file.go          # 文件上传
+│       ├── tools.go         # 工具定义
+│       ├── block_helper.go  # 飞书 Block 类型映射与文本提取
+│       ├── block_type_map.go
+│       └── errors.go        # 飞书 API 错误处理
+│
+├── oauth/                   # OAuth 2.0 框架
+│   ├── provider.go          # Provider 接口、Token 类型
+│   ├── manager.go           # 授权流程管理（CSRF、pending flows）
+│   ├── server.go            # OAuth 回调 HTTP 服务器
+│   ├── storage.go           # Token 持久化（SQLite）
+│   └── providers/
+│       └── feishu.go        # 飞书 OAuth Provider
 │
 ├── session/                 # 会话管理
-│   ├── session.go           # 会话持久化
 │   ├── multitenant.go       # 多租户会话管理器
-│   ├── tenant.go            # 租户会话（消息历史 + 记忆）
-│   └── memory.go            # 租户记忆读写
+│   └── tenant.go            # 租户会话（消息历史 + 记忆）
 │
 ├── storage/                 # 存储层
 │   ├── migrate.go           # 数据库迁移
-│   └── sqlite/              # SQLite 实现
+│   └── sqlite/              # SQLite 实现（纯 Go，无 CGO）
 │       ├── db.go            # 数据库连接与初始化
 │       ├── session.go       # 会话存储
 │       ├── memory.go        # 记忆存储
@@ -114,6 +144,9 @@ xbot/
 │
 ├── config/                  # 配置加载
 │   └── config.go            # 环境变量 → 结构体
+│
+├── version/                 # 版本信息
+│   └── version.go           # 构建时注入（Version / Commit / BuildTime）
 │
 ├── logger/                  # 日志
 │   └── logger.go            # logrus 封装
@@ -127,7 +160,7 @@ xbot/
 ### 前置要求
 
 - Go 1.25+
-- 飞书开放平台应用（用于飞书渠道）
+- 飞书开放平台应用 和/或 QQ 开放平台应用
 - LLM API Key（DeepSeek / OpenAI 兼容 / CodeBuddy）
 
 ### 安装与运行
@@ -139,7 +172,7 @@ cd xbot
 
 # 配置环境变量
 cp .env.example .env
-# 编辑 .env，填写 LLM API Key、飞书应用凭证等
+# 编辑 .env，填写 LLM API Key、飞书/QQ 应用凭证等
 
 # 构建并运行
 make build
@@ -155,7 +188,7 @@ make dev
 make fmt      # 格式化代码
 make lint     # golangci-lint 检查
 make test     # 运行测试（-race + 覆盖率）
-make build    # 编译二进制
+make build    # 编译二进制（注入版本信息）
 make run      # 编译并运行
 make dev      # go run 开发模式
 make clean    # 清理构建产物
@@ -194,38 +227,93 @@ sudo systemctl enable --now xbot
 
 所有配置通过环境变量或 `.env` 文件设置：
 
+### LLM
+
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `LLM_PROVIDER` | LLM 提供商（`openai` / `codebuddy`） | `openai` |
 | `LLM_BASE_URL` | API 地址 | — |
 | `LLM_API_KEY` | API 密钥 | — |
 | `LLM_MODEL` | 模型名称 | `deepseek-chat` |
+| `LLM_USER_ID` | CodeBuddy 用户 ID | — |
+| `LLM_ENTERPRISE_ID` | CodeBuddy 企业 ID | — |
+| `LLM_DOMAIN` | CodeBuddy 域名 | — |
+
+### 飞书
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
 | `FEISHU_ENABLED` | 启用飞书渠道 | `false` |
 | `FEISHU_APP_ID` | 飞书应用 ID | — |
 | `FEISHU_APP_SECRET` | 飞书应用密钥 | — |
-| `FEISHU_ENCRYPT_KEY` | 飞书事件加密密钥 | — |
-| `FEISHU_VERIFICATION_TOKEN` | 飞书验证 Token | — |
+| `FEISHU_ENCRYPT_KEY` | 事件加密密钥 | — |
+| `FEISHU_VERIFICATION_TOKEN` | 验证 Token | — |
 | `FEISHU_ALLOW_FROM` | 允许的用户 ID（逗号分隔） | 空（允许所有） |
+| `FEISHU_DOMAIN` | 飞书域名（用于文档链接） | — |
+
+### QQ
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `QQ_ENABLED` | 启用 QQ 渠道 | `false` |
+| `QQ_APP_ID` | QQ 应用 ID | — |
+| `QQ_CLIENT_SECRET` | QQ 应用密钥 | — |
+| `QQ_ALLOW_FROM` | 允许的用户 ID（逗号分隔） | 空（允许所有） |
+
+### Agent
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
 | `AGENT_MAX_ITERATIONS` | 单次对话最大工具调用轮数 | `20` |
 | `AGENT_MEMORY_WINDOW` | 上下文保留的历史消息数 | `50` |
 | `WORK_DIR` | 工作目录 | `.` |
 | `PROMPT_FILE` | 自定义提示词模板路径 | 空（使用内置） |
+
+### MCP 会话管理
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `MCP_INACTIVITY_TIMEOUT` | MCP 连接不活跃超时 | `30m` |
+| `MCP_CLEANUP_INTERVAL` | MCP 清理扫描间隔 | `5m` |
+| `SESSION_CACHE_TIMEOUT` | 会话缓存超时 | `24h` |
+
+### OAuth
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `OAUTH_ENABLE` | 启用 OAuth 功能 | `false` |
+| `OAUTH_PORT` | OAuth 回调端口 | `8081` |
+| `OAUTH_BASE_URL` | OAuth 回调基础 URL（需公网可达） | — |
+
+### 服务器 & 日志
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `SERVER_HOST` | 服务监听地址 | `0.0.0.0` |
+| `SERVER_PORT` | 服务监听端口 | `8080` |
 | `LOG_LEVEL` | 日志级别 | `info` |
 | `LOG_FORMAT` | 日志格式（`text` / `json`） | `json` |
 | `PPROF_ENABLE` | 启用 pprof 性能分析 | `false` |
 | `PPROF_HOST` | pprof 监听地址 | `localhost` |
 | `PPROF_PORT` | pprof 监听端口 | `6060` |
-| `SERVER_HOST` | 服务监听地址 | `0.0.0.0` |
-| `SERVER_PORT` | 服务监听端口 | `8080` |
 
 ## 🧠 记忆系统
 
-xbot 采用双层记忆架构，基于 SQLite 多租户存储：
+xbot 采用可插拔的记忆架构（`MemoryProvider` 接口），当前实现为 FlatMemory：
 
-- **MEMORY**（长期记忆）— 持续更新的事实性知识，如用户偏好、项目信息、待办事项。每次对话时注入系统提示词。
+- **MEMORY**（长期记忆）— 持续更新的事实性知识，如用户偏好、项目信息、待办事项。每次对话时全量注入系统提示词。
 - **HISTORY**（历史日志）— 按时间追加的事件记录，支持检索。用于回溯过去发生的事情。
 
 当会话消息超过 `AGENT_MEMORY_WINDOW` 时，Agent 自动触发异步记忆合并：LLM 将旧消息摘要写入 MEMORY 和 HISTORY，然后释放上下文空间。
+
+```go
+// 扩展记忆系统只需实现 MemoryProvider 接口
+type MemoryProvider interface {
+    Recall(ctx context.Context, query string) (string, error)
+    Memorize(ctx context.Context, input MemorizeInput) (MemorizeResult, error)
+    Close() error
+}
+```
 
 ### 用户画像
 
@@ -233,14 +321,15 @@ Agent 可通过 `update_user_profile` 工具记录对用户的观察（沟通风
 
 ## 🔧 技能系统
 
-技能（Skill）是可热加载的 Markdown 文件，激活后注入系统提示词，动态扩展 Agent 能力。
+技能（Skill）采用 OpenClaw 风格的渐进式加载：启动时扫描目录生成技能目录，对话时 Agent 按需通过 `Read` 工具加载相关技能。
 
 ```
 .xbot/skills/
 └── my-skill/
-    ├── SKILL.md          # 技能定义（YAML frontmatter + Markdown 指令）
+    ├── SKILL.md          # 技能定义（必需）
     ├── scripts/          # 可选：脚本文件
-    └── references/       # 可选：参考资料
+    ├── references/       # 可选：参考资料
+    └── assets/           # 可选：资源文件
 ```
 
 SKILL.md 格式：
@@ -251,17 +340,17 @@ name: my-skill
 description: 技能简介（用于自动匹配和发现）
 ---
 
-（Markdown 正文，激活后加载到系统提示词中）
+（Markdown 正文，加载后注入系统提示词）
 ```
 
-通过对话中的 Skill 工具管理：创建、激活、停用、删除。Agent 会根据对话主题自动匹配并激活相关技能。
+技能目录在系统提示词中以 XML 格式列出，Agent 根据对话主题自主决定是否加载。
 
 ## 🎴 飞书交互卡片
 
-xbot 内置渐进式卡片构建系统，通过工具调用逐步构建复杂的飞书交互卡片：
+内置渐进式卡片构建系统，通过工具调用逐步构建复杂的飞书交互卡片：
 
 ```
-card_create → card_add_content / card_add_interactive / card_add_container → card_preview → card_send
+card_create → card_add_content / card_add_interactive / card_add_container → card_send
 ```
 
 支持的组件：
@@ -274,9 +363,24 @@ card_create → card_add_content / card_add_interactive / card_add_container →
 
 卡片工具按需动态注册：只有调用 `card_create` 后才会注册其余卡片工具，发送完成后自动注销。
 
+## 📄 飞书文档 & 知识库
+
+通过 OAuth 用户授权，xbot 可以直接操作飞书工作台：
+
+- **文档读写** — 读取飞书文档内容（转为 Markdown）、写入/更新文档
+- **知识库搜索** — 搜索知识库空间和节点
+- **多维表格** — 读取字段定义、查询/创建/更新记录
+- **文件上传** — 上传文件到飞书云盘
+
+需要配置 OAuth（`OAUTH_ENABLE=true`）并完成飞书应用的 OAuth 权限配置。
+
 ## 🔌 MCP 支持
 
-在工作目录下创建 `mcp.json` 配置 MCP 工具服务器：
+xbot 支持两层 MCP 工具管理：
+
+### 全局 MCP
+
+在工作目录下创建 `mcp.json` 配置全局 MCP 工具服务器，启动时自动连接：
 
 ```json
 {
@@ -292,7 +396,31 @@ card_create → card_add_content / card_add_interactive / card_add_container →
 }
 ```
 
-启动时自动连接并注册 MCP 工具到 Agent 工具集。可通过 `ManageTools` 工具在运行时动态管理。
+### 会话级 MCP
+
+通过 `ManageTools` 工具在运行时动态添加/移除 MCP 服务器。会话级 MCP 连接支持：
+
+- **懒加载** — 首次使用时才建立连接
+- **不活跃超时** — 超过 `MCP_INACTIVITY_TIMEOUT` 自动断开
+- **自动清理** — 定期扫描并回收空闲连接
+
+支持 **stdio** 和 **HTTP** 两种 MCP 传输模式。
+
+## 🤖 子代理 (SubAgent)
+
+可将独立任务委派给子代理执行，子代理拥有完整的工具集但不能创建更多子代理：
+
+```
+SubAgent(task="审查 agent.go 的改动", role="code-reviewer")
+```
+
+预定义角色：
+
+| 角色 | 说明 |
+|------|------|
+| `code-reviewer` | 代码审查专家，对照计划/需求审查实现，按严重程度分类问题 |
+
+也可通过 `system_prompt` 参数自定义子代理行为。
 
 ## 📝 命令
 
@@ -301,6 +429,7 @@ card_create → card_add_content / card_add_interactive / card_add_container →
 | 命令 | 说明 |
 |------|------|
 | `/new` | 归档记忆并重置会话 |
+| `/version` | 显示版本信息 |
 | `/help` | 显示帮助信息 |
 
 ## 🔄 CI

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -113,6 +113,12 @@ func New(cfg Config) *Agent {
 
 	skillStore := NewSkillStore(cfg.SkillsDir)
 
+	// 加载 agent 角色定义（从 .xbot/agents/ 目录）
+	agentsDir := filepath.Join(cfg.WorkDir, ".xbot", "agents")
+	if err := tools.InitAgentRoles(agentsDir); err != nil {
+		log.WithError(err).Warn("Failed to load agent roles, SubAgent will have no predefined roles")
+	}
+
 	registry := tools.DefaultRegistry()
 
 	// 创建聊天历史存储
@@ -934,7 +940,8 @@ func (a *Agent) injectInbound(channel, chatID, content string) {
 
 // RunSubAgent 实现 tools.SubAgentManager 接口
 // 创建一个独立的子 Agent 循环来执行任务，子 Agent 拥有自己的工具集但不能再创建子 Agent
-func (a *Agent) RunSubAgent(ctx context.Context, parentAgentID string, task string, systemPrompt string) (string, error) {
+// allowedTools 为工具白名单，为空时使用所有工具（除 SubAgent）
+func (a *Agent) RunSubAgent(ctx context.Context, parentAgentID string, task string, systemPrompt string, allowedTools []string) (string, error) {
 	if systemPrompt == "" {
 		systemPrompt = "You are a helpful assistant. Complete the given task using the available tools."
 	}
@@ -942,6 +949,19 @@ func (a *Agent) RunSubAgent(ctx context.Context, parentAgentID string, task stri
 	// 子 Agent 工具集：除 SubAgent 外的所有标准工具（防止递归创建）
 	subTools := a.tools.Clone()
 	subTools.Unregister("SubAgent")
+
+	// 如果指定了工具白名单，只保留白名单中的工具
+	if len(allowedTools) > 0 {
+		allowed := make(map[string]bool, len(allowedTools))
+		for _, name := range allowedTools {
+			allowed[name] = true
+		}
+		for _, tool := range subTools.List() {
+			if !allowed[tool.Name()] {
+				subTools.Unregister(tool.Name())
+			}
+		}
+	}
 
 	// 构建子 Agent 的消息
 	messages := []llm.ChatMessage{

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -34,7 +34,8 @@ type ToolContext struct {
 // SubAgentManager SubAgent 管理接口，避免循环依赖
 type SubAgentManager interface {
 	// RunSubAgent 创建并运行一个 SubAgent，返回最终响应文本
-	RunSubAgent(ctx context.Context, parentAgentID string, task string, systemPrompt string) (string, error)
+	// allowedTools 为工具白名单，为空时使用所有工具（除 SubAgent）
+	RunSubAgent(ctx context.Context, parentAgentID string, task string, systemPrompt string, allowedTools []string) (string, error)
 }
 
 // ToolResult 工具执行结果

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -17,42 +17,44 @@ func (t *SubAgentTool) Description() string {
 	roles := ListSubAgentRoles()
 	var roleLines []string
 	for _, r := range roles {
-		roleLines = append(roleLines, fmt.Sprintf("  - \"%s\": %s", r.Name, r.Description))
+		toolsInfo := ""
+		if len(r.AllowedTools) > 0 {
+			toolsInfo = fmt.Sprintf(" [tools: %s]", strings.Join(r.AllowedTools, ", "))
+		}
+		roleLines = append(roleLines, fmt.Sprintf("  - \"%s\": %s%s", r.Name, r.Description, toolsInfo))
 	}
 	roleList := strings.Join(roleLines, "\n")
 
-	return fmt.Sprintf(`Delegate a task to a sub-agent that runs independently with its own tool set and context.
-Use this when a task is complex, self-contained, or benefits from isolation (e.g., research, code generation, file operations on a separate concern).
-The sub-agent has access to all standard tools (Shell, Read, Edit, Glob, Grep, etc.) but cannot create further sub-agents.
+	if roleList == "" {
+		return `Delegate a task to a sub-agent that runs independently with its own tool set and context.
+No predefined roles are available. Please configure agent roles in the .xbot/agents/ directory.`
+	}
+
+	return fmt.Sprintf(`Delegate a task to a sub-agent with a predefined role.
+The sub-agent runs independently with its own tool set and context, specialized for the given role.
 The sub-agent runs synchronously and returns its final response.
 
 Parameters (JSON):
   - task: string (required), the task description for the sub-agent
-  - role: string (optional), use a predefined role with specialized system prompt. If set, system_prompt is ignored.
-  - system_prompt: string (optional), custom system prompt for the sub-agent. If empty and no role specified, uses default system prompt.
+  - role: string (required), the predefined role name to use
 
 Available roles:
 %s
 
-Example: {"task": "Review the changes in core/agent.go for potential bugs", "role": "code-reviewer"}
-Example: {"task": "Write unit tests for tools/subagent.go", "role": "test-writer"}
-Example: {"task": "Read all Go files in the tools/ directory and write a summary of what each tool does."}
-Example: {"task": "Find and fix all TODO comments in the codebase", "system_prompt": "You are a code cleanup specialist."}`, roleList)
+Example: {"task": "Review the changes in core/agent.go for potential bugs", "role": "code-reviewer"}`, roleList)
 }
 
 func (t *SubAgentTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
 		{Name: "task", Type: "string", Description: "The task description for the sub-agent to execute", Required: true},
-		{Name: "role", Type: "string", Description: "Predefined role name (e.g. code-reviewer, test-writer, refactor, doc-writer, security-auditor, bug-finder). Overrides system_prompt if set.", Required: false},
-		{Name: "system_prompt", Type: "string", Description: "Optional custom system prompt for the sub-agent (ignored if role is set)", Required: false},
+		{Name: "role", Type: "string", Description: "Predefined role name (e.g. code-reviewer)", Required: true},
 	}
 }
 
 func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, error) {
 	var params struct {
-		Task         string `json:"task"`
-		Role         string `json:"role"`
-		SystemPrompt string `json:"system_prompt"`
+		Task string `json:"task"`
+		Role string `json:"role"`
 	}
 	if err := json.Unmarshal([]byte(input), &params); err != nil {
 		return nil, fmt.Errorf("invalid parameters: %w", err)
@@ -62,24 +64,28 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 		return nil, fmt.Errorf("task is required")
 	}
 
+	if params.Role == "" {
+		available := make([]string, 0)
+		for _, r := range ListSubAgentRoles() {
+			available = append(available, r.Name)
+		}
+		return nil, fmt.Errorf("role is required (available: %s)", strings.Join(available, ", "))
+	}
+
+	role, ok := GetSubAgentRole(params.Role)
+	if !ok {
+		available := make([]string, 0)
+		for _, r := range ListSubAgentRoles() {
+			available = append(available, r.Name)
+		}
+		return nil, fmt.Errorf("unknown role: %s (available: %s)", params.Role, strings.Join(available, ", "))
+	}
+
 	if ctx == nil || ctx.Manager == nil {
 		return nil, fmt.Errorf("sub-agent capability not available")
 	}
 
-	systemPrompt := params.SystemPrompt
-	if params.Role != "" {
-		role, ok := GetSubAgentRole(params.Role)
-		if !ok {
-			available := make([]string, 0)
-			for _, r := range ListSubAgentRoles() {
-				available = append(available, r.Name)
-			}
-			return nil, fmt.Errorf("unknown role: %s (available: %s)", params.Role, strings.Join(available, ", "))
-		}
-		systemPrompt = role.SystemPrompt
-	}
-
-	result, err := ctx.Manager.RunSubAgent(ctx.Ctx, ctx.AgentID, params.Task, systemPrompt)
+	result, err := ctx.Manager.RunSubAgent(ctx.Ctx, ctx.AgentID, params.Task, role.SystemPrompt, role.AllowedTools)
 	if err != nil {
 		return nil, fmt.Errorf("sub-agent failed: %w", err)
 	}

--- a/tools/subagent_loader.go
+++ b/tools/subagent_loader.go
@@ -1,0 +1,163 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadAgentRoles 从目录加载所有 agent 定义文件（*.md）
+// 每个文件包含 YAML frontmatter（name, description, tools）和 SystemPrompt 正文
+func LoadAgentRoles(dir string) ([]SubAgentRole, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read agents dir %s: %w", dir, err)
+	}
+
+	var roles []SubAgentRole
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		role, err := parseAgentFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("parse agent file %s: %w", path, err)
+		}
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+// parseAgentFile 解析单个 agent 定义文件
+// 格式：YAML frontmatter（--- 之间）+ Markdown 正文作为 SystemPrompt
+func parseAgentFile(path string) (SubAgentRole, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SubAgentRole{}, err
+	}
+
+	content := string(data)
+
+	// 分离 frontmatter 和正文
+	frontmatter, body, err := splitFrontmatter(content)
+	if err != nil {
+		return SubAgentRole{}, fmt.Errorf("invalid frontmatter: %w", err)
+	}
+
+	// 解析 frontmatter 字段
+	name, description, allowedTools, err := parseFrontmatter(frontmatter)
+	if err != nil {
+		return SubAgentRole{}, fmt.Errorf("parse frontmatter: %w", err)
+	}
+
+	if name == "" {
+		// 用文件名（去掉 .md）作为 fallback
+		name = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+
+	return SubAgentRole{
+		Name:         name,
+		Description:  description,
+		SystemPrompt: strings.TrimSpace(body),
+		AllowedTools: allowedTools,
+	}, nil
+}
+
+// splitFrontmatter 分离 YAML frontmatter 和正文
+// 期望格式：以 "---\n" 开头，第二个 "---\n" 结束 frontmatter
+func splitFrontmatter(content string) (frontmatter, body string, err error) {
+	// 去掉可能的 BOM
+	content = strings.TrimPrefix(content, "\xef\xbb\xbf")
+
+	if !strings.HasPrefix(content, "---") {
+		return "", "", fmt.Errorf("file does not start with ---")
+	}
+
+	// 找第二个 ---
+	rest := content[3:] // 跳过第一个 ---
+	rest = strings.TrimPrefix(rest, "\r\n")
+	rest = strings.TrimPrefix(rest, "\n")
+
+	idx := strings.Index(rest, "\n---")
+	if idx < 0 {
+		return "", "", fmt.Errorf("closing --- not found")
+	}
+
+	frontmatter = rest[:idx]
+	body = rest[idx+4:] // 跳过 "\n---"
+	// 跳过 --- 后面的换行
+	body = strings.TrimPrefix(body, "\r\n")
+	body = strings.TrimPrefix(body, "\n")
+
+	return frontmatter, body, nil
+}
+
+// parseFrontmatter 手动解析简单 YAML frontmatter
+// 只支持 name, description（字符串）和 tools（列表）三个字段
+func parseFrontmatter(fm string) (name, description string, tools []string, err error) {
+	lines := strings.Split(fm, "\n")
+	var currentField string
+
+	for _, line := range lines {
+		// 去掉 \r
+		line = strings.TrimRight(line, "\r")
+
+		// 跳过空行和注释
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// 列表项：以 "  - " 或 "- " 开头（属于当前字段）
+		if strings.HasPrefix(trimmed, "- ") {
+			if currentField == "tools" {
+				item := strings.TrimSpace(strings.TrimPrefix(trimmed, "-"))
+				if item != "" {
+					tools = append(tools, item)
+				}
+			}
+			continue
+		}
+
+		// 键值对：key: value
+		colonIdx := strings.Index(line, ":")
+		if colonIdx < 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:colonIdx])
+		value := strings.TrimSpace(line[colonIdx+1:])
+
+		// 去掉引号包裹
+		value = stripQuotes(value)
+
+		switch key {
+		case "name":
+			name = value
+			currentField = "name"
+		case "description":
+			description = value
+			currentField = "description"
+		case "tools":
+			currentField = "tools"
+			// tools 的值可能在同一行（如 tools: [a, b]）或后续行（列表格式）
+			// 我们只支持列表格式，忽略同行值
+		default:
+			currentField = ""
+		}
+	}
+
+	return name, description, tools, nil
+}
+
+// stripQuotes 去掉字符串两端的引号（单引号或双引号）
+func stripQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/tools/subagent_roles.go
+++ b/tools/subagent_roles.go
@@ -1,5 +1,14 @@
 package tools
 
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	log "xbot/logger"
+)
+
+// SubAgentRole 预定义的 SubAgent 角色
 type SubAgentRole struct {
 	Name         string
 	Description  string
@@ -7,91 +16,44 @@ type SubAgentRole struct {
 	AllowedTools []string
 }
 
-var predefinedRoles = map[string]SubAgentRole{
-	"code-reviewer": {
-		Name:        "code-reviewer",
-		Description: "高级代码审查专家，对照计划/需求审查实现，按严重程度分类问题，给出明确的合并建议",
-		SystemPrompt: `你是一位高级代码审查专家，精通软件架构、设计模式和最佳实践。你的职责是对照原始计划审查已完成的实现，确保代码质量。
+// agentRoles 从文件加载的角色列表
+var agentRoles []SubAgentRole
 
-## 审查流程
+// InitAgentRoles 从指定目录加载 agent 角色定义
+// 如果目录不存在，不报错（没有预定义角色也可以）
+func InitAgentRoles(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles loaded")
+		return nil
+	}
 
-1. **计划对齐分析**
-   - 对照原始计划/需求文档逐项比对实现
-   - 识别偏差：是合理改进还是有问题的偏离？
-   - 验证所有计划功能是否已实现
+	roles, err := LoadAgentRoles(dir)
+	if err != nil {
+		return fmt.Errorf("load agent roles from %s: %w", dir, err)
+	}
 
-2. **代码质量评估**
-   - 错误处理、类型安全、防御性编程
-   - 代码组织、命名规范、可维护性
-   - 测试覆盖率和测试质量
-   - 安全漏洞和性能问题
-
-3. **架构与设计审查**
-   - SOLID 原则、关注点分离、松耦合
-   - 与现有系统的集成
-   - 可扩展性考量
-
-## 输出格式
-
-### 优点
-[具体说明做得好的地方，引用 file:line]
-
-### 问题
-
-#### 🔴 Critical（必须修复）
-[Bug、安全问题、数据丢失风险、功能损坏]
-
-#### 🟡 Important（应该修复）
-[架构问题、缺失功能、错误处理不足、测试缺口]
-
-#### 🔵 Minor（建议改进）
-[代码风格、优化机会、文档改进]
-
-**每个问题必须包含：**
-- File:line 引用
-- 问题描述
-- 为什么重要
-- 如何修复
-
-### 评估
-
-**可以合并吗？** [是 / 否 / 修复后可以]
-**理由：** [1-2 句技术评估]
-
-## 关键规则
-
-**必须做：**
-- 按实际严重程度分类（不是所有问题都是 Critical）
-- 具体到 file:line，不要含糊
-- 解释问题的影响
-- 先肯定优点再指出问题
-- 给出明确结论
-
-**禁止做：**
-- 没检查就说"看起来不错"
-- 把小问题标为 Critical
-- 对没审查的代码给反馈
-- 含糊其辞（"改进错误处理"）
-- 回避给出明确结论
-
-## 关键原则
-
-**不要信任报告，要验证代码。** 实现者的报告可能不完整或过于乐观。你必须独立阅读代码验证一切。`,
-	},
+	agentRoles = roles
+	log.WithField("count", len(roles)).Info("Agent roles loaded")
+	for _, r := range roles {
+		log.WithFields(log.Fields{
+			"name":  r.Name,
+			"tools": strings.Join(r.AllowedTools, ", "),
+		}).Debug("Loaded agent role")
+	}
+	return nil
 }
 
+// GetSubAgentRole 根据名称查找角色
 func GetSubAgentRole(name string) (*SubAgentRole, bool) {
-	role, exists := predefinedRoles[name]
-	if !exists {
-		return nil, false
+	for i := range agentRoles {
+		if agentRoles[i].Name == name {
+			return &agentRoles[i], true
+		}
 	}
-	return &role, true
+	return nil, false
 }
 
+// ListSubAgentRoles 返回所有可用角色
 func ListSubAgentRoles() []SubAgentRole {
-	roles := make([]SubAgentRole, 0, len(predefinedRoles))
-	for _, role := range predefinedRoles {
-		roles = append(roles, role)
-	}
-	return roles
+	return agentRoles
 }


### PR DESCRIPTION
## 改动

### 问题
SubAgent 有 `system_prompt` 自由参数，主 agent 可以绕过预设角色传任意 prompt，行为不可控。

### 方案
兼容 Claude Code 的 agent 定义格式，只允许预定义角色。

### 改动
- **删除** `system_prompt` 参数，`role` 改为 required
- **新增** `.xbot/agents/*.md` 角色定义文件加载（YAML frontmatter + Markdown body）
- **新增** 工具白名单过滤（每个角色可限制可用工具）
- **新增** `.xbot/agents/code-reviewer.md` 作为首个预定义角色

### 格式兼容 Claude Code
```markdown
---
name: code-reviewer
description: 高级代码审查专家
tools:
  - Read
  - Grep
  - Glob
  - Shell
---

（system prompt 内容）
```

### 文件变更
| 文件 | 说明 |
|------|------|
| `tools/subagent.go` | 删除 system_prompt，role 改 required |
| `tools/subagent_loader.go` | 新增：Markdown agent 文件加载器 |
| `tools/subagent_roles.go` | 重写：从文件加载替代硬编码 |
| `tools/interface.go` | RunSubAgent 签名新增 allowedTools |
| `agent/agent.go` | InitAgentRoles 调用 + 白名单过滤实现 |
| `README.md` | 更新至当前架构 |
