### PR TITLE
fix: hide model thinking content from progress messages

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -801,10 +801,8 @@ func (a *Agent) runLoop(ctx context.Context, messages []llm.ChatMessage, channel
 			return content, toolsUsed, false, nil
 		}
 
-		// 模型的中间思考内容加入进度（不加引用前缀，保留原始 markdown 格式）
-		if autoNotify && strings.TrimSpace(response.Content) != "" {
-			progressLines = append(progressLines, strings.TrimSpace(response.Content))
-		}
+		// 模型的中间思考内容不显示给用户（避免暴露推理过程）
+		// response.Content 仍然会记录到 messages 中供 LLM 上下文使用
 
 		// 记录 assistant 消息（含 tool_calls）
 		assistantMsg := llm.ChatMessage{


### PR DESCRIPTION
## Problem

When the LLM returns intermediate content (thinking/reasoning) alongside tool calls, this content was appended to `progressLines` and displayed to the user in the progress message card. This exposed internal model reasoning that should not be visible to users.

**Before**: User sees model's thinking text mixed with tool progress:
```
让我先查看相关代码...    ← model thinking (should be hidden)
> ⏳ Read: agent/agent.go ...
> ✅ Read: agent/agent.go (0.5s)
好的，我来分析一下...    ← model thinking (should be hidden)
> ⏳ Grep: "pattern" ...
```

**After**: User only sees clean tool progress:
```
> ⏳ Read: agent/agent.go ...
> ✅ Read: agent/agent.go (0.5s)
> ⏳ Grep: "pattern" ...
```

## Fix

Remove the code that appends `response.Content` to `progressLines` in `runLoop`. The intermediate content is still recorded in the `messages` array for LLM context continuity, just not displayed to the user.

## Changes

- `agent/agent.go`: Remove 4 lines, add 2 comment lines (+2/-4)