### PR TITLE
refactor: enhance MCP tool indexing and Docker sandbox management

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -107,7 +107,7 @@ func indexGlobalMCPTools(registry *tools.Registry, multiSession *session.MultiTe
 	dummySessionKey := "indexing:dummy"
 	mcpMgr := tools.NewSessionMCPManager(
 		dummySessionKey,
-		"",                  // userID (not needed for global indexing)
+		"__system__",        // system userID (avoids invalid Docker image name "xbot-:latest")
 		globalMCPConfigPath, // global config (read-only)
 		"",                  // no user config
 		"",                  // no workspace root needed

--- a/session/multitenant.go
+++ b/session/multitenant.go
@@ -94,14 +94,15 @@ type MultiTenantSession struct {
 	mu                    sync.RWMutex
 	tenantCache           map[string]*TenantSession // key: "channel:chat_id"
 	dbPath                string
-	mcpConfigPath         string           // MCP 配置文件路径
-	mcpInactivityTimeout  time.Duration    // MCP 不活跃超时配置
-	mcpCleanupInterval    time.Duration    // MCP 清理扫描间隔
-	sessionCacheTimeout   time.Duration    // 会话缓存超时配置
-	cleanupStopCh         chan struct{}    // 清理协程停止信号
-	cleanupWg             sync.WaitGroup   // 清理协程等待组
-	cleanupStopOnce       sync.Once        // 确保 StopCleanupRoutine 只执行一次
-	toolIndexFingerprints map[int64]string // per-tenant catalog fingerprint (guarded by mu)
+	mcpConfigPath         string                    // MCP 配置文件路径
+	mcpInactivityTimeout  time.Duration             // MCP 不活跃超时配置
+	mcpCleanupInterval    time.Duration             // MCP 清理扫描间隔
+	sessionCacheTimeout   time.Duration             // 会话缓存超时配置
+	cleanupStopCh         chan struct{}             // 清理协程停止信号
+	cleanupWg             sync.WaitGroup            // 清理协程等待组
+	cleanupStopOnce       sync.Once                 // 确保 StopCleanupRoutine 只执行一次
+	toolIndexFingerprints map[int64]string          // per-tenant catalog fingerprint (guarded by mu)
+	toolIndexPrevNames    map[int64]map[string]bool // per-tenant previous tool name set (guarded by mu)
 }
 
 // NewMultiTenant creates a new multi-tenant session manager
@@ -121,6 +122,7 @@ func NewMultiTenant(dbPath string, opts ...MultiTenantOption) (*MultiTenantSessi
 		memoryProvider:        "flat",
 		tenantCache:           make(map[string]*TenantSession),
 		toolIndexFingerprints: make(map[int64]string),
+		toolIndexPrevNames:    make(map[int64]map[string]bool),
 		dbPath:                dbPath,
 		mcpConfigPath:         "mcp.json", // 默认在工作目录下
 		mcpInactivityTimeout:  30 * time.Minute,
@@ -277,8 +279,8 @@ func catalogFingerprint(catalog []tools.MCPServerCatalogEntry) string {
 }
 
 // indexPersonalMCPTools indexes personal MCP tools for a tenant.
-// Returns the full tool name list when catalog changes (for immediate activation);
-// returns nil when catalog is unchanged or tool index is unavailable.
+// Returns only truly NEW tool names (added since last catalog snapshot) for immediate activation.
+// On first load or when catalog is unchanged, returns nil.
 func (m *MultiTenantSession) indexPersonalMCPTools(tenantID int64, mgr *tools.SessionMCPManager) []string {
 	if mgr == nil {
 		return nil
@@ -313,6 +315,7 @@ func (m *MultiTenantSession) indexPersonalMCPTools(tenantID int64, mgr *tools.Se
 	fp := catalogFingerprint(catalog)
 	m.mu.RLock()
 	prev := m.toolIndexFingerprints[tenantID]
+	prevNames := m.toolIndexPrevNames[tenantID]
 	m.mu.RUnlock()
 	if fp == prev {
 		return nil
@@ -327,7 +330,6 @@ func (m *MultiTenantSession) indexPersonalMCPTools(tenantID int64, mgr *tools.Se
 			defer cancel()
 			if err := m.IndexToolsForTenant(ctx, tenantID, entriesCopy); err != nil {
 				log.WithError(err).Warnf("Failed to index personal MCP tools for tenant %d", tenantID)
-				// Clear fingerprint so next message retries
 				m.mu.Lock()
 				delete(m.toolIndexFingerprints, tenantID)
 				m.mu.Unlock()
@@ -337,12 +339,29 @@ func (m *MultiTenantSession) indexPersonalMCPTools(tenantID int64, mgr *tools.Se
 		}()
 	}
 
-	// Update fingerprint optimistically (async indexing in progress)
+	// Update fingerprint and tool name snapshot
+	currentNames := make(map[string]bool, len(toolNames))
+	for _, name := range toolNames {
+		currentNames[name] = true
+	}
 	m.mu.Lock()
 	m.toolIndexFingerprints[tenantID] = fp
+	m.toolIndexPrevNames[tenantID] = currentNames
 	m.mu.Unlock()
 
-	return toolNames
+	// First load: no previous snapshot → all tools are pre-existing, not "new"
+	if prevNames == nil {
+		return nil
+	}
+
+	// Subsequent change: only return tools not in previous catalog
+	var newTools []string
+	for _, name := range toolNames {
+		if !prevNames[name] {
+			newTools = append(newTools, name)
+		}
+	}
+	return newTools
 }
 
 // migrateProfileToCoreMemory performs a one-time forward-compatible migration

--- a/tools/manage_tools.go
+++ b/tools/manage_tools.go
@@ -129,7 +129,7 @@ func (t *ManageTools) addMCP(ctx *ToolContext, args manageToolsArgs) (*ToolResul
 		return nil, fmt.Errorf("save mcp config: %w", err)
 	}
 
-	return NewResult(fmt.Sprintf("MCP server '%s' has been added. Use 'reload' action to connect to it.", args.Name)), nil
+	return NewResult(fmt.Sprintf("MCP server '%s' has been added. Use ManageTools' 'reload' action to connect to it.", args.Name)), nil
 }
 
 func (t *ManageTools) removeMCP(ctx *ToolContext, args manageToolsArgs) (*ToolResult, error) {

--- a/tools/sandbox_runner.go
+++ b/tools/sandbox_runner.go
@@ -168,17 +168,25 @@ type dockerContainer struct {
 func (s *dockerSandbox) Name() string { return "docker" }
 
 // Close 关闭并清理所有 Docker 容器
-// 仅当容器有文件系统变更时才 commit，commit 后清理旧的 dangling 镜像
+// 分两阶段执行：先 commit 所有用户容器（保证数据持久化优先），再 stop+rm。
+// 这样即使进程在 stop 阶段被外层 Docker SIGKILL，用户数据也已 commit。
 func (s *dockerSandbox) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Phase 1: commit all user containers (fast, critical for data persistence)
 	for userID, c := range s.containers {
 		if !c.started {
 			continue
 		}
-
 		s.commitIfDirty(c.name, userID)
+	}
+
+	// Phase 2: stop + rm all containers (may be slow, less critical)
+	for _, c := range s.containers {
+		if !c.started {
+			continue
+		}
 
 		stopCmd := exec.Command("docker", "stop", "-t", "10", c.name)
 		if err := stopCmd.Run(); err != nil {
@@ -200,6 +208,11 @@ func (s *dockerSandbox) Close() error {
 
 // commitIfDirty 仅在容器有文件系统变更时 commit，并清理旧的 dangling 镜像
 func (s *dockerSandbox) commitIfDirty(containerName, userID string) {
+	if userID == "" || strings.HasPrefix(userID, "__") {
+		log.Debugf("Skipping commit for system container %s (userID=%q)", containerName, userID)
+		return
+	}
+
 	diffCmd := exec.Command("docker", "diff", containerName)
 	diffOutput, err := diffCmd.Output()
 	if err != nil {


### PR DESCRIPTION
- Updated the userID handling in the MCP manager to use a system identifier, improving Docker image naming consistency.
- Introduced a new map to track previous tool names for tenants, allowing for more efficient indexing of personal MCP tools.
- Refined the indexing logic to return only new tool names since the last catalog snapshot, enhancing tool activation accuracy.
- Improved the Docker sandbox cleanup process by implementing a two-phase commit strategy for user containers, ensuring data persistence even during abrupt shutdowns.
- Enhanced logging for system containers to avoid unnecessary commits, improving overall performance and clarity in container management.