### PR TITLE
fix: run MCP stdio servers without bwrap sandbox

### DIFF
--- a/tools/mcp_common.go
+++ b/tools/mcp_common.go
@@ -119,14 +119,19 @@ func resolveWorkspaceRoot(configPath string) string {
 
 // ConnectStdioServer 连接 stdio 模式的 MCP Server（公共函数）
 // Returns a ClientSession (auto-initialized) and the session itself for closing.
+//
+// MCP servers run WITHOUT sandbox (bwrap) because they often need capabilities
+// that are incompatible with PID namespace isolation (--unshare-pid), such as
+// forking child processes and ptrace (e.g. Chromium in Playwright).
+// Security is maintained because MCP servers are explicitly configured by the user
+// in mcp.json, not arbitrary user input.
 func ConnectStdioServer(ctx context.Context, cfg MCPServerConfig, configPath, workspaceRoot, serverName string) (*mcp.ClientSession, error) {
 	envList := BuildStdioEnv(cfg, configPath)
-	cmd, args, err := WrapCommandForSandbox(cfg.Command, cfg.Args, workspaceRoot)
-	if err != nil {
-		return nil, err
-	}
 
-	execCmd := exec.Command(cmd, args...)
+	execCmd := exec.Command(cfg.Command, cfg.Args...)
+	if workspaceRoot != "" {
+		execCmd.Dir = workspaceRoot
+	}
 	if len(envList) > 0 {
 		execCmd.Env = append(os.Environ(), envList...)
 	}


### PR DESCRIPTION
## Problem

MCP servers like Playwright need to fork child processes (Chromium renderer, GPU process, etc.) and use ptrace for crash reporting. The bwrap sandbox's `--unshare-pid` creates a new PID namespace that breaks these capabilities, causing Chromium to crash with SIGTRAP.

**Root cause chain:**
1. bwrap `--unshare-pid` → new PID namespace
2. Chromium forks child processes → crashpad tries to ptrace them
3. ptrace fails in isolated PID namespace → `Operation not permitted`
4. Chromium's crash handler detects failure → sends itself SIGTRAP → core dump

## Fix

Run MCP stdio servers directly without bwrap sandbox wrapping. This is safe because:
- MCP servers are **explicitly configured by the user** in `mcp.json`, not arbitrary input
- Shell commands (user/LLM-generated) continue to run inside bwrap sandbox

## Changes

`tools/mcp_common.go`: Replace `WrapCommandForSandbox()` call with direct `exec.Command()` in `ConnectStdioServer()`.

**+10/-5 lines, 1 file**