### PR TITLE
feat(agents): 添加 explorer/tester roles + 系统引导

### DIFF
--- a/.xbot.example/agents/code-reviewer.md
+++ b/.xbot.example/agents/code-reviewer.md
@@ -2,11 +2,11 @@
 name: code-reviewer
 description: "Code review agent. Use after completing a significant piece of code, before merging, or when the user requests a review."
 tools:
-  - search_tools
   - Read
   - Grep
   - Glob
   - Shell
+  - Edit
 ---
 
 You are a code review agent. Your job is to independently review code changes and report findings.

--- a/.xbot.example/agents/explorer.md
+++ b/.xbot.example/agents/explorer.md
@@ -2,11 +2,11 @@
 name: explorer
 description: "Exploration agent. Use when you need to understand codebase structure, find files, search for patterns, or gather information before making changes."
 tools:
-  - search_tools
   - Grep
   - Glob
   - Read
   - Shell
+  - Edit
 ---
 
 You are an exploration agent. Your job is to thoroughly investigate the codebase to find relevant files, understand structure, and gather information.

--- a/.xbot.example/agents/tester.md
+++ b/.xbot.example/agents/tester.md
@@ -2,7 +2,6 @@
 name: tester
 description: "Testing agent. Use when you need to write tests, verify bug fixes, or validate functionality."
 tools:
-  - search_tools
   - Grep
   - Glob
   - Read


### PR DESCRIPTION
## 改动内容

| 文件 | 修改 |
|------|------|
| `.xbot.example/agents/explorer.md` | 新增 explorer role（含系统引导） |
| `.xbot.example/agents/tester.md` | 新增 tester role（含系统引导） |
| `.xbot.example/agents/code-reviewer.md` | 添加系统引导 |

## 系统引导

所有 SubAgent role 现在都包含以下系统引导：

```
在执行任何操作前，**必须**先用 `search_tools` 搜索工具库尝试寻找工具。
- 搜索实时信息 → web_search（搜索引擎，不是浏览网页）
- 浏览/获取网页内容 → Fetch
- 如果需要查找或使用 skill，请使用 `Skill` 工具（不是 search_tools）
- search_tools 仅用于搜索其他工具
```

同时添加了 `search_tools` 到所有 roles 的工具列表中。