### PR TITLE
fix: propagate sandbox config to SubAgent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1050,7 +1050,9 @@ func (a *Agent) injectInbound(channel, chatID, content string) {
 // RunSubAgent 实现 tools.SubAgentManager 接口
 // 创建一个独立的子 Agent 循环来执行任务，子 Agent 拥有自己的工具集但不能再创建子 Agent
 // allowedTools 为工具白名单，为空时使用所有工具（除 SubAgent）
-func (a *Agent) RunSubAgent(ctx context.Context, parentAgentID string, task string, systemPrompt string, allowedTools []string) (string, error) {
+func (a *Agent) RunSubAgent(parentCtx *tools.ToolContext, task string, systemPrompt string, allowedTools []string) (string, error) {
+	ctx := parentCtx.Ctx
+	parentAgentID := parentCtx.AgentID
 	if systemPrompt == "" {
 		systemPrompt = "You are a helpful assistant. Complete the given task using the available tools."
 	}
@@ -1146,9 +1148,13 @@ func (a *Agent) RunSubAgent(ctx context.Context, parentAgentID string, task stri
 			execCtx, cancel := context.WithTimeout(ctx, toolTimeout)
 
 			toolCtx := &tools.ToolContext{
-				Ctx:        execCtx,
-				WorkingDir: a.workDir,
-				AgentID:    parentAgentID + "/sub",
+				Ctx:              execCtx,
+				WorkingDir:       parentCtx.WorkingDir,
+				WorkspaceRoot:    parentCtx.WorkspaceRoot,
+				ReadOnlyRoots:    parentCtx.ReadOnlyRoots,
+				SandboxEnabled:   parentCtx.SandboxEnabled,
+				PreferredSandbox: parentCtx.PreferredSandbox,
+				AgentID:          parentAgentID + "/sub",
 			}
 
 			result, execErr := tool.Execute(toolCtx, tc.Arguments)

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -48,7 +48,7 @@ type ToolContext struct {
 type SubAgentManager interface {
 	// RunSubAgent 创建并运行一个 SubAgent，返回最终响应文本
 	// allowedTools 为工具白名单，为空时使用所有工具（除 SubAgent）
-	RunSubAgent(ctx context.Context, parentAgentID string, task string, systemPrompt string, allowedTools []string) (string, error)
+	RunSubAgent(parentCtx *ToolContext, task string, systemPrompt string, allowedTools []string) (string, error)
 }
 
 // ToolResult 工具执行结果

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -59,7 +59,7 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 		return nil, fmt.Errorf("sub-agent capability not available")
 	}
 
-	result, err := ctx.Manager.RunSubAgent(ctx.Ctx, ctx.AgentID, params.Task, role.SystemPrompt, role.AllowedTools)
+	result, err := ctx.Manager.RunSubAgent(ctx, params.Task, role.SystemPrompt, role.AllowedTools)
 	if err != nil {
 		return nil, fmt.Errorf("sub-agent failed: %w", err)
 	}


### PR DESCRIPTION
## Problem

SubAgent's `ToolContext` was missing sandbox fields (`WorkspaceRoot`, `ReadOnlyRoots`, `SandboxEnabled`, `PreferredSandbox`), allowing SubAgent's Shell/Read/Edit to bypass sandbox restrictions entirely.

(CR issue #1 from #43)

## Changes

- **`tools/interface.go`**: `RunSubAgent(ctx, parentAgentID, ...)` → `RunSubAgent(parentCtx *ToolContext, ...)`
- **`tools/subagent.go`**: Pass full `ToolContext` instead of extracting fields
- **`agent/agent.go`**: SubAgent `ToolContext` inherits parent's sandbox config + uses parent's `WorkingDir` (was incorrectly using `a.workDir`)

3 files, +12/-6