### PR TITLE
feat: .xbot.example/ reference config + dynamic SubAgent catalog

### DIFF
--- a/.xbot.example/README.md
+++ b/.xbot.example/README.md
@@ -1,0 +1,57 @@
+# .xbot.example
+
+xbot 运行时配置的参考示例。首次部署时复制到工作目录：
+
+```bash
+cp -r .xbot.example /path/to/workdir/.xbot
+```
+
+## 目录结构
+
+```
+.xbot/
+├── agents/          # SubAgent 角色定义（Markdown + YAML frontmatter）
+│   └── *.md
+├── skills/          # 技能目录（每个技能一个子目录）
+│   └── <name>/
+│       └── SKILL.md # 技能描述与指令（必需）
+└── xbot.db          # SQLite 数据库（运行时自动创建）
+```
+
+## Agents
+
+SubAgent 角色定义，格式兼容 Claude Code：
+
+```markdown
+---
+name: my-agent
+description: "When to use this agent"
+tools:
+  - Read
+  - Grep
+---
+
+System prompt for the agent...
+```
+
+- `name`：角色标识，主 agent 通过此名称调用
+- `tools`：工具白名单（可选，不设则允许所有）
+
+## Skills
+
+技能通过 `SKILL.md` 定义，启动时扫描注册，按需加载：
+
+```markdown
+---
+name: my-skill
+description: What it does and when to use it
+---
+
+Detailed instructions...
+```
+
+## 自定义
+
+- 添加 agent：`agents/` 下创建 `.md` 文件
+- 添加 skill：`skills/` 下创建子目录，放入 `SKILL.md`
+- 技能可包含 `scripts/`、`references/`、`assets/` 辅助目录

--- a/.xbot.example/agents/code-reviewer.md
+++ b/.xbot.example/agents/code-reviewer.md
@@ -1,0 +1,46 @@
+---
+name: code-reviewer
+description: "Code review agent. Use after completing a significant piece of code, before merging, or when the user requests a review."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Shell
+---
+
+You are a code review agent. Your job is to independently review code changes and report findings.
+
+## Process
+
+1. **Understand scope** — Read the diff or changed files. Identify what was added, modified, deleted.
+2. **Verify correctness** — Read the actual code (not just the diff). Check logic, edge cases, error handling.
+3. **Check build/tests** — Run `go build ./...`, `go vet ./...`, or equivalent. Report actual output.
+4. **Assess quality** — Naming, structure, duplication, security, performance.
+
+## Output Format
+
+Return a single structured report:
+
+### Summary
+One paragraph: what the change does, overall assessment.
+
+### Issues
+
+Classify by severity:
+
+- 🔴 **Critical** — Bugs, security holes, data loss, crashes
+- 🟡 **Important** — Missing error handling, architectural concerns, test gaps
+- 🔵 **Minor** — Style, naming, minor optimizations
+
+Each issue: `file:line` + what's wrong + why it matters + suggested fix.
+
+### Verdict
+**Merge?** Yes / No / After fixes — with one-line justification.
+
+## Rules
+
+- **Verify, don't trust.** Read the code yourself. Don't rely on descriptions.
+- **Be specific.** `file:line` references, not vague suggestions.
+- **Be proportional.** Don't flag style nits as critical.
+- **Run the build.** If it doesn't compile, say so immediately.
+- **No fluff.** Skip praise unless something is genuinely noteworthy.

