### PR TITLE
feat: send startup notification after boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,11 @@ OAUTH_PORT=8081
 # 仅在自动检测失败时手动设置（例如使用了自定义 hostname 导致无法自省容器）：
 # HOST_WORK_DIR=/home/user
 
+# --- 启动通知 ---
+# 启动后自动发送上线通知到指定渠道和会话
+# STARTUP_NOTIFY_CHANNEL=feishu
+# STARTUP_NOTIFY_CHAT_ID=oc_xxxx
+
 # --- 日志配置 ---
 LOG_LEVEL=info
 LOG_FORMAT=text

--- a/config/config.go
+++ b/config/config.go
@@ -42,18 +42,25 @@ type EmbeddingConfig struct {
 	Model   string // Embedding 模型名称（如 bge-m3、text-embedding-3-small）
 }
 
+// StartupNotifyConfig 启动通知配置
+type StartupNotifyConfig struct {
+	Channel string // 通知渠道: "feishu", "qq" 等，空则不发送
+	ChatID  string // 通知目标 chat_id
+}
+
 // Config 应用配置
 type Config struct {
-	Server    ServerConfig
-	LLM       LLMConfig
-	Embedding EmbeddingConfig
-	Log       LogConfig
-	PProf     PProfConfig
-	Feishu    FeishuConfig
-	QQ        QQConfig
-	Agent     AgentConfig
-	OAuth     OAuthConfig
-	Sandbox   SandboxConfig
+	Server        ServerConfig
+	LLM           LLMConfig
+	Embedding     EmbeddingConfig
+	Log           LogConfig
+	PProf         PProfConfig
+	Feishu        FeishuConfig
+	QQ            QQConfig
+	Agent         AgentConfig
+	OAuth         OAuthConfig
+	Sandbox       SandboxConfig
+	StartupNotify StartupNotifyConfig
 }
 
 // FeishuConfig 飞书渠道配置
@@ -188,6 +195,10 @@ func Load() *Config {
 			Mode:        getEnvOrDefault("SANDBOX_MODE", "docker"),
 			DockerImage: getEnvOrDefault("SANDBOX_DOCKER_IMAGE", "ubuntu:22.04"),
 			HostWorkDir: getEnvOrDefault("HOST_WORK_DIR", ""),
+		},
+		StartupNotify: StartupNotifyConfig{
+			Channel: getEnvOrDefault("STARTUP_NOTIFY_CHANNEL", ""),
+			ChatID:  getEnvOrDefault("STARTUP_NOTIFY_CHAT_ID", ""),
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"xbot/agent"
 	"xbot/bus"
@@ -19,6 +20,7 @@ import (
 	"xbot/storage"
 	"xbot/tools"
 	"xbot/tools/feishu_mcp"
+	"xbot/version"
 )
 
 func main() {
@@ -257,6 +259,11 @@ func main() {
 	log.Info("xbot started successfully")
 	fmt.Println("🤖 xbot is running. Press Ctrl+C to stop.")
 
+	// 启动后发送上线通知
+	if cfg.StartupNotify.Channel != "" && cfg.StartupNotify.ChatID != "" {
+		go sendStartupNotify(disp, cfg)
+	}
+
 	// 等待退出信号
 	<-sigCh
 	fmt.Println("\nShutting down...")
@@ -343,4 +350,36 @@ func getChannels(disp *channel.Dispatcher) map[string]channel.Channel {
 		}
 	}
 	return result
+}
+
+// sendStartupNotify 发送启动上线通知
+func sendStartupNotify(disp *channel.Dispatcher, cfg *config.Config) {
+	// 等待渠道 WebSocket 连接建立
+	time.Sleep(3 * time.Second)
+
+	content := fmt.Sprintf("🟢 **xbot 已上线**\n- 版本：%s\n- 时间：%s\n- 模型：%s\n- 沙箱：%s\n- 记忆：%s",
+		version.Info(),
+		time.Now().Format("2006-01-02 15:04:05 MST"),
+		cfg.LLM.Model,
+		cfg.Sandbox.Mode,
+		cfg.Agent.MemoryProvider,
+	)
+
+	for i := 0; i < 3; i++ {
+		_, err := disp.SendDirect(bus.OutboundMessage{
+			Channel: cfg.StartupNotify.Channel,
+			ChatID:  cfg.StartupNotify.ChatID,
+			Content: content,
+		})
+		if err == nil {
+			log.WithFields(log.Fields{
+				"channel": cfg.StartupNotify.Channel,
+				"chat_id": cfg.StartupNotify.ChatID,
+			}).Info("Startup notification sent")
+			return
+		}
+		log.WithError(err).Warn("Failed to send startup notification, retrying...")
+		time.Sleep(2 * time.Second)
+	}
+	log.Error("Failed to send startup notification after 3 attempts")
 }


### PR DESCRIPTION
## Summary

Closes #76

xbot 启动后自动发送上线通知到指定渠道和会话。

## 配置

```env
STARTUP_NOTIFY_CHANNEL=feishu
STARTUP_NOTIFY_CHAT_ID=oc_xxxx
```

两个变量都设置时才发送通知，任一为空则不发送（无需额外 bool 开关）。

## 通知内容

```
🟢 xbot 已上线
- 版本：xbot dev (commit: abc1234, built: 2026-03-14T00:00:00Z)
- 时间：2026-03-14 01:35:00 CST
- 模型：deepseek-chat
- 沙箱：none
- 记忆：letta
```

## 改动

| 文件 | 改动 |
|------|------|
| `config/config.go` | 新增 `StartupNotifyConfig` 结构体和配置加载 |
| `main.go` | 新增 `sendStartupNotify()`，启动后 goroutine 发送通知 |
| `.env.example` | 新增配置项文档 |

## 设计决策

- **渠道无关**：通过 `Dispatcher.SendDirect()` 发送，支持 feishu/qq/任何已注册渠道
- **延迟 3s**：等待 WebSocket 连接建立后再发送
- **重试 3 次**：每次间隔 2s，应对渠道连接尚未就绪的情况
- **不阻塞启动**：在独立 goroutine 中执行