### PR TITLE
feat: add SANDBOX_ENABLED toggle and fix file sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ AGENT_MAX_ITERATIONS=20
 AGENT_MEMORY_WINDOW=50
 # 工作目录（所有文件相对此目录存放，.xbot/ 下存放 session 和 skills）
 # WORK_DIR=.
+# 沙箱隔离（默认 true，每个用户独立工作区 + bwrap 沙箱；设为 false 关闭隔离，所有用户共享工作目录）
+# SANDBOX_ENABLED=true
 
 # --- 记忆系统 ---
 # 记忆提供者: "flat"（默认，简单双层） 或 "letta"（三层 MemGPT 架构）

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -71,19 +71,20 @@ func resolveGlobalSkillsDirs(workDir, legacySkillsDir string) []string {
 
 // Agent 核心 Agent 引擎
 type Agent struct {
-	bus           *bus.MessageBus
-	llmClient     llm.LLM
-	model         string
-	multiSession  *session.MultiTenantSession // Multi-tenant session manager
-	tools         *tools.Registry
-	maxIterations int
-	memoryWindow  int
-	skills        *SkillStore
-	agents        *AgentStore
-	chatHistory   *tools.ChatHistoryStore // 聊天历史缓存
-	cardBuilder   *tools.CardBuilder      // Card Builder MCP
-	workDir       string
-	promptLoader  *PromptLoader
+	bus            *bus.MessageBus
+	llmClient      llm.LLM
+	model          string
+	multiSession   *session.MultiTenantSession // Multi-tenant session manager
+	tools          *tools.Registry
+	maxIterations  int
+	memoryWindow   int
+	skills         *SkillStore
+	agents         *AgentStore
+	chatHistory    *tools.ChatHistoryStore // 聊天历史缓存
+	cardBuilder    *tools.CardBuilder      // Card Builder MCP
+	workDir        string
+	sandboxEnabled bool
+	promptLoader   *PromptLoader
 
 	consolidatingMu sync.Mutex
 	consolidating   map[string]bool // key: "channel:chat_id", value: 是否正在进行记忆合并
@@ -92,6 +93,7 @@ type Agent struct {
 	sessionMsgIDs    sync.Map                                  // key: "channel:chatID" -> 当前 session 已发消息 ID（用于 Patch 更新）
 	sessionReplyTo   sync.Map                                  // key: "channel:chatID" -> 用户入站消息 ID（用于首条回复的 reply 模式）
 	sessionFinalSent sync.Map                                  // key: "channel:chatID" -> bool, 工具已发送最终回复（如卡片），后续 sendMessage 跳过
+	sessionWorkspace sync.Map                                  // key: "channel:chatID" -> string, 当前会话的工作目录（用于文件发送路径解析）
 }
 
 func buildToolMessageContent(result *tools.ToolResult) string {
@@ -121,6 +123,8 @@ type Config struct {
 	EmbeddingBaseURL string // 嵌入向量服务地址
 	EmbeddingAPIKey  string // 嵌入向量服务密钥
 	EmbeddingModel   string // 嵌入模型名称
+
+	SandboxEnabled bool // 是否启用沙箱隔离（默认 true）
 
 	// MCP 会话管理配置
 	MCPInactivityTimeout time.Duration // MCP 不活跃超时时间
@@ -216,20 +220,21 @@ func New(cfg Config) *Agent {
 	}
 
 	return &Agent{
-		bus:           cfg.Bus,
-		llmClient:     cfg.LLM,
-		model:         cfg.Model,
-		multiSession:  multiSession,
-		tools:         registry,
-		maxIterations: cfg.MaxIterations,
-		memoryWindow:  cfg.MemoryWindow,
-		skills:        skillStore,
-		agents:        agentStore,
-		chatHistory:   chatHistory,
-		cardBuilder:   cardBuilder,
-		workDir:       cfg.WorkDir,
-		promptLoader:  NewPromptLoader(cfg.PromptFile),
-		consolidating: make(map[string]bool),
+		bus:            cfg.Bus,
+		llmClient:      cfg.LLM,
+		model:          cfg.Model,
+		multiSession:   multiSession,
+		tools:          registry,
+		maxIterations:  cfg.MaxIterations,
+		memoryWindow:   cfg.MemoryWindow,
+		skills:         skillStore,
+		agents:         agentStore,
+		chatHistory:    chatHistory,
+		cardBuilder:    cardBuilder,
+		workDir:        cfg.WorkDir,
+		sandboxEnabled: cfg.SandboxEnabled,
+		promptLoader:   NewPromptLoader(cfg.PromptFile),
+		consolidating:  make(map[string]bool),
 	}
 }
 
@@ -313,6 +318,7 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*bu
 	key := msg.Channel + ":" + msg.ChatID
 	a.sessionMsgIDs.Delete(key)
 	a.sessionFinalSent.Delete(key)
+	a.sessionWorkspace.Store(key, resolveWorkDir(a.workDir, msg.SenderID, a.sandboxEnabled))
 	if msg.Metadata != nil && msg.Metadata["message_id"] != "" {
 		a.sessionReplyTo.Store(key, msg.Metadata["message_id"])
 	} else {
@@ -455,7 +461,7 @@ func (a *Agent) processCronMessage(ctx context.Context, msg bus.InboundMessage) 
 
 	// 使用创建者的工作区路径
 	senderID := msg.SenderID
-	workspaceRoot := tools.UserWorkspaceRoot(a.workDir, senderID)
+	workspaceRoot := resolveWorkDir(a.workDir, senderID, a.sandboxEnabled)
 	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
 		log.WithError(err).Warn("Failed to create cron user workspace")
 	}
@@ -488,6 +494,16 @@ func (a *Agent) processCronMessage(ctx context.Context, msg bus.InboundMessage) 
 	}, nil
 }
 
+// resolveWorkDir 根据隔离模式决定工作目录
+// 隔离开启：{workDir}/.xbot/users/{senderID}/workspace
+// 隔离关闭：workDir
+func resolveWorkDir(workDir, senderID string, sandboxEnabled bool) string {
+	if !sandboxEnabled || senderID == "" {
+		return workDir
+	}
+	return tools.UserWorkspaceRoot(workDir, senderID)
+}
+
 // buildPrompt 构建完整的 LLM 消息列表（共用逻辑：processMessage 和 handlePromptQuery 都调用）
 func (a *Agent) buildPrompt(msg bus.InboundMessage, tenantSession *session.TenantSession) ([]llm.ChatMessage, error) {
 	history, err := tenantSession.GetHistory(a.memoryWindow)
@@ -495,7 +511,7 @@ func (a *Agent) buildPrompt(msg bus.InboundMessage, tenantSession *session.Tenan
 		log.WithError(err).Warn("Failed to get history, using empty history")
 		history = nil
 	}
-	workspaceRoot := tools.UserWorkspaceRoot(a.workDir, msg.SenderID)
+	workspaceRoot := resolveWorkDir(a.workDir, msg.SenderID, a.sandboxEnabled)
 	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create user workspace: %w", err)
 	}
@@ -555,7 +571,7 @@ func (a *Agent) handlePromptQuery(_ context.Context, msg bus.InboundMessage, ten
 	fmt.Fprintf(&buf, "\n--- Total messages: %d ---\n", len(messages))
 
 	// 写入文件并发送
-	workspaceRoot := tools.UserWorkspaceRoot(a.workDir, msg.SenderID)
+	workspaceRoot := resolveWorkDir(a.workDir, msg.SenderID, a.sandboxEnabled)
 	promptFile := filepath.Join(workspaceRoot, "prompt-dryrun.md")
 	if err := os.WriteFile(promptFile, []byte(buf.String()), 0o644); err != nil {
 		return nil, fmt.Errorf("write prompt file: %w", err)
@@ -640,7 +656,7 @@ func (a *Agent) handleCardResponse(ctx context.Context, msg bus.InboundMessage, 
 		log.WithError(err).Warn("Failed to get history, using empty history")
 		history = nil
 	}
-	workspaceRoot := tools.UserWorkspaceRoot(a.workDir, msg.SenderID)
+	workspaceRoot := resolveWorkDir(a.workDir, msg.SenderID, a.sandboxEnabled)
 	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create user workspace: %w", err)
 	}
@@ -1037,14 +1053,15 @@ func (a *Agent) executeTool(ctx context.Context, tc llm.ToolCall, channel, chatI
 	}
 	defer cancel()
 
+	workspaceRoot := resolveWorkDir(a.workDir, senderID, a.sandboxEnabled)
 	toolCtx := &tools.ToolContext{
 		Ctx:                 execCtx,
 		WorkingDir:          a.workDir,
-		WorkspaceRoot:       tools.UserWorkspaceRoot(a.workDir, senderID),
+		WorkspaceRoot:       workspaceRoot,
 		ReadOnlyRoots:       resolveGlobalSkillsDirs(a.workDir, filepath.Join(a.workDir, ".xbot", "skills")),
 		MCPConfigPath:       tools.UserMCPConfigPath(a.workDir, senderID),
 		GlobalMCPConfigPath: resolveDataPath(a.workDir, "mcp.json"),
-		SandboxEnabled:      true,
+		SandboxEnabled:      a.sandboxEnabled,
 		PreferredSandbox:    "bwrap,nsjail",
 		AgentID:             "main",
 		Manager:             a,
@@ -1102,6 +1119,11 @@ func (a *Agent) sendMessage(channel, chatID, content string) error {
 		Channel: channel,
 		ChatID:  chatID,
 		Content: content,
+	}
+
+	// Attach workspace root for file path resolution
+	if ws, ok := a.sessionWorkspace.Load(key); ok {
+		msg.WorkspaceRoot = ws.(string)
 	}
 
 	isFinal := strings.HasPrefix(content, "__FEISHU_CARD__:")

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -45,11 +45,12 @@ type InboundMessage struct {
 
 // OutboundMessage 发送到 IM 渠道的出站消息
 type OutboundMessage struct {
-	Channel  string            // 目标渠道
-	ChatID   string            // 目标会话
-	Content  string            // 消息文本
-	Media    []string          // 附件文件路径
-	Metadata map[string]string // 附加元数据
+	Channel       string            // 目标渠道
+	ChatID        string            // 目标会话
+	Content       string            // 消息文本
+	Media         []string          // 附件文件路径
+	Metadata      map[string]string // 附加元数据
+	WorkspaceRoot string            // 发送者的工作目录（用于解析文件路径）
 }
 
 // MessageBus 异步消息总线，解耦渠道和 Agent

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -248,9 +248,9 @@ func (f *FeishuChannel) Send(msg bus.OutboundMessage) (string, error) {
 	}).Debug("Feishu: sending message")
 
 	// 1) 提取 markdown 中的本地文件链接 [name](path)，上传并单独发送，从内容中移除
-	content := f.extractAndSendLocalFiles(msg.ChatID, msg.Content)
+	content := f.extractAndSendLocalFiles(msg.ChatID, msg.Content, msg.WorkspaceRoot)
 	// 2) 替换 markdown 中的本地图片引用 ![alt](path) 为飞书 image_key
-	content = f.replaceLocalImages(content)
+	content = f.replaceLocalImages(content, msg.WorkspaceRoot)
 
 	if strings.TrimSpace(content) == "" {
 		return "", nil
@@ -432,7 +432,7 @@ var imageExtensions = map[string]bool{
 var mdLinkRe = regexp.MustCompile(`(?:^|[^!])\[([^\]]+)\]\(([^)]+)\)`)
 
 // extractAndSendLocalFiles 从 markdown 中提取本地文件链接（非图片），上传并发送文件消息，从内容中移除该链接
-func (f *FeishuChannel) extractAndSendLocalFiles(chatID, content string) string {
+func (f *FeishuChannel) extractAndSendLocalFiles(chatID, content, workspaceRoot string) string {
 	return mdLinkRe.ReplaceAllStringFunc(content, func(match string) string {
 		subs := mdLinkRe.FindStringSubmatch(match)
 		if len(subs) < 3 {
@@ -457,18 +457,24 @@ func (f *FeishuChannel) extractAndSendLocalFiles(chatID, content string) string 
 			return match
 		}
 
+		// 解析文件路径：相对路径基于 workspaceRoot 解析
+		resolvedPath := linkPath
+		if !filepath.IsAbs(linkPath) && workspaceRoot != "" {
+			resolvedPath = filepath.Join(workspaceRoot, linkPath)
+		}
+
 		// 检查文件是否存在
-		if _, err := os.Stat(linkPath); err != nil {
+		if _, err := os.Stat(resolvedPath); err != nil {
 			return match
 		}
 
 		// 上传并发送文件
-		if err := f.sendFile(chatID, linkPath); err != nil {
-			log.WithError(err).WithField("path", linkPath).Warn("Failed to send local file")
+		if err := f.sendFile(chatID, resolvedPath); err != nil {
+			log.WithError(err).WithField("path", resolvedPath).Warn("Failed to send local file")
 			return match
 		}
 
-		log.WithField("path", linkPath).Debug("Sent local file from markdown link")
+		log.WithField("path", resolvedPath).Debug("Sent local file from markdown link")
 
 		// 替换链接为纯文本提示
 		return prefix + "📎 " + subs[1]
@@ -1328,7 +1334,7 @@ func (f *FeishuChannel) extractFromLang(langContent map[string]any, messageId st
 var mdImageRe = regexp.MustCompile(`!\[([^\]]*)\]\(([^)]+)\)`)
 
 // replaceLocalImages 扫描 markdown 中的本地图片引用，上传后替换为飞书 image_key
-func (f *FeishuChannel) replaceLocalImages(content string) string {
+func (f *FeishuChannel) replaceLocalImages(content, workspaceRoot string) string {
 	return mdImageRe.ReplaceAllStringFunc(content, func(match string) string {
 		subs := mdImageRe.FindStringSubmatch(match)
 		if len(subs) < 3 {
@@ -1347,21 +1353,27 @@ func (f *FeishuChannel) replaceLocalImages(content string) string {
 			return match
 		}
 
+		// 解析文件路径：相对路径基于 workspaceRoot 解析
+		resolvedPath := imgPath
+		if !filepath.IsAbs(imgPath) && workspaceRoot != "" {
+			resolvedPath = filepath.Join(workspaceRoot, imgPath)
+		}
+
 		// 检查文件是否存在
-		if _, err := os.Stat(imgPath); err != nil {
-			log.WithField("path", imgPath).Debug("Local image not found, keeping original markdown")
+		if _, err := os.Stat(resolvedPath); err != nil {
+			log.WithField("path", resolvedPath).Debug("Local image not found, keeping original markdown")
 			return match
 		}
 
 		// 上传图片
-		imageKey, err := f.uploadImage(imgPath)
+		imageKey, err := f.uploadImage(resolvedPath)
 		if err != nil {
-			log.WithError(err).WithField("path", imgPath).Warn("Failed to upload local image, keeping original markdown")
+			log.WithError(err).WithField("path", resolvedPath).Warn("Failed to upload local image, keeping original markdown")
 			return match
 		}
 
 		log.WithFields(log.Fields{
-			"path":      imgPath,
+			"path":      resolvedPath,
 			"image_key": imageKey,
 		}).Debug("Replaced local image with image_key")
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,8 @@ type AgentConfig struct {
 	WorkDir        string // 工作目录（所有文件相对此目录存放）
 	PromptFile     string // 系统提示词模板文件路径（空则使用内置默认值）
 
+	SandboxEnabled bool // 是否启用沙箱隔离（默认 true）
+
 	// MCP 会话管理配置
 	MCPInactivityTimeout time.Duration // MCP 不活跃超时时间（默认 30 分钟）
 	MCPCleanupInterval   time.Duration // MCP 清理扫描间隔（默认 5 分钟）
@@ -165,6 +167,7 @@ func Load() *Config {
 			MemoryProvider:       getEnvOrDefault("MEMORY_PROVIDER", "flat"),
 			WorkDir:              getEnvOrDefault("WORK_DIR", "."),
 			PromptFile:           getEnvOrDefault("PROMPT_FILE", "prompt.md"),
+			SandboxEnabled:       getEnvBoolOrDefault("SANDBOX_ENABLED", true),
 			MCPInactivityTimeout: getEnvDurationOrDefault("MCP_INACTIVITY_TIMEOUT", 30*time.Minute),
 			MCPCleanupInterval:   getEnvDurationOrDefault("MCP_CLEANUP_INTERVAL", 5*time.Minute),
 			SessionCacheTimeout:  getEnvDurationOrDefault("SESSION_CACHE_TIMEOUT", 24*time.Hour),

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func main() {
 		EmbeddingBaseURL:     embBaseURL,
 		EmbeddingAPIKey:      embAPIKey,
 		EmbeddingModel:       cfg.Embedding.Model,
+		SandboxEnabled:       cfg.Agent.SandboxEnabled,
 		MCPInactivityTimeout: cfg.Agent.MCPInactivityTimeout,
 		MCPCleanupInterval:   cfg.Agent.MCPCleanupInterval,
 		SessionCacheTimeout:  cfg.Agent.SessionCacheTimeout,

--- a/tools/path_guard.go
+++ b/tools/path_guard.go
@@ -37,15 +37,23 @@ func ResolveWritePath(ctx *ToolContext, inputPath string) (string, error) {
 		return "", fmt.Errorf("path is required")
 	}
 
-	if ctx == nil || (ctx.WorkspaceRoot == "" && ctx.WorkingDir == "" && len(ctx.ReadOnlyRoots) == 0) {
+	// When sandbox is disabled or no workspace configured, allow unrestricted access
+	if ctx == nil || !ctx.SandboxEnabled || (ctx.WorkspaceRoot == "" && ctx.WorkingDir == "" && len(ctx.ReadOnlyRoots) == 0) {
 		if filepath.IsAbs(inputPath) {
 			return cleanAbsPath(inputPath)
 		}
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("failed to get working directory: %w", err)
+		base := ""
+		if ctx != nil {
+			base = defaultWorkspaceRoot(ctx)
 		}
-		return cleanAbsPath(filepath.Join(cwd, inputPath))
+		if base == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("failed to get working directory: %w", err)
+			}
+			base = cwd
+		}
+		return cleanAbsPath(filepath.Join(base, inputPath))
 	}
 
 	root, err := resolveScopedBase(ctx)
@@ -87,15 +95,23 @@ func ResolveReadPath(ctx *ToolContext, inputPath string) (string, error) {
 		return "", fmt.Errorf("path is required")
 	}
 
-	if ctx == nil || (ctx.WorkspaceRoot == "" && ctx.WorkingDir == "" && len(ctx.ReadOnlyRoots) == 0) {
+	// When sandbox is disabled or no workspace configured, allow unrestricted access
+	if ctx == nil || !ctx.SandboxEnabled || (ctx.WorkspaceRoot == "" && ctx.WorkingDir == "" && len(ctx.ReadOnlyRoots) == 0) {
 		if filepath.IsAbs(inputPath) {
 			return cleanAbsPath(inputPath)
 		}
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("failed to get working directory: %w", err)
+		base := ""
+		if ctx != nil {
+			base = defaultWorkspaceRoot(ctx)
 		}
-		return cleanAbsPath(filepath.Join(cwd, inputPath))
+		if base == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("failed to get working directory: %w", err)
+			}
+			base = cwd
+		}
+		return cleanAbsPath(filepath.Join(base, inputPath))
 	}
 
 	root, err := resolveScopedBase(ctx)

--- a/tools/path_guard_test.go
+++ b/tools/path_guard_test.go
@@ -8,7 +8,7 @@ import (
 func TestResolveWritePath_EnforceWorkspace(t *testing.T) {
 	root := t.TempDir()
 	workspace := filepath.Join(root, "workspace")
-	ctx := &ToolContext{WorkspaceRoot: workspace}
+	ctx := &ToolContext{WorkspaceRoot: workspace, SandboxEnabled: true}
 
 	allowed, err := ResolveWritePath(ctx, "notes/todo.txt")
 	if err != nil {
@@ -30,8 +30,9 @@ func TestResolveReadPath_AllowReadOnlyRoots(t *testing.T) {
 	globalSkills := filepath.Join(root, "global-skills")
 
 	ctx := &ToolContext{
-		WorkspaceRoot: workspace,
-		ReadOnlyRoots: []string{globalSkills},
+		WorkspaceRoot:  workspace,
+		ReadOnlyRoots:  []string{globalSkills},
+		SandboxEnabled: true,
 	}
 
 	workspaceFile := filepath.Join(workspace, "a.txt")

--- a/tools/sandbox_runner.go
+++ b/tools/sandbox_runner.go
@@ -72,7 +72,8 @@ func shellWrapForSandbox(shellCommand string, workspaceRoot string) (string, []s
 		if strings.Contains(err.Error(), "disabled on Windows") {
 			return "", nil, err
 		}
-		return "", nil, err
+		// No sandbox runner found: fall back to direct execution
+		return "sh", []string{"-c", shellCommand}, nil
 	}
 	return baseCmd, baseArgs, nil
 }

--- a/tools/shell.go
+++ b/tools/shell.go
@@ -64,20 +64,26 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	defer cancel()
 
 	workspaceRoot := ""
+	sandboxEnabled := true
 	if toolCtx != nil {
 		if toolCtx.WorkspaceRoot != "" {
 			workspaceRoot = toolCtx.WorkspaceRoot
 		} else {
 			workspaceRoot = toolCtx.WorkingDir
 		}
+		sandboxEnabled = toolCtx.SandboxEnabled
 	}
 
-	cmdName, cmdArgs, err := shellWrapForSandbox(params.Command, workspaceRoot)
-	if err != nil {
-		return nil, err
+	var cmd *exec.Cmd
+	if sandboxEnabled {
+		cmdName, cmdArgs, err := shellWrapForSandbox(params.Command, workspaceRoot)
+		if err != nil {
+			return nil, err
+		}
+		cmd = exec.CommandContext(ctx, cmdName, cmdArgs...)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", params.Command)
 	}
-
-	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
 
 	if workspaceRoot != "" {
 		cmd.Dir = workspaceRoot
@@ -93,7 +99,7 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err = cmd.Run()
+	runErr := cmd.Run()
 
 	// 合并输出
 	var resultBuilder strings.Builder
@@ -109,7 +115,7 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	}
 	result := strings.TrimSpace(resultBuilder.String())
 
-	if err != nil {
+	if runErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			// 超时：杀掉进程
 			killProcess(cmd)
@@ -120,9 +126,9 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 		}
 		// 命令执行失败但有输出（如 exit code != 0）
 		if result != "" {
-			return NewResult(fmt.Sprintf("[EXIT %s]\n%s", err, result)), nil
+			return NewResult(fmt.Sprintf("[EXIT %s]\n%s", runErr, result)), nil
 		}
-		return nil, fmt.Errorf("command failed: %w", err)
+		return nil, fmt.Errorf("command failed: %w", runErr)
 	}
 
 	if result == "" {


### PR DESCRIPTION
## Changes

### 1. Sandbox Toggle (`SANDBOX_ENABLED`)

Add `SANDBOX_ENABLED` environment variable (default `true`) to control workspace isolation:

| Mode | WorkDir | Shell | Path Guard | File Send |
|------|---------|-------|------------|-----------|
| **Enabled** (default) | `{workDir}/.xbot/users/{senderID}/workspace` | bwrap sandbox | Restricted to workspace | Resolve from workspace |
| **Disabled** | `{workDir}` (shared) | Direct exec | Unrestricted | Resolve from workDir |

**Use cases for disabling:**
- Single-user deployment (no need for per-user isolation)
- Development/debugging (simpler path handling)
- Environments without bwrap installed

### 2. Fix File Sending Path Resolution

**Root cause:** `extractAndSendLocalFiles` and `replaceLocalImages` used `os.Stat(relativePath)` which resolved against xbot's process CWD, not the user's workspace.

**Fix:** 
- `OutboundMessage` now carries `WorkspaceRoot` field
- Agent stores session workspace in `sync.Map`, attaches to every outbound message
- Feishu channel resolves relative paths against `WorkspaceRoot` before `os.Stat`

### Files Changed

| File | Change |
|------|--------|
| `config/config.go` | +`SandboxEnabled` field |
| `agent/agent.go` | +`resolveWorkDir()` helper, pass sandbox config through all paths |
| `bus/bus.go` | +`WorkspaceRoot` on `OutboundMessage` |
| `channel/feishu.go` | File path resolution using `WorkspaceRoot` |
| `tools/shell.go` | Conditional bwrap vs direct exec |
| `tools/path_guard.go` | Skip restrictions when sandbox disabled |
| `tools/sandbox_runner.go` | Graceful fallback when no sandbox runner found |
| `tools/path_guard_test.go` | Explicit `SandboxEnabled: true` |
| `main.go` | Pass `SandboxEnabled` to agent |
| `.env.example` | Document `SANDBOX_ENABLED` |

### Testing

- All existing tests pass ✅
- Path guard tests updated to explicitly set `SandboxEnabled: true`