--- a/.xbot.example/skills/github/SKILL.md
+++ b/.xbot.example/skills/github/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: github
+description: "GitHub operations via `gh` CLI: issues, PRs, CI runs, code review, API queries. Use when: (1) checking PR status or CI, (2) creating/commenting on issues, (3) listing/filtering PRs or issues, (4) viewing run logs. NOT for: complex web UI interactions requiring manual browser flows (use browser tooling when available), bulk operations across many repos (script with gh api), or when gh auth is not configured."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🐙",
+        "requires": { "bins": ["gh"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "gh",
+              "bins": ["gh"],
+              "label": "Install GitHub CLI (brew)",
+            },
+            {
+              "id": "apt",
+              "kind": "apt",
+              "package": "gh",
+              "bins": ["gh"],
+              "label": "Install GitHub CLI (apt)",
+            },
+          ],
+      },
+  }
+---
+
+# GitHub Skill
+
+Use the `gh` CLI to interact with GitHub repositories, issues, PRs, and CI.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- Checking PR status, reviews, or merge readiness
+- Viewing CI/workflow run status and logs
+- Creating, closing, or commenting on issues
+- Creating or merging pull requests
+- Querying GitHub API for repository data
+- Listing repos, releases, or collaborators
+
+## When NOT to Use
+
+❌ **DON'T use this skill when:**
+
+- Local git operations (commit, push, pull, branch) → use `git` directly
+- Non-GitHub repos (GitLab, Bitbucket, self-hosted) → different CLIs
+- Cloning repositories → use `git clone`
+- Reviewing actual code changes → use `coding-agent` skill
+- Complex multi-file diffs → use `coding-agent` or read files directly
+
+## Setup
+
+```bash
+# Authenticate (one-time)
+gh auth login
+
+# Verify
+gh auth status
+```
+
+## Common Commands
+
+### Pull Requests
+
+```bash
+# List PRs
+gh pr list --repo owner/repo
+
+# Check CI status
+gh pr checks 55 --repo owner/repo
+
+# View PR details
+gh pr view 55 --repo owner/repo
+
+# Create PR
+gh pr create --title "feat: add feature" --body "Description"
+
+# Merge PR
+gh pr merge 55 --squash --repo owner/repo
+```
+
+### Issues
+
+```bash
+# List issues
+gh issue list --repo owner/repo --state open
+
+# Create issue
+gh issue create --title "Bug: something broken" --body "Details..."
+
+# Close issue
+gh issue close 42 --repo owner/repo
+```
+
+### CI/Workflow Runs
+
+```bash
+# List recent runs
+gh run list --repo owner/repo --limit 10
+
+# View specific run
+gh run view <run-id> --repo owner/repo
+
+# View failed step logs only
+gh run view <run-id> --repo owner/repo --log-failed
+
+# Re-run failed jobs
+gh run rerun <run-id> --failed --repo owner/repo
+```
+
+### API Queries
+
+```bash
+# Get PR with specific fields
+gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
+
+# List all labels
+gh api repos/owner/repo/labels --jq '.[].name'
+
+# Get repo stats
+gh api repos/owner/repo --jq '{stars: .stargazers_count, forks: .forks_count}'
+```
+
+## JSON Output
+
+Most commands support `--json` for structured output with `--jq` filtering:
+
+```bash
+gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
+gh pr list --json number,title,state,mergeable --jq '.[] | select(.mergeable == "MERGEABLE")'
+```
+
+## Templates
+
+### PR Review Summary
+
+```bash
+# Get PR overview for review
+PR=55 REPO=owner/repo
+echo "## PR #$PR Summary"
+gh pr view $PR --repo $REPO --json title,body,author,additions,deletions,changedFiles \
+  --jq '"**\(.title)** by @\(.author.login)\n\n\(.body)\n\n📊 +\(.additions) -\(.deletions) across \(.changedFiles) files"'
+gh pr checks $PR --repo $REPO
+```
+
+### Issue Triage
+
+```bash
+# Quick issue triage view
+gh issue list --repo owner/repo --state open --json number,title,labels,createdAt \
+  --jq '.[] | "[\(.number)] \(.title) - \([.labels[].name] | join(", ")) (\(.createdAt[:10]))"'
+```
+
+## Notes
+
+- Always specify `--repo owner/repo` when not in a git directory
+- Use URLs directly: `gh pr view https://github.com/owner/repo/pull/55`
+- Rate limits apply; use `gh api --cache 1h` for repeated queries

--- a/.xbot.example/skills/skill-creator/SKILL.md
+++ b/.xbot.example/skills/skill-creator/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: skill-creator
+description: Create, update, or delete skills. Use when designing, structuring, or packaging skills with scripts, references, and assets. Activate when user asks to create a new skill, modify an existing skill, or discusses skill design.
+---
+
+# Skill Creator
+
+Guide for creating and managing skills in xbot.
+
+## Skill Directory
+
+All skills live under `.xbot/skills/`. Each skill is a directory:
+
+```
+.xbot/skills/{skill-name}/
+├── SKILL.md          # Required: YAML frontmatter + markdown body
+├── scripts/          # Optional: executable scripts (bash/python)
+├── references/       # Optional: docs loaded into context on demand
+└── assets/           # Optional: templates, images, fonts for output
+```
+
+## How Skills Work (Progressive Disclosure)
+
+1. **Discovery**: On every message, all skill `name` + `description` are listed in system prompt as `<available_skills>` XML
+2. **Loading**: LLM uses `Read` tool to load SKILL.md when task matches a skill's description
+3. **Execution**: LLM runs scripts via `Shell` tool, reads references via `Read` tool
+
+**Key implication**: `description` in frontmatter is the ONLY trigger mechanism. Write it clearly and comprehensively.
+
+## Creating a Skill
+
+Use `Edit` tool to create all files. No special Skill tool needed.
+
+### Step 1: Create SKILL.md
+
+```bash
+# Use Edit tool with mode "create"
+path: .xbot/skills/{skill-name}/SKILL.md
+```
+
+SKILL.md format:
+
+```markdown
+---
+name: my-skill
+description: What this skill does and WHEN to use it. Be specific about triggers.
+---
+
+# Skill Title
+
+Instructions for using this skill...
+```
+
+### Step 2: Add scripts/references/assets (if needed)
+
+```bash
+# Scripts
+path: .xbot/skills/{skill-name}/scripts/run.sh
+
+# References
+path: .xbot/skills/{skill-name}/references/api-docs.md
+
+# Assets
+path: .xbot/skills/{skill-name}/assets/template.html
+```
+
+### Step 3: Referencing paths in SKILL.md
+
+Use the skill's directory path relative to the working directory:
+
+```markdown
+Run the script:
+bash .xbot/skills/my-skill/scripts/run.sh <args>
+
+Read the reference:
+See .xbot/skills/my-skill/references/api-docs.md for details.
+```
+
+## Updating a Skill
+
+Use `Read` tool to view current SKILL.md, then `Edit` tool (replace/line mode) to modify.
+
+## Deleting a Skill
+
+```bash
+# Use Shell tool
+rm -rf .xbot/skills/{skill-name}
+```
+
+## Writing Guidelines
+
+### Frontmatter
+
+- `name`: lowercase, hyphens, short (e.g. `pdf-editor`)
+- `description`: include WHAT it does + WHEN to use it. This is the only thing visible before loading.
+
+### Body
+
+- Keep under 500 lines. Split large content into `references/` files.
+- Use imperative form ("Run the script", not "You should run the script")
+- Only include info the LLM doesn't already know
+- Prefer concise examples over verbose explanations
+
+### Scripts
+
+- Include when the same code would be rewritten repeatedly
+- Test scripts before finalizing
+- Use `#!/usr/bin/env bash` or `#!/usr/bin/env python3` shebang
+
+### References
+
+- For large docs (>100 lines), include a table of contents
+- Reference from SKILL.md with clear "when to read" guidance
+
+### What NOT to include
+
+- README.md, CHANGELOG.md, INSTALLATION_GUIDE.md
+- User-facing documentation
+- Setup/testing procedures

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -52,6 +52,7 @@ type Agent struct {
 	maxIterations int
 	memoryWindow  int
 	skills        *SkillStore
+	agents        *AgentStore
 	chatHistory   *tools.ChatHistoryStore // 聊天历史缓存
 	cardBuilder   *tools.CardBuilder      // Card Builder MCP
 	workDir       string
@@ -124,6 +125,7 @@ func New(cfg Config) *Agent {
 	if err := tools.InitAgentRoles(agentsDir); err != nil {
 		log.WithError(err).Warn("Failed to load agent roles, SubAgent will have no predefined roles")
 	}
+	agentStore := NewAgentStore(agentsDir)
 
 	registry := tools.DefaultRegistry()
 
@@ -183,6 +185,7 @@ func New(cfg Config) *Agent {
 		maxIterations: cfg.MaxIterations,
 		memoryWindow:  cfg.MemoryWindow,
 		skills:        skillStore,
+		agents:        agentStore,
 		chatHistory:   chatHistory,
 		cardBuilder:   cardBuilder,
 		workDir:       cfg.WorkDir,
@@ -329,8 +332,9 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*bu
 		history = nil
 	}
 	skillsCatalog := a.skills.GetSkillsCatalog()
+	agentsCatalog := a.agents.GetAgentsCatalog()
 	memory := tenantSession.Memory()
-	messages := BuildMessages(history, msg.Content, msg.Channel, memory, a.workDir, skillsCatalog, a.promptLoader, msg.SenderName)
+	messages := BuildMessages(history, msg.Content, msg.Channel, memory, a.workDir, skillsCatalog, agentsCatalog, a.promptLoader, msg.SenderName)
 
 	// 运行 Agent 循环
 	finalContent, toolsUsed, waitingUser, err := a.runLoop(ctx, messages, msg.Channel, msg.ChatID, msg.SenderID, msg.SenderName, true)
@@ -495,8 +499,9 @@ func (a *Agent) handleCardResponse(ctx context.Context, msg bus.InboundMessage, 
 		history = nil
 	}
 	skillsCatalog := a.skills.GetSkillsCatalog()
+	agentsCatalog := a.agents.GetAgentsCatalog()
 	memory := tenantSession.Memory()
-	messages := BuildMessages(history, summary, msg.Channel, memory, a.workDir, skillsCatalog, a.promptLoader, msg.SenderName)
+	messages := BuildMessages(history, summary, msg.Channel, memory, a.workDir, skillsCatalog, agentsCatalog, a.promptLoader, msg.SenderName)
 
 	finalContent, toolsUsed, waitingUser, err := a.runLoop(ctx, messages, msg.Channel, msg.ChatID, msg.SenderID, msg.SenderName, true)
 	if err != nil {

--- a/agent/agents.go
+++ b/agent/agents.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "xbot/logger"
+	"xbot/tools"
+)
+
+// AgentStore scans agent directories and generates a catalog for the system prompt.
+// Agents are predefined SubAgent roles loaded from .xbot/agents/*.md files.
+type AgentStore struct {
+	dir string // agents root directory (e.g. {WorkDir}/.xbot/agents)
+}
+
+// NewAgentStore creates an AgentStore
+func NewAgentStore(dir string) *AgentStore {
+	return &AgentStore{dir: dir}
+}
+
+// GetAgentsCatalog returns a formatted catalog of all available agents for the system prompt.
+// This is dynamically generated on each call so new agent files are picked up without restart.
+func (s *AgentStore) GetAgentsCatalog() string {
+	if _, err := os.Stat(s.dir); os.IsNotExist(err) {
+		return ""
+	}
+
+	roles, err := tools.LoadAgentRoles(s.dir)
+	if err != nil {
+		log.WithError(err).Warn("Failed to load agent roles for catalog")
+		return ""
+	}
+	if len(roles) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<available_agents>\n")
+	for _, r := range roles {
+		toolsInfo := ""
+		if len(r.AllowedTools) > 0 {
+			toolsInfo = strings.Join(r.AllowedTools, ", ")
+		}
+		location := filepath.Join(s.dir, r.Name+".md")
+		fmt.Fprintf(&sb, "  <agent>\n    <name>%s</name>\n    <description>%s</description>\n    <tools>%s</tools>\n    <location>%s</location>\n  </agent>\n",
+			r.Name, r.Description, toolsInfo, location)
+	}
+	sb.WriteString("</available_agents>\n")
+	return sb.String()
+}

--- a/agent/context.go
+++ b/agent/context.go
@@ -124,7 +124,7 @@ func (pl *PromptLoader) Render(data PromptData) string {
 // 拼接顺序经过优化以最大化 KV-cache 命中率：
 //
 //	固定提示词 → Self Profile（很少变） → Skills（相对稳定） → Memory（会变化） → User Profile（会变化） → Time（每次都变）
-func BuildMessages(history []llm.ChatMessage, userContent string, channel string, mem memory.MemoryProvider, workDir string, skillsCatalog string, promptLoader *PromptLoader, senderName string) []llm.ChatMessage {
+func BuildMessages(history []llm.ChatMessage, userContent string, channel string, mem memory.MemoryProvider, workDir string, skillsCatalog string, agentsCatalog string, promptLoader *PromptLoader, senderName string) []llm.ChatMessage {
 	now := time.Now().Format("2006-01-02 15:04:05 MST")
 
 	// 渲染固定部分的模板（不含时间戳）
@@ -136,6 +136,11 @@ func BuildMessages(history []llm.ChatMessage, userContent string, channel string
 	// 注入 skills 目录（让 LLM 按需用 Read 工具加载 SKILL.md）
 	if skillsCatalog != "" {
 		systemContent += "\n" + skillsCatalog
+	}
+
+	// 注入 agents 目录（让 LLM 知道可用的 SubAgent 角色）
+	if agentsCatalog != "" {
+		systemContent += "\n" + agentsCatalog
 	}
 
 	// 注入长期记忆（Letta 模式下包含 Core Memory blocks + archival summary）

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"xbot/llm"
 )
 
@@ -14,23 +13,7 @@ func (t *SubAgentTool) Name() string {
 }
 
 func (t *SubAgentTool) Description() string {
-	roles := ListSubAgentRoles()
-	var roleLines []string
-	for _, r := range roles {
-		toolsInfo := ""
-		if len(r.AllowedTools) > 0 {
-			toolsInfo = fmt.Sprintf(" [tools: %s]", strings.Join(r.AllowedTools, ", "))
-		}
-		roleLines = append(roleLines, fmt.Sprintf("  - \"%s\": %s%s", r.Name, r.Description, toolsInfo))
-	}
-	roleList := strings.Join(roleLines, "\n")
-
-	if roleList == "" {
-		return `Delegate a task to a sub-agent that runs independently with its own tool set and context.
-No predefined roles are available. Please configure agent roles in the .xbot/agents/ directory.`
-	}
-
-	return fmt.Sprintf(`Delegate a task to a sub-agent with a predefined role.
+	return `Delegate a task to a sub-agent with a predefined role.
 The sub-agent runs independently with its own tool set and context, specialized for the given role.
 The sub-agent runs synchronously and returns its final response.
 
@@ -38,10 +21,9 @@ Parameters (JSON):
   - task: string (required), the task description for the sub-agent
   - role: string (required), the predefined role name to use
 
-Available roles:
-%s
+Available roles are listed in the <available_agents> section of the system prompt.
 
-Example: {"task": "Review the changes in core/agent.go for potential bugs", "role": "code-reviewer"}`, roleList)
+Example: {"task": "Review the changes in core/agent.go for potential bugs", "role": "code-reviewer"}`
 }
 
 func (t *SubAgentTool) Parameters() []llm.ToolParam {
@@ -65,20 +47,12 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 	}
 
 	if params.Role == "" {
-		available := make([]string, 0)
-		for _, r := range ListSubAgentRoles() {
-			available = append(available, r.Name)
-		}
-		return nil, fmt.Errorf("role is required (available: %s)", strings.Join(available, ", "))
+		return nil, fmt.Errorf("role is required, see <available_agents> in system prompt")
 	}
 
 	role, ok := GetSubAgentRole(params.Role)
 	if !ok {
-		available := make([]string, 0)
-		for _, r := range ListSubAgentRoles() {
-			available = append(available, r.Name)
-		}
-		return nil, fmt.Errorf("unknown role: %s (available: %s)", params.Role, strings.Join(available, ", "))
+		return nil, fmt.Errorf("unknown role: %s, see <available_agents> in system prompt", params.Role)
 	}
 
 	if ctx == nil || ctx.Manager == nil {

--- a/tools/subagent_roles.go
+++ b/tools/subagent_roles.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	log "xbot/logger"
 )
@@ -16,44 +15,40 @@ type SubAgentRole struct {
 	AllowedTools []string
 }
 
-// agentRoles 从文件加载的角色列表
-var agentRoles []SubAgentRole
+// agentsDir 存储 agents 目录路径，供运行时按需加载
+var agentsDir string
 
-// InitAgentRoles 从指定目录加载 agent 角色定义
-// 如果目录不存在，不报错（没有预定义角色也可以）
+// InitAgentRoles 设置 agents 目录路径（启动时调用一次）
+// 实际加载在每次 GetSubAgentRole 调用时按需进行
 func InitAgentRoles(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles loaded")
+		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles available")
 		return nil
 	}
-
+	agentsDir = dir
+	// 验证目录可读
 	roles, err := LoadAgentRoles(dir)
 	if err != nil {
-		return fmt.Errorf("load agent roles from %s: %w", dir, err)
+		return fmt.Errorf("validate agent roles in %s: %w", dir, err)
 	}
-
-	agentRoles = roles
-	log.WithField("count", len(roles)).Info("Agent roles loaded")
-	for _, r := range roles {
-		log.WithFields(log.Fields{
-			"name":  r.Name,
-			"tools": strings.Join(r.AllowedTools, ", "),
-		}).Debug("Loaded agent role")
-	}
+	log.WithField("count", len(roles)).Info("Agent roles directory configured")
 	return nil
 }
 
-// GetSubAgentRole 根据名称查找角色
+// GetSubAgentRole 根据名称查找角色（每次从文件加载，支持热更新）
 func GetSubAgentRole(name string) (*SubAgentRole, bool) {
-	for i := range agentRoles {
-		if agentRoles[i].Name == name {
-			return &agentRoles[i], true
+	if agentsDir == "" {
+		return nil, false
+	}
+	roles, err := LoadAgentRoles(agentsDir)
+	if err != nil {
+		log.WithError(err).Warn("Failed to load agent roles")
+		return nil, false
+	}
+	for i := range roles {
+		if roles[i].Name == name {
+			return &roles[i], true
 		}
 	}
 	return nil, false
-}
-
-// ListSubAgentRoles 返回所有可用角色
-func ListSubAgentRoles() []SubAgentRole {
-	return agentRoles
 }


### PR DESCRIPTION
## Changes

### 1. Reference configuration (.xbot.example/)
- `agents/code-reviewer.md` — Claude Code style SubAgent role definition
- `skills/github/SKILL.md` — GitHub operations via gh CLI
- `skills/skill-creator/SKILL.md` — Skill creation guide
- `README.md` — Usage instructions (`cp -r .xbot.example .xbot`)

### 2. Dynamic SubAgent role catalog
- New `AgentStore` scans `.xbot/agents/*.md` and injects `<available_agents>` into system prompt
- Aligned with skill mechanism: catalog in system prompt → LLM reads on demand
- `GetSubAgentRole` loads from file on each call — no global cache, no restart needed
- Eliminates concurrency hazard on global `agentRoles` variable
- SubAgent tool description simplified to reference `<available_agents>`