### PR TITLE
fix: SubAgent can now ask questions to users

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1615,6 +1615,11 @@ func (a *Agent) RunSubAgent(parentCtx *tools.ToolContext, task string, systemPro
 				SandboxEnabled:   parentCtx.SandboxEnabled,
 				PreferredSandbox: parentCtx.PreferredSandbox,
 				AgentID:          parentAgentID + "/sub",
+				Channel:          parentCtx.Channel,
+				ChatID:           parentCtx.ChatID,
+				SenderID:         parentCtx.SenderID,
+				SendFunc:         parentCtx.SendFunc,
+				InjectInbound:    parentCtx.InjectInbound,
 			}
 
 			result, execErr := tool.Execute(toolCtx, tc.Arguments)


### PR DESCRIPTION
## 问题

SubAgent 无法向用户提问，因为创建 toolCtx 时没有传入消息发送和注入相关字段。

## 修复

在 `RunSubAgent` 方法中，为 SubAgent 的 toolCtx 添加以下字段：

- `Channel` - 消息渠道
- `ChatID` - 会话 ID
- `SenderID` - 发送者 ID
- `SendFunc` - 发送消息函数
- `InjectInbound` - 注入入站消息函数

这样 SubAgent 内部就可以使用 `card_create` 等工具向用户发送卡片消息并等待响应。