### PR TITLE
fix: MCP auto-reconnect after inactivity unload

### DIFF
--- a/tools/session_mcp.go
+++ b/tools/session_mcp.go
@@ -159,6 +159,11 @@ func (sm *SessionMCPManager) UnloadInactiveServers() time.Time {
 		}
 	}
 
+	// 所有服务器都被卸载后，重置初始化标志以便下次自动重连
+	if len(sm.connections) == 0 && len(serversToUnload) > 0 {
+		sm.initialized = false
+	}
+
 	return sm.sessionLastUsed
 }
 


### PR DESCRIPTION
## Problem

When all MCP servers are unloaded due to inactivity timeout (`UnloadInactiveServers`), the `initialized` flag remains `true`. On next message, `GetCatalog()` / `GetSessionTools()` skip `loadAndConnect()` because they think initialization is already done, resulting in empty tool lists.

**Timeline observed in logs:**
```
01:37:50  MCP server connected for session (22 tools)   ← connected
02:09:36  Unloaded inactive MCP server "playwright"      ← auto-unloaded after 30min
09:50:58  No MCP tool schemas found                      ← broken, no reconnect
```

## Fix

Reset `initialized = false` when `UnloadInactiveServers()` removes all connections, so the next `GetCatalog()` / `GetSessionTools()` call triggers `loadAndConnect()` again.

## Changes

- `tools/session_mcp.go`: +5 lines in `UnloadInactiveServers()`