### PR TITLE
feat: per-user human block in Letta memory

### DIFF
--- a/.xbot.example/skills/agent-creator/SKILL.md
+++ b/.xbot.example/skills/agent-creator/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: agent-creator
+description: "Create a new SubAgent role. Use when user asks to create a new agent/role, or needs a specialized assistant for a specific task."
+---
+
+# Agent Creator
+
+Create new SubAgent roles for specialized tasks.
+
+## Required Tools
+
+After loading this skill, immediately call `load_tools` for these tools:
+- Edit
+- Shell
+- Glob
+
+## Instructions
+
+### Step 1: Understand the Agent's Purpose
+
+Ask the user:
+1. What task should this agent handle?
+2. What tools does it need?
+3. Any specific output format or workflow?
+
+### Step 2: Create Agent File
+
+Create `.xbot/agents/{agent-name}.md` with this template:
+
+```markdown
+---
+name: {agent-name}
+description: "{What this agent does. Use WHEN to use it — this is the trigger.}"
+tools:
+  - ToolName1
+  - ToolName2
+---
+
+You are a {agent-name} agent. Your job is to {one-sentence purpose}.
+
+## Process
+
+1. **Step 1** — Description
+2. **Step 2** — Description
+3. **Step 3** — Description
+
+## Output Format
+
+### Summary
+One paragraph: what was done, overall result.
+
+### Details
+Structured output based on task type.
+
+## Rules
+
+- **Rule 1** — What to do
+- **Rule 2** — What to avoid
+- **Rule 3** — Specific constraints
+```
+
+### Step 3: Choose Tools
+
+Common tools for agents:
+- **Code**: Read, Grep, Glob, Shell, Edit
+- **Research**: WebSearch, Fetch, Grep, Glob
+- **Testing**: Shell, Read, Glob
+- **Communication**: feishu_send_message, feishu_docx_*
+
+### Step 4: Write Quality Content
+
+Follow `code-reviewer.md` quality standard:
+- ✅ Specific process steps (not vague)
+- ✅ Clear output format with examples
+- ✅ Explicit rules and constraints
+- ✅ Edge case handling
+- ❌ Avoid generic descriptions like "analyze code" — specify how
+
+### Step 5: Verify
+
+List available agents to confirm:
+```bash
+ls -la .xbot/agents/
+```
+
+## Agent Naming Convention
+
+- Use lowercase with hyphens: `code-reviewer`, `explorer`, `tester`
+- Name should reflect its role/function
+- Description must include "Use when..." trigger phrase
+
+## Example
+
+User wants: "a data analyst agent"
+
+```markdown
+---
+name: data-analyst
+description: "Data analysis agent. Use when user needs to analyze data, generate insights, or create visualizations."
+tools:
+  - Read
+  - Grep
+  - Shell
+---
+
+You are a data analyst agent. Your job is to analyze data and generate actionable insights.
+
+## Process
+
+1. **Understand data** — Read data files, identify structure and fields.
+2. **Explore patterns** — Use shell commands (awk, sed, sort, uniq) to find patterns.
+3. **Generate insights** — Summarize findings with specific numbers.
+
+## Output Format
+
+### Summary
+Key findings in one paragraph.
+
+### Statistics
+| Metric | Value |
+|--------|-------|
+| Total records | X |
+| Unique values | Y |
+
+### Insights
+- Finding 1
+- Finding 2
+
+## Rules
+- Always provide specific numbers, not vague statements
+- Use tables for structured data
+- Cite file:line references when analyzing code
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -587,7 +587,7 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*bu
 	}
 
 	// 获取或创建租户会话
-	tenantSession, err := a.multiSession.GetOrCreateSession(msg.Channel, msg.ChatID)
+	tenantSession, err := a.multiSession.GetOrCreateSession(msg.Channel, msg.ChatID, msg.SenderID)
 	if err != nil {
 		return nil, fmt.Errorf("get/create tenant session: %w", err)
 	}
@@ -1403,7 +1403,7 @@ func (a *Agent) executeTool(ctx context.Context, tc llm.ToolCall, channel, chatI
 	}
 
 	// Wire Letta memory fields if the session uses LettaMemory
-	if ts, err := a.multiSession.GetOrCreateSession(channel, chatID); err == nil {
+	if ts, err := a.multiSession.GetOrCreateSession(channel, chatID, senderID); err == nil {
 		if lm, ok := ts.Memory().(*letta.LettaMemory); ok {
 			toolCtx.TenantID = lm.TenantID()
 			toolCtx.CoreMemory = lm.CoreService()

--- a/memory/letta/letta.go
+++ b/memory/letta/letta.go
@@ -20,6 +20,7 @@ import (
 // - Recall Memory: conversation history retrieval by time range
 type LettaMemory struct {
 	tenantID     int64
+	userID       *int64 // for per-user human block
 	coreSvc      *sqlite.CoreMemoryService
 	archivalSvc  *vectordb.ArchivalService
 	memorySvc    *sqlite.MemoryService
@@ -30,13 +31,15 @@ var _ memory.MemoryProvider = (*LettaMemory)(nil)
 var _ memory.ToolIndexer = (*LettaMemory)(nil)
 
 // New creates a LettaMemory instance.
-func New(tenantID int64, coreSvc *sqlite.CoreMemoryService, archivalSvc *vectordb.ArchivalService, memorySvc *sqlite.MemoryService, toolIndexSvc *vectordb.ToolIndexService) *LettaMemory {
-	// Ensure default blocks exist
-	if err := coreSvc.InitBlocks(tenantID); err != nil {
+// If userID is provided, the human block will be per-user instead of per-tenant.
+func New(tenantID int64, userID *int64, coreSvc *sqlite.CoreMemoryService, archivalSvc *vectordb.ArchivalService, memorySvc *sqlite.MemoryService, toolIndexSvc *vectordb.ToolIndexService) *LettaMemory {
+	// Ensure default blocks exist (with userID for human block)
+	if err := coreSvc.InitBlocks(tenantID, userID); err != nil {
 		log.WithError(err).WithField("tenant_id", tenantID).Warn("Failed to init core memory blocks")
 	}
 	return &LettaMemory{
 		tenantID:     tenantID,
+		userID:       userID,
 		coreSvc:      coreSvc,
 		archivalSvc:  archivalSvc,
 		memorySvc:    memorySvc,
@@ -48,7 +51,7 @@ func New(tenantID int64, coreSvc *sqlite.CoreMemoryService, archivalSvc *vectord
 // Unlike FlatMemory which dumps everything, Letta injects only structured blocks.
 // Archival memory is accessed on-demand via tools.
 func (m *LettaMemory) Recall(_ context.Context, _ string) (string, error) {
-	blocks, err := m.coreSvc.GetAllBlocks(m.tenantID)
+	blocks, err := m.coreSvc.GetAllBlocks(m.tenantID, m.userID)
 	if err != nil {
 		return "", fmt.Errorf("recall core blocks: %w", err)
 	}
@@ -152,7 +155,7 @@ func (m *LettaMemory) Memorize(ctx context.Context, input memory.MemorizeInput) 
 	}
 
 	// Read current core memory blocks
-	blocks, err := m.coreSvc.GetAllBlocks(m.tenantID)
+	blocks, err := m.coreSvc.GetAllBlocks(m.tenantID, m.userID)
 	if err != nil {
 		log.WithError(err).Error("Failed to read core memory for consolidation")
 		return memory.MemorizeResult{NewLastConsolidated: lastConsolidated, OK: false}, nil
@@ -224,7 +227,7 @@ Review the conversation below and call the consolidate_memory tool to update the
 				"old_len":   len(oldContent),
 				"new_len":   len(newContent),
 			}).Info("Updating core memory block")
-			if err := m.coreSvc.SetBlock(m.tenantID, blockName, newContent); err != nil {
+			if err := m.coreSvc.SetBlock(m.tenantID, blockName, newContent, m.userID); err != nil {
 				log.WithError(err).WithField("block", blockName).Error("Failed to update core memory block")
 			}
 		}

--- a/session/multitenant.go
+++ b/session/multitenant.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -180,8 +181,9 @@ func (m *MultiTenantSession) SetMCPConfigPath(path string) {
 	m.mcpConfigPath = path
 }
 
-// GetOrCreateSession retrieves or creates a tenant session for the given channel and chatID
-func (m *MultiTenantSession) GetOrCreateSession(channel, chatID string) (*TenantSession, error) {
+// GetOrCreateSession retrieves or creates a tenant session for the given channel, chatID and senderID.
+// senderID is used to create per-user human block in Letta memory. Can be empty for backward compatibility.
+func (m *MultiTenantSession) GetOrCreateSession(channel, chatID, senderID string) (*TenantSession, error) {
 	key := channel + ":" + chatID
 
 	// Fast path: check cache with read lock
@@ -214,11 +216,22 @@ func (m *MultiTenantSession) GetOrCreateSession(channel, chatID string) (*Tenant
 	// 创建会话 MCP 管理器（用户作用域由 ConfigureSessionMCP 在消息处理时注入）
 	sessionKey := channel + ":" + chatID
 	mcpManager := tools.NewSessionMCPManager(sessionKey, "", m.mcpConfigPath, "", "", m.mcpInactivityTimeout)
+
+	// 解析 senderID 为 int64，用于 per-user human block
+	var userID *int64
+	if senderID != "" {
+		if parsed, err := strconv.ParseInt(senderID, 10, 64); err == nil {
+			userID = &parsed
+		} else {
+			log.WithField("sender_id", senderID).Warn("Failed to parse senderID as int64, using nil for human block")
+		}
+	}
+
 	// 根据配置选择记忆提供者
 	var memProvider memory.MemoryProvider
 	switch m.memoryProvider {
 	case "letta":
-		memProvider = letta.New(tenantID, m.coreSvc, m.archivalSvc, m.memorySvc, m.toolIndexSvc)
+		memProvider = letta.New(tenantID, userID, m.coreSvc, m.archivalSvc, m.memorySvc, m.toolIndexSvc)
 		// 前向兼容：一次性迁移 user_profiles → core memory blocks
 		m.migrateProfileToCoreMemory(tenantID)
 	default:
@@ -243,7 +256,7 @@ func (m *MultiTenantSession) GetOrCreateSession(channel, chatID string) (*Tenant
 // ConfigureSessionMCP 根据当前用户更新会话 MCP 作用域。
 // 返回新注册的个人 MCP 工具名列表（用于立即激活），catalog 未变化时返回 nil。
 func (m *MultiTenantSession) ConfigureSessionMCP(channel, chatID, senderID, workDir string) ([]string, error) {
-	sess, err := m.GetOrCreateSession(channel, chatID)
+	sess, err := m.GetOrCreateSession(channel, chatID, senderID)
 	if err != nil {
 		return nil, err
 	}
@@ -366,12 +379,11 @@ func (m *MultiTenantSession) indexPersonalMCPTools(tenantID int64, mgr *tools.Se
 
 // migrateProfileToCoreMemory performs a one-time forward-compatible migration
 // of legacy user_profiles data into Letta core memory blocks.
-// - __me__ profile → persona block (bot identity)
-// - Other profiles are not migrated to the human block (it's per-tenant, not per-user).
+// - __me__ profile → persona block (bot identity, global per-tenant)
 // Only writes if the target block is currently empty to avoid overwriting user edits.
 func (m *MultiTenantSession) migrateProfileToCoreMemory(tenantID int64) {
-	// Check if persona block is already populated
-	persona, _, err := m.coreSvc.GetBlock(tenantID, "persona")
+	// Check if persona block is already populated (persona is global, use nil for userID)
+	persona, _, err := m.coreSvc.GetBlock(tenantID, "persona", nil)
 	if err != nil {
 		log.WithError(err).Warn("Profile migration: failed to read persona block")
 		return
@@ -390,7 +402,8 @@ func (m *MultiTenantSession) migrateProfileToCoreMemory(tenantID int64) {
 		return // No profile to migrate
 	}
 
-	if err := m.coreSvc.SetBlock(tenantID, "persona", selfProfile); err != nil {
+	// Write to persona block (global, use nil for userID)
+	if err := m.coreSvc.SetBlock(tenantID, "persona", selfProfile, nil); err != nil {
 		log.WithError(err).Warn("Profile migration: failed to write persona block")
 		return
 	}

--- a/session/multitenant_test.go
+++ b/session/multitenant_test.go
@@ -18,7 +18,7 @@ func TestMultiTenantSession_GetOrCreateSession(t *testing.T) {
 	defer mt.Close()
 
 	// Create session for tenant 1
-	sess1, err := mt.GetOrCreateSession("feishu", "chat123")
+	sess1, err := mt.GetOrCreateSession("feishu", "chat123", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestMultiTenantSession_GetOrCreateSession(t *testing.T) {
 	}
 
 	// Get same session - should return cached version
-	sess1Again, err := mt.GetOrCreateSession("feishu", "chat123")
+	sess1Again, err := mt.GetOrCreateSession("feishu", "chat123", "")
 	if err != nil {
 		t.Fatalf("Failed to get existing session: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestMultiTenantSession_GetOrCreateSession(t *testing.T) {
 	}
 
 	// Create session for different tenant
-	sess2, err := mt.GetOrCreateSession("feishu", "chat456")
+	sess2, err := mt.GetOrCreateSession("feishu", "chat456", "")
 	if err != nil {
 		t.Fatalf("Failed to create second session: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestMultiTenantSession_GetOrCreateSession(t *testing.T) {
 	}
 
 	// Create session for different channel
-	sess3, err := mt.GetOrCreateSession("slack", "chat123")
+	sess3, err := mt.GetOrCreateSession("slack", "chat123", "")
 	if err != nil {
 		t.Fatalf("Failed to create session with different channel: %v", err)
 	}
@@ -69,11 +69,11 @@ func TestMultiTenantSession_Isolation(t *testing.T) {
 	defer mt.Close()
 
 	// Create two sessions
-	sess1, err := mt.GetOrCreateSession("feishu", "chat1")
+	sess1, err := mt.GetOrCreateSession("feishu", "chat1", "")
 	if err != nil {
 		t.Fatalf("Failed to create session 1: %v", err)
 	}
-	sess2, err := mt.GetOrCreateSession("feishu", "chat2")
+	sess2, err := mt.GetOrCreateSession("feishu", "chat2", "")
 	if err != nil {
 		t.Fatalf("Failed to create session 2: %v", err)
 	}
@@ -123,11 +123,11 @@ func TestMultiTenantSession_MemoryIsolation(t *testing.T) {
 	defer mt.Close()
 
 	// Create two sessions
-	sess1, err := mt.GetOrCreateSession("feishu", "chat1")
+	sess1, err := mt.GetOrCreateSession("feishu", "chat1", "")
 	if err != nil {
 		t.Fatalf("Failed to create session 1: %v", err)
 	}
-	sess2, err := mt.GetOrCreateSession("feishu", "chat2")
+	sess2, err := mt.GetOrCreateSession("feishu", "chat2", "")
 	if err != nil {
 		t.Fatalf("Failed to create session 2: %v", err)
 	}
@@ -174,13 +174,13 @@ func TestMigrateProfileToCoreMemory_MigratesMe(t *testing.T) {
 	}
 
 	// Create a Letta session — should trigger migration
-	sess, err := mt.GetOrCreateSession("feishu", "chat_migrate")
+	sess, err := mt.GetOrCreateSession("feishu", "chat_migrate", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 
-	// Check that persona block was populated
-	persona, _, err := mt.coreSvc.GetBlock(sess.TenantID(), "persona")
+	// Check that persona block was populated (persona is global, use nil for userID)
+	persona, _, err := mt.coreSvc.GetBlock(sess.TenantID(), "persona", nil)
 	if err != nil {
 		t.Fatalf("Failed to read persona block: %v", err)
 	}
@@ -207,18 +207,18 @@ func TestMigrateProfileToCoreMemory_SkipsIfPersonaPopulated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create tenant: %v", err)
 	}
-	if err := mt.coreSvc.InitBlocks(tenantID); err != nil {
+	if err := mt.coreSvc.InitBlocks(tenantID, nil); err != nil {
 		t.Fatalf("Failed to init blocks: %v", err)
 	}
 	existingPersona := "- Already configured persona"
-	if err := mt.coreSvc.SetBlock(tenantID, "persona", existingPersona); err != nil {
+	if err := mt.coreSvc.SetBlock(tenantID, "persona", existingPersona, nil); err != nil {
 		t.Fatalf("Failed to set existing persona: %v", err)
 	}
 
 	// Run migration — should NOT overwrite
 	mt.migrateProfileToCoreMemory(tenantID)
 
-	persona, _, err := mt.coreSvc.GetBlock(tenantID, "persona")
+	persona, _, err := mt.coreSvc.GetBlock(tenantID, "persona", nil)
 	if err != nil {
 		t.Fatalf("Failed to read persona block: %v", err)
 	}
@@ -236,12 +236,12 @@ func TestMigrateProfileToCoreMemory_NoProfileNoError(t *testing.T) {
 	defer mt.Close()
 
 	// No __me__ profile inserted — migration should be a no-op
-	sess, err := mt.GetOrCreateSession("feishu", "chat_noprofile")
+	sess, err := mt.GetOrCreateSession("feishu", "chat_noprofile", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
 
-	persona, _, err := mt.coreSvc.GetBlock(sess.TenantID(), "persona")
+	persona, _, err := mt.coreSvc.GetBlock(sess.TenantID(), "persona", nil)
 	if err != nil {
 		t.Fatalf("Failed to read persona block: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestMultiTenantSession_LettaSessionRecall(t *testing.T) {
 	}
 	defer mt.Close()
 
-	sess, err := mt.GetOrCreateSession("feishu", "chat_letta")
+	sess, err := mt.GetOrCreateSession("feishu", "chat_letta", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}

--- a/session/tenant_test.go
+++ b/session/tenant_test.go
@@ -14,7 +14,7 @@ func TestTenantSession_AddMessage(t *testing.T) {
 	}
 	defer mt.Close()
 
-	sess, err := mt.GetOrCreateSession("test", "chat1")
+	sess, err := mt.GetOrCreateSession("test", "chat1", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestTenantSession_GetHistory(t *testing.T) {
 	}
 	defer mt.Close()
 
-	sess, err := mt.GetOrCreateSession("test", "chat1")
+	sess, err := mt.GetOrCreateSession("test", "chat1", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestTenantSession_Clear(t *testing.T) {
 	}
 	defer mt.Close()
 
-	sess, err := mt.GetOrCreateSession("test", "chat1")
+	sess, err := mt.GetOrCreateSession("test", "chat1", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestTenantSession_LastConsolidated(t *testing.T) {
 	}
 	defer mt.Close()
 
-	sess, err := mt.GetOrCreateSession("test", "chat1")
+	sess, err := mt.GetOrCreateSession("test", "chat1", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestTenantSession_String(t *testing.T) {
 	}
 	defer mt.Close()
 
-	sess, err := mt.GetOrCreateSession("feishu", "chat123")
+	sess, err := mt.GetOrCreateSession("feishu", "chat123", "")
 	if err != nil {
 		t.Fatalf("Failed to create session: %v", err)
 	}

--- a/storage/sqlite/core_memory.go
+++ b/storage/sqlite/core_memory.go
@@ -25,13 +25,19 @@ var DefaultBlocks = map[string]int{
 }
 
 // InitBlocks ensures all default blocks exist for a tenant.
-func (s *CoreMemoryService) InitBlocks(tenantID int64) error {
+// For human block, uses userID if provided (for per-user human block).
+func (s *CoreMemoryService) InitBlocks(tenantID int64, userID *int64) error {
 	conn := s.db.Conn()
 	for name, limit := range DefaultBlocks {
+		// human block is per-user, others are per-tenant
+		var uid *int64
+		if name == "human" && userID != nil {
+			uid = userID
+		}
 		_, err := conn.Exec(`
-			INSERT OR IGNORE INTO core_memory_blocks (tenant_id, block_name, char_limit)
-			VALUES (?, ?, ?)
-		`, tenantID, name, limit)
+			INSERT OR IGNORE INTO core_memory_blocks (tenant_id, block_name, user_id, char_limit)
+			VALUES (?, ?, ?, ?)
+		`, tenantID, name, uid, limit)
 		if err != nil {
 			return fmt.Errorf("init block %s: %w", name, err)
 		}
@@ -40,11 +46,19 @@ func (s *CoreMemoryService) InitBlocks(tenantID int64) error {
 }
 
 // GetBlock reads a single core memory block.
-func (s *CoreMemoryService) GetBlock(tenantID int64, blockName string) (content string, charLimit int, err error) {
+// For human block, if userID is provided, reads the user-specific block.
+func (s *CoreMemoryService) GetBlock(tenantID int64, blockName string, userID *int64) (content string, charLimit int, err error) {
 	conn := s.db.Conn()
+
+	// For human block, use userID if provided
+	var uid *int64
+	if blockName == "human" && userID != nil {
+		uid = userID
+	}
+
 	err = conn.QueryRow(
-		"SELECT content, char_limit FROM core_memory_blocks WHERE tenant_id = ? AND block_name = ?",
-		tenantID, blockName,
+		"SELECT content, char_limit FROM core_memory_blocks WHERE tenant_id = ? AND block_name = ? AND (user_id = ? OR (user_id IS NULL AND ? IS NULL))",
+		tenantID, blockName, uid, uid,
 	).Scan(&content, &charLimit)
 	if err == sql.ErrNoRows {
 		// Return defaults for known blocks
@@ -60,11 +74,18 @@ func (s *CoreMemoryService) GetBlock(tenantID int64, blockName string) (content 
 }
 
 // SetBlock upserts a core memory block.
-func (s *CoreMemoryService) SetBlock(tenantID int64, blockName, content string) error {
+// For human block, if userID is provided, writes to the user-specific block.
+func (s *CoreMemoryService) SetBlock(tenantID int64, blockName, content string, userID *int64) error {
 	conn := s.db.Conn()
 
+	// For human block, use userID if provided
+	var uid *int64
+	if blockName == "human" && userID != nil {
+		uid = userID
+	}
+
 	// Get char limit
-	_, charLimit, err := s.GetBlock(tenantID, blockName)
+	_, charLimit, err := s.GetBlock(tenantID, blockName, uid)
 	if err != nil {
 		return err
 	}
@@ -73,11 +94,11 @@ func (s *CoreMemoryService) SetBlock(tenantID int64, blockName, content string) 
 	}
 
 	_, err = conn.Exec(`
-		INSERT INTO core_memory_blocks (tenant_id, block_name, content, char_limit)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT(tenant_id, block_name)
+		INSERT INTO core_memory_blocks (tenant_id, block_name, user_id, content, char_limit)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id, block_name, user_id)
 		DO UPDATE SET content = excluded.content, updated_at = CURRENT_TIMESTAMP
-	`, tenantID, blockName, content, charLimit)
+	`, tenantID, blockName, uid, content, charLimit)
 	if err != nil {
 		return fmt.Errorf("set block %s: %w", blockName, err)
 	}
@@ -85,18 +106,24 @@ func (s *CoreMemoryService) SetBlock(tenantID int64, blockName, content string) 
 	log.WithFields(log.Fields{
 		"tenant_id":  tenantID,
 		"block_name": blockName,
+		"user_id":    uid,
 		"length":     len(content),
 	}).Debug("Core memory block updated")
 	return nil
 }
 
 // GetAllBlocks reads all core memory blocks for a tenant.
-func (s *CoreMemoryService) GetAllBlocks(tenantID int64) (map[string]string, error) {
+// If userID is provided, includes user-specific human block.
+func (s *CoreMemoryService) GetAllBlocks(tenantID int64, userID *int64) (map[string]string, error) {
 	conn := s.db.Conn()
-	rows, err := conn.Query(
-		"SELECT block_name, content FROM core_memory_blocks WHERE tenant_id = ? ORDER BY block_name",
-		tenantID,
-	)
+
+	// Query: get global blocks + user-specific human block
+	rows, err := conn.Query(`
+		SELECT block_name, content FROM core_memory_blocks
+		WHERE tenant_id = ?
+		  AND (user_id IS NULL OR user_id = ?)
+		ORDER BY block_name
+	`, tenantID, userID)
 	if err != nil {
 		return nil, fmt.Errorf("query blocks: %w", err)
 	}

--- a/storage/sqlite/db.go
+++ b/storage/sqlite/db.go
@@ -19,7 +19,7 @@ type DB struct {
 	mu   sync.RWMutex
 }
 
-const schemaVersion = 6
+const schemaVersion = 7
 
 // Open opens or creates a SQLite database at the given path
 // If the database doesn't exist, it will be created with the required schema
@@ -158,10 +158,11 @@ CREATE TABLE user_profiles (
 CREATE TABLE core_memory_blocks (
     tenant_id INTEGER NOT NULL,
     block_name TEXT NOT NULL,
+    user_id INTEGER,
     content TEXT NOT NULL DEFAULT '',
     char_limit INTEGER NOT NULL DEFAULT 2000,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (tenant_id, block_name),
+    PRIMARY KEY (tenant_id, block_name, user_id),
     FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
 );
 
@@ -188,7 +189,7 @@ END;
 CREATE TABLE schema_version (
     version INTEGER PRIMARY KEY
 );
-INSERT INTO schema_version (version) VALUES (6);
+INSERT INTO schema_version (version) VALUES (7);
 
 CREATE TABLE user_llm_configs (
     sender_id TEXT PRIMARY KEY,
@@ -362,6 +363,37 @@ UPDATE schema_version SET version = 6;
 			return fmt.Errorf("migrate v5->v6: %w", err)
 		}
 		log.Info("Database migrated to v6 (added user_llm_configs)")
+	}
+
+	if from < 7 {
+		// Migration to add user_id to core_memory_blocks for per-user human block
+		// Step 1: Add user_id column (允许 NULL，兼容旧数据)
+		_, err := conn.Exec("ALTER TABLE core_memory_blocks ADD COLUMN user_id INTEGER")
+		if err != nil {
+			return fmt.Errorf("migrate v6->v7: add user_id column: %w", err)
+		}
+
+		// Step 2: Migrate existing private chat human blocks to user_id
+		// Private chats have tenant_id in tenants table where channel='private'
+		// We can infer user_id from the chat_id (format: private:{userID})
+		_, err = conn.Exec(`
+			UPDATE core_memory_blocks
+			SET user_id = CAST(SUBSTR(t.chat_id, 9) AS INTEGER)
+			FROM tenants t
+			WHERE t.channel = 'private'
+			  AND t.id = core_memory_blocks.tenant_id
+			  AND core_memory_blocks.block_name = 'human'
+			  AND t.chat_id LIKE 'private:%'
+		`)
+		if err != nil {
+			return fmt.Errorf("migrate v6->v7: migrate private human blocks: %w", err)
+		}
+		log.Info("Database migrated to v7 (added user_id to core_memory_blocks, migrated private human blocks)")
+
+		// Step 3: Update schema version
+		if _, err := conn.Exec("UPDATE schema_version SET version = 7"); err != nil {
+			return fmt.Errorf("update schema version: %w", err)
+		}
 	}
 
 	return nil

--- a/tools/memory_tools.go
+++ b/tools/memory_tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -59,8 +60,9 @@ func (t *CoreMemoryAppendTool) Execute(ctx *ToolContext, input string) (*ToolRes
 		return NewResult("Core memory is not available (memory provider is not letta)."), nil
 	}
 	tenantID := ctx.TenantID
+	userID := parseUserID(ctx.SenderID)
 
-	current, _, err := coreSvc.GetBlock(tenantID, args.Block)
+	current, _, err := coreSvc.GetBlock(tenantID, args.Block, userID)
 	if err != nil {
 		return nil, fmt.Errorf("read block: %w", err)
 	}
@@ -72,7 +74,7 @@ func (t *CoreMemoryAppendTool) Execute(ctx *ToolContext, input string) (*ToolRes
 		newContent = current + "\n" + args.Content
 	}
 
-	if err := coreSvc.SetBlock(tenantID, args.Block, newContent); err != nil {
+	if err := coreSvc.SetBlock(tenantID, args.Block, newContent, userID); err != nil {
 		return nil, fmt.Errorf("update block: %w", err)
 	}
 
@@ -140,8 +142,9 @@ func (t *CoreMemoryReplaceTool) Execute(ctx *ToolContext, input string) (*ToolRe
 		return NewResult("Core memory is not available (memory provider is not letta)."), nil
 	}
 	tenantID := ctx.TenantID
+	userID := parseUserID(ctx.SenderID)
 
-	current, _, err := coreSvc.GetBlock(tenantID, args.Block)
+	current, _, err := coreSvc.GetBlock(tenantID, args.Block, userID)
 	if err != nil {
 		return nil, fmt.Errorf("read block: %w", err)
 	}
@@ -151,7 +154,7 @@ func (t *CoreMemoryReplaceTool) Execute(ctx *ToolContext, input string) (*ToolRe
 	}
 
 	newContent := strings.Replace(current, args.OldText, args.NewText, 1)
-	if err := coreSvc.SetBlock(tenantID, args.Block, newContent); err != nil {
+	if err := coreSvc.SetBlock(tenantID, args.Block, newContent, userID); err != nil {
 		return nil, fmt.Errorf("update block: %w", err)
 	}
 
@@ -211,8 +214,9 @@ func (t *RethinkTool) Execute(ctx *ToolContext, input string) (*ToolResult, erro
 		return NewResult("Core memory is not available (memory provider is not letta)."), nil
 	}
 	tenantID := ctx.TenantID
+	userID := parseUserID(ctx.SenderID)
 
-	if err := coreSvc.SetBlock(tenantID, args.Block, args.NewContent); err != nil {
+	if err := coreSvc.SetBlock(tenantID, args.Block, args.NewContent, userID); err != nil {
 		return nil, fmt.Errorf("rewrite block: %w", err)
 	}
 
@@ -452,6 +456,20 @@ func isValidBlock(name string) bool {
 		return true
 	}
 	return false
+}
+
+// parseUserID parses senderID string to *int64 for per-user human block.
+// Returns nil if senderID is empty or cannot be parsed.
+func parseUserID(senderID string) *int64 {
+	if senderID == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(senderID, 10, 64)
+	if err != nil {
+		log.WithField("sender_id", senderID).Warn("Failed to parse senderID as int64 for core memory")
+		return nil
+	}
+	return &parsed
 }
 
 // LettaMemoryTools returns all Letta memory tools for registration.


### PR DESCRIPTION
## 概述

实现 per-user human block：human block 按用户区分（不同群组/私聊中同一用户的 human block 保持一致），persona block 保持全局共享。

## 改动

### 1. 数据库迁移 (storage/sqlite/db.go)
- v7 迁移：添加 user_id 列到 core_memory_blocks 表
- 迁移私聊中的 human block 到对应的 userID

### 2. CoreMemoryService (storage/sqlite/core_memory.go)
- 所有方法添加 userID 参数：
  - `InitBlocks(tenantID, userID)` - human block 按用户初始化
  - `GetBlock(tenantID, blockName, userID)` - 获取用户专属的 human block
  - `SetBlock(tenantID, blockName, content, userID)` - 设置用户专属的 human block
  - `GetAllBlocks(tenantID, userID)` - 获取所有 blocks（包括用户专属 human block）

### 3. LettaMemory (memory/letta/letta.go)
- 添加 userID 字段
- 创建时传入 userID，用于 per-user human block

### 4. Session (session/multitenant.go)
- `GetOrCreateSession` 解析 senderID 并传给 LettaMemory

### 5. Memory Tools (tools/memory_tools.go)
- `core_memory_append/replace/rethink` 使用 senderID 实现 per-user blocks

### 6. MigrateProfileToCoreMemory
- 跳过 human block，只迁移 persona（因为 human 需要 userID）

## 行为变化

| Block | 区分键 | 说明 |
|-------|--------|------|
| **persona** | NULL（全局） | bot 自己的设定，全局共享 |
| **human** | userID | 用户画像，按用户区分 |
| **working_context** | tenantID | 群组/私聊会话级别 |