### PR TITLE
refactor: dynamic SubAgent role catalog via system prompt

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -51,6 +51,7 @@ type Agent struct {
 	maxIterations int
 	memoryWindow  int
 	skills        *SkillStore
+	agents        *AgentStore
 	chatHistory   *tools.ChatHistoryStore // 聊天历史缓存
 	cardBuilder   *tools.CardBuilder      // Card Builder MCP
 	workDir       string
@@ -118,6 +119,7 @@ func New(cfg Config) *Agent {
 	if err := tools.InitAgentRoles(agentsDir); err != nil {
 		log.WithError(err).Warn("Failed to load agent roles, SubAgent will have no predefined roles")
 	}
+	agentStore := NewAgentStore(agentsDir)
 
 	registry := tools.DefaultRegistry()
 
@@ -159,6 +161,7 @@ func New(cfg Config) *Agent {
 		maxIterations: cfg.MaxIterations,
 		memoryWindow:  cfg.MemoryWindow,
 		skills:        skillStore,
+		agents:        agentStore,
 		chatHistory:   chatHistory,
 		cardBuilder:   cardBuilder,
 		workDir:       cfg.WorkDir,
@@ -309,8 +312,9 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*bu
 		history = nil
 	}
 	skillsCatalog := a.skills.GetSkillsCatalog()
+	agentsCatalog := a.agents.GetAgentsCatalog()
 	memory := tenantSession.Memory()
-	messages := BuildMessages(history, msg.Content, msg.Channel, memory, a.workDir, skillsCatalog, a.promptLoader, msg.SenderName, userProfile, selfProfile)
+	messages := BuildMessages(history, msg.Content, msg.Channel, memory, a.workDir, skillsCatalog, agentsCatalog, a.promptLoader, msg.SenderName, userProfile, selfProfile)
 
 	// 运行 Agent 循环
 	finalContent, toolsUsed, waitingUser, err := a.runLoop(ctx, messages, msg.Channel, msg.ChatID, msg.SenderID, msg.SenderName, true)
@@ -470,8 +474,9 @@ func (a *Agent) handleCardResponse(ctx context.Context, msg bus.InboundMessage, 
 		history = nil
 	}
 	skillsCatalog := a.skills.GetSkillsCatalog()
+	agentsCatalog := a.agents.GetAgentsCatalog()
 	memory := tenantSession.Memory()
-	messages := BuildMessages(history, summary, msg.Channel, memory, a.workDir, skillsCatalog, a.promptLoader, msg.SenderName, userProfile, selfProfile)
+	messages := BuildMessages(history, summary, msg.Channel, memory, a.workDir, skillsCatalog, agentsCatalog, a.promptLoader, msg.SenderName, userProfile, selfProfile)
 
 	finalContent, toolsUsed, waitingUser, err := a.runLoop(ctx, messages, msg.Channel, msg.ChatID, msg.SenderID, msg.SenderName, true)
 	if err != nil {

--- a/agent/agents.go
+++ b/agent/agents.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "xbot/logger"
+	"xbot/tools"
+)
+
+// AgentStore scans agent directories and generates a catalog for the system prompt.
+// Agents are predefined SubAgent roles loaded from .xbot/agents/*.md files.
+type AgentStore struct {
+	dir string // agents root directory (e.g. {WorkDir}/.xbot/agents)
+}
+
+// NewAgentStore creates an AgentStore
+func NewAgentStore(dir string) *AgentStore {
+	return &AgentStore{dir: dir}
+}
+
+// GetAgentsCatalog returns a formatted catalog of all available agents for the system prompt.
+// This is dynamically generated on each call so new agent files are picked up without restart.
+func (s *AgentStore) GetAgentsCatalog() string {
+	if _, err := os.Stat(s.dir); os.IsNotExist(err) {
+		return ""
+	}
+
+	roles, err := tools.LoadAgentRoles(s.dir)
+	if err != nil {
+		log.WithError(err).Warn("Failed to load agent roles for catalog")
+		return ""
+	}
+	if len(roles) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<available_agents>\n")
+	for _, r := range roles {
+		toolsInfo := ""
+		if len(r.AllowedTools) > 0 {
+			toolsInfo = strings.Join(r.AllowedTools, ", ")
+		}
+		location := filepath.Join(s.dir, r.Name+".md")
+		fmt.Fprintf(&sb, "  <agent>\n    <name>%s</name>\n    <description>%s</description>\n    <tools>%s</tools>\n    <location>%s</location>\n  </agent>\n",
+			r.Name, r.Description, toolsInfo, location)
+	}
+	sb.WriteString("</available_agents>\n")
+	return sb.String()
+}

--- a/agent/context.go
+++ b/agent/context.go
@@ -124,7 +124,7 @@ func (pl *PromptLoader) Render(data PromptData) string {
 // 拼接顺序经过优化以最大化 KV-cache 命中率：
 //
 //	固定提示词 → Self Profile（很少变） → Skills（相对稳定） → Memory（会变化） → User Profile（会变化） → Time（每次都变）
-func BuildMessages(history []llm.ChatMessage, userContent string, channel string, mem memory.MemoryProvider, workDir string, skillsCatalog string, promptLoader *PromptLoader, senderName string, userProfile string, selfProfile string) []llm.ChatMessage {
+func BuildMessages(history []llm.ChatMessage, userContent string, channel string, mem memory.MemoryProvider, workDir string, skillsCatalog string, agentsCatalog string, promptLoader *PromptLoader, senderName string, userProfile string, selfProfile string) []llm.ChatMessage {
 	now := time.Now().Format("2006-01-02 15:04:05 MST")
 
 	// 渲染固定部分的模板（不含时间戳）
@@ -141,6 +141,11 @@ func BuildMessages(history []llm.ChatMessage, userContent string, channel string
 	// 注入 skills 目录（让 LLM 按需用 Read 工具加载 SKILL.md）
 	if skillsCatalog != "" {
 		systemContent += "\n" + skillsCatalog
+	}
+
+	// 注入 agents 目录（让 LLM 知道可用的 SubAgent 角色）
+	if agentsCatalog != "" {
+		systemContent += "\n" + agentsCatalog
 	}
 
 	// 注入长期记忆（会随合并变化，放在 Skills 之后）

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"xbot/llm"
 )
 
@@ -14,23 +13,7 @@ func (t *SubAgentTool) Name() string {
 }
 
 func (t *SubAgentTool) Description() string {
-	roles := ListSubAgentRoles()
-	var roleLines []string
-	for _, r := range roles {
-		toolsInfo := ""
-		if len(r.AllowedTools) > 0 {
-			toolsInfo = fmt.Sprintf(" [tools: %s]", strings.Join(r.AllowedTools, ", "))
-		}
-		roleLines = append(roleLines, fmt.Sprintf("  - \"%s\": %s%s", r.Name, r.Description, toolsInfo))
-	}
-	roleList := strings.Join(roleLines, "\n")
-
-	if roleList == "" {
-		return `Delegate a task to a sub-agent that runs independently with its own tool set and context.
-No predefined roles are available. Please configure agent roles in the .xbot/agents/ directory.`
-	}
-
-	return fmt.Sprintf(`Delegate a task to a sub-agent with a predefined role.
+	return `Delegate a task to a sub-agent with a predefined role.
 The sub-agent runs independently with its own tool set and context, specialized for the given role.
 The sub-agent runs synchronously and returns its final response.
 
@@ -38,10 +21,9 @@ Parameters (JSON):
   - task: string (required), the task description for the sub-agent
   - role: string (required), the predefined role name to use
 
-Available roles:
-%s
+Available roles are listed in the <available_agents> section of the system prompt.
 
-Example: {"task": "Review the changes in core/agent.go for potential bugs", "role": "code-reviewer"}`, roleList)
+Example: {"task": "Review the changes in core/agent.go for potential bugs", "role": "code-reviewer"}`
 }
 
 func (t *SubAgentTool) Parameters() []llm.ToolParam {
@@ -65,20 +47,12 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 	}
 
 	if params.Role == "" {
-		available := make([]string, 0)
-		for _, r := range ListSubAgentRoles() {
-			available = append(available, r.Name)
-		}
-		return nil, fmt.Errorf("role is required (available: %s)", strings.Join(available, ", "))
+		return nil, fmt.Errorf("role is required, see <available_agents> in system prompt")
 	}
 
 	role, ok := GetSubAgentRole(params.Role)
 	if !ok {
-		available := make([]string, 0)
-		for _, r := range ListSubAgentRoles() {
-			available = append(available, r.Name)
-		}
-		return nil, fmt.Errorf("unknown role: %s (available: %s)", params.Role, strings.Join(available, ", "))
+		return nil, fmt.Errorf("unknown role: %s, see <available_agents> in system prompt", params.Role)
 	}
 
 	if ctx == nil || ctx.Manager == nil {

--- a/tools/subagent_roles.go
+++ b/tools/subagent_roles.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	log "xbot/logger"
 )
@@ -16,44 +15,40 @@ type SubAgentRole struct {
 	AllowedTools []string
 }
 
-// agentRoles 从文件加载的角色列表
-var agentRoles []SubAgentRole
+// agentsDir 存储 agents 目录路径，供运行时按需加载
+var agentsDir string
 
-// InitAgentRoles 从指定目录加载 agent 角色定义
-// 如果目录不存在，不报错（没有预定义角色也可以）
+// InitAgentRoles 设置 agents 目录路径（启动时调用一次）
+// 实际加载在每次 GetSubAgentRole 调用时按需进行
 func InitAgentRoles(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles loaded")
+		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles available")
 		return nil
 	}
-
+	agentsDir = dir
+	// 验证目录可读
 	roles, err := LoadAgentRoles(dir)
 	if err != nil {
-		return fmt.Errorf("load agent roles from %s: %w", dir, err)
+		return fmt.Errorf("validate agent roles in %s: %w", dir, err)
 	}
-
-	agentRoles = roles
-	log.WithField("count", len(roles)).Info("Agent roles loaded")
-	for _, r := range roles {
-		log.WithFields(log.Fields{
-			"name":  r.Name,
-			"tools": strings.Join(r.AllowedTools, ", "),
-		}).Debug("Loaded agent role")
-	}
+	log.WithField("count", len(roles)).Info("Agent roles directory configured")
 	return nil
 }
 
-// GetSubAgentRole 根据名称查找角色
+// GetSubAgentRole 根据名称查找角色（每次从文件加载，支持热更新）
 func GetSubAgentRole(name string) (*SubAgentRole, bool) {
-	for i := range agentRoles {
-		if agentRoles[i].Name == name {
-			return &agentRoles[i], true
+	if agentsDir == "" {
+		return nil, false
+	}
+	roles, err := LoadAgentRoles(agentsDir)
+	if err != nil {
+		log.WithError(err).Warn("Failed to load agent roles")
+		return nil, false
+	}
+	for i := range roles {
+		if roles[i].Name == name {
+			return &roles[i], true
 		}
 	}
 	return nil, false
-}
-
-// ListSubAgentRoles 返回所有可用角色
-func ListSubAgentRoles() []SubAgentRole {
-	return agentRoles
 }


### PR DESCRIPTION
## 改动

与 Skill 机制对齐，SubAgent 可用角色通过 system prompt 注入而非写死在工具参数中。

### 变更
- **新增 `agent/agents.go`**：`AgentStore` 动态扫描 `.xbot/agents/` 生成 `<available_agents>` catalog，与 `SkillStore` 模式一致
- **`context.go`**：`BuildMessages` 新增 `agentsCatalog` 参数，注入到 system prompt（skills 之后、memory 之前）
- **`subagent_roles.go`**：去掉全局 `agentRoles` 缓存，`GetSubAgentRole` 每次从文件加载，支持热更新
- **`subagent.go`**：`Description()` 不再列举角色，引导 LLM 查看 system prompt 中的 `<available_agents>`

### 效果
- 新增/修改 agent `.md` 文件后**无需重启**即可生效
- 角色列表不再占用工具定义 token，改为 system prompt 注入（与 skills 一致）
- 消除了 `agentRoles` 全局变量的并发安全隐患