### PR TITLE
feat: register WebSearch as core tool

### DIFF
--- a/tools/interface.go
+++ b/tools/interface.go
@@ -510,7 +510,7 @@ func DefaultRegistry() *Registry {
 	r.RegisterCore(&SearchToolsTool{})
 	// CronTool 需要依赖注入，需在 agent 初始化后单独注册
 	r.RegisterCore(&DownloadFileTool{})
-	// 可加载工具：需通过 load_tools 按需激活
-	r.Register(NewWebSearchTool())
+	// WebSearch: always available (requires TAVILY_API_KEY)
+	r.RegisterCore(NewWebSearchTool())
 	return r
 }

--- a/tools/load_tools_test.go
+++ b/tools/load_tools_test.go
@@ -595,7 +595,7 @@ func TestDefaultRegistry_CoreToolsAlwaysInDefinitions(t *testing.T) {
 	defs := registry.AsDefinitions()
 
 	// Note: Cron is now registered separately with dependency injection
-	coreExpected := []string{"load_tools", "Shell", "Glob", "Grep", "Read", "Edit", "DownloadFile", "SubAgent"}
+	coreExpected := []string{"load_tools", "Shell", "Glob", "Grep", "Read", "Edit", "DownloadFile", "SubAgent", "WebSearch"}
 	for _, name := range coreExpected {
 		if !hasToolDefinitionName(defs, name) {
 			t.Errorf("%s should always appear in definitions (core tool)", name)
@@ -603,7 +603,7 @@ func TestDefaultRegistry_CoreToolsAlwaysInDefinitions(t *testing.T) {
 	}
 
 	// Non-core tools should NOT be in AsDefinitions
-	nonCore := []string{"WebSearch"}
+	nonCore := []string{}
 	for _, name := range nonCore {
 		if hasToolDefinitionName(defs, name) {
 			t.Errorf("%s should NOT appear in AsDefinitions (non-core)", name)


### PR DESCRIPTION
## What

Promote `WebSearch` (Tavily API) from non-core tool to **core tool**, so it's always available in tool definitions without requiring `load_tools` activation.

## Why

WebSearch is a fundamental capability for the agent — fetching real-time information from the web. Requiring manual activation via `load_tools` adds unnecessary friction and means the agent can't search the web by default.

## Changes

| File | Change |
|------|--------|
| `tools/interface.go` | `Register(NewWebSearchTool())" → `RegisterCore(NewWebSearchTool())` |
| `tools/load_tools_test.go` | Move `WebSearch` from non-core to core expected list |

## Notes

- Requires `TAVILY_API_KEY` env var to be set (unchanged behavior — returns error if missing)
- No new dependencies