### PR TITLE
test+docs: add CoreMemory isolation regression tests and design doc

### DIFF
--- a/design/core-memory-isolation.md
+++ b/design/core-memory-isolation.md
@@ -1,0 +1,113 @@
+# Core Memory 隔离设计
+
+## 概述
+
+Core Memory（核心记忆）存储 bot 的身份设定、用户画像和工作上下文。采用分层隔离策略：persona 全局共享，human 跨 tenant 按用户共享，working_context 按会话隔离。
+
+## 存储策略
+
+| Block | TenantID | UserID | 说明 |
+|-------|----------|--------|------|
+| persona | 0 (固定) | "" | 全局共享，所有用户看到同一个 bot 身份 |
+| human | 0 (固定) | userID | 跨 tenant 共享，同一用户在不同会话共享画像 |
+| working_context | tenantID | "" | 按会话隔离，不同群聊/私聊独立 |
+
+## 读写一致性
+
+**关键原则：读写使用相同的 key**
+
+- GetBlock / SetBlock / GetAllBlocks 对同一 block type 使用相同的 effectiveTenantID 和 uid 计算逻辑
+- 任何修改必须同时保证 Get/Set/GetAll 行为一致
+
+### 代码位置
+
+```
+storage/sqlite/core_memory.go
+```
+
+### 关键逻辑
+
+```go
+switch blockName {
+case "persona":
+    effectiveTenantID = 0  // 固定
+case "human":
+    effectiveTenantID = 0  // 固定
+    uid = userID           // 按用户区分
+case "working_context":
+    effectiveTenantID = tenantID  // 按会话隔离
+    uid = ""
+}
+```
+
+## 历史数据迁移
+
+### 问题
+
+旧版本 persona 和 human 存储在各自 tenantID 下，导致：
+1. 私聊和群聊的 human 不共享
+2. persona 在不同 tenant 下有不同副本
+
+### 迁移策略
+
+1. **合并 persona**：所有 tenantID 的 persona 取最长内容，合并到 tenantID=0
+2. **合并 human**：每个 userID 取最长内容，合并到 tenantID=0
+3. **清理旧数据**：迁移后删除 tenantID != 0 的 persona/human 记录
+
+### SQL 实现
+
+```sql
+-- persona: 取最长内容
+INSERT OR REPLACE INTO core_memory_blocks (...)
+SELECT 0, 'persona', '', content, char_limit, CURRENT_TIMESTAMP
+FROM core_memory_blocks
+WHERE block_name = 'persona' AND user_id = ''
+ORDER BY LENGTH(content) DESC
+LIMIT 1;
+
+-- human: 按 userID 取最长内容
+INSERT OR REPLACE INTO core_memory_blocks (...)
+SELECT 0, 'human', user_id, content, char_limit, CURRENT_TIMESTAMP
+FROM (
+    SELECT user_id, content, char_limit,
+        ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY LENGTH(content) DESC) AS rn
+    FROM core_memory_blocks
+    WHERE block_name = 'human' AND user_id != ''
+)
+WHERE rn = 1;
+
+-- 清理旧数据
+DELETE FROM core_memory_blocks
+WHERE block_name IN ('persona', 'human') AND tenant_id != 0;
+```
+
+## 回归测试
+
+测试文件：`storage/sqlite/core_memory_test.go`
+
+| 测试 | 验证场景 |
+|------|----------|
+| TestCoreMemoryService_PersonaGlobal | 不同 tenant 写入/读取同一 persona |
+| TestCoreMemoryService_HumanCrossTenant | 不同 tenant 下同一 userID 共享 human |
+| TestCoreMemoryService_WorkingContextPerTenant | 不同 tenant 独立的 working_context |
+| TestCoreMemoryService_ReadWriteConsistency | 写入能读回 |
+| TestCoreMemoryService_DefaultBlocks | 默认字符限制正确 |
+| TestCoreMemoryService_CharLimit | 超过限制报错 |
+| TestCoreMemoryService_DifferentUsersDifferentHuman | 不同用户 human 独立 |
+| TestCoreMemoryService_MigrationKeepsLongest | 迁移保留最长内容 |
+
+## 常见错误
+
+### 读写 key 不一致
+
+**错误示例**：
+```go
+// SetBlock 中 human 没有设 effectiveTenantID = 0
+case "human":
+    // 漏了 effectiveTenantID = 0
+    uid = userID
+```
+
+**后果**：写入用 tenantID=群聊ID，读取用 tenantID=0，读不到写入的数据。
+
+**修复**：确保 GetBlock / SetBlock / InitBlocks 中相同 block type 使用相同的 effectiveTenantID 计算逻辑。

--- a/storage/sqlite/core_memory_test.go
+++ b/storage/sqlite/core_memory_test.go
@@ -1,0 +1,455 @@
+package sqlite
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestCoreMemoryService_PersonaGlobal tests that persona is always stored at tenantID=0 (global shared).
+func TestCoreMemoryService_PersonaGlobal(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID1 := int64(100)
+	tenantID2 := int64(200)
+
+	// Initialize both tenants
+	if err := svc.InitBlocks(tenantID1, ""); err != nil {
+		t.Fatalf("InitBlocks tenant1 failed: %v", err)
+	}
+	if err := svc.InitBlocks(tenantID2, ""); err != nil {
+		t.Fatalf("InitBlocks tenant2 failed: %v", err)
+	}
+
+	// Set persona from tenant1
+	if err := svc.SetBlock(tenantID1, "persona", "Persona from tenant1", ""); err != nil {
+		t.Fatalf("SetBlock persona tenant1 failed: %v", err)
+	}
+
+	// Set persona from tenant2 (should overwrite tenant1's)
+	if err := svc.SetBlock(tenantID2, "persona", "Persona from tenant2", ""); err != nil {
+		t.Fatalf("SetBlock persona tenant2 failed: %v", err)
+	}
+
+	// Both tenants should read the same (last write wins)
+	content1, _, err := svc.GetBlock(tenantID1, "persona", "")
+	if err != nil {
+		t.Fatalf("GetBlock persona tenant1 failed: %v", err)
+	}
+	content2, _, err := svc.GetBlock(tenantID2, "persona", "")
+	if err != nil {
+		t.Fatalf("GetBlock persona tenant2 failed: %v", err)
+	}
+
+	if content1 != content2 {
+		t.Errorf("Persona should be global, got tenant1: %q, tenant2: %q", content1, content2)
+	}
+	if content1 != "Persona from tenant2" {
+		t.Errorf("Expected last write 'Persona from tenant2', got: %q", content1)
+	}
+
+	// GetAllBlocks also returns same persona
+	blocks1, _ := svc.GetAllBlocks(tenantID1, "")
+	blocks2, _ := svc.GetAllBlocks(tenantID2, "")
+	if blocks1["persona"] != blocks2["persona"] {
+		t.Errorf("GetAllBlocks persona should be same: %q vs %q", blocks1["persona"], blocks2["persona"])
+	}
+}
+
+// TestCoreMemoryService_HumanCrossTenant tests that human is cross-tenant (tenantID=0 + userID).
+func TestCoreMemoryService_HumanCrossTenant(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID1 := int64(100)
+	tenantID2 := int64(200)
+	userID := "ou_123"
+
+	// Initialize both tenants
+	if err := svc.InitBlocks(tenantID1, userID); err != nil {
+		t.Fatalf("InitBlocks tenant1 failed: %v", err)
+	}
+	if err := svc.InitBlocks(tenantID2, userID); err != nil {
+		t.Fatalf("InitBlocks tenant2 failed: %v", err)
+	}
+
+	// Set human from tenant1
+	if err := svc.SetBlock(tenantID1, "human", "Human from tenant1", userID); err != nil {
+		t.Fatalf("SetBlock human tenant1 failed: %v", err)
+	}
+
+	// Set human from tenant2 (same userID, should overwrite)
+	if err := svc.SetBlock(tenantID2, "human", "Human from tenant2", userID); err != nil {
+		t.Fatalf("SetBlock human tenant2 failed: %v", err)
+	}
+
+	// Both tenants should read same human (cross-tenant)
+	content1, _, err := svc.GetBlock(tenantID1, "human", userID)
+	if err != nil {
+		t.Fatalf("GetBlock human tenant1 failed: %v", err)
+	}
+	content2, _, err := svc.GetBlock(tenantID2, "human", userID)
+	if err != nil {
+		t.Fatalf("GetBlock human tenant2 failed: %v", err)
+	}
+
+	if content1 != content2 {
+		t.Errorf("Human should be cross-tenant, got tenant1: %q, tenant2: %q", content1, content2)
+	}
+	if content1 != "Human from tenant2" {
+		t.Errorf("Expected last write 'Human from tenant2', got: %q", content1)
+	}
+}
+
+// TestCoreMemoryService_WorkingContextPerTenant tests that working_context is per-tenant isolated.
+func TestCoreMemoryService_WorkingContextPerTenant(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID1 := int64(100)
+	tenantID2 := int64(200)
+
+	// Initialize both tenants
+	if err := svc.InitBlocks(tenantID1, ""); err != nil {
+		t.Fatalf("InitBlocks tenant1 failed: %v", err)
+	}
+	if err := svc.InitBlocks(tenantID2, ""); err != nil {
+		t.Fatalf("InitBlocks tenant2 failed: %v", err)
+	}
+
+	// Set working_context for each tenant
+	if err := svc.SetBlock(tenantID1, "working_context", "WC tenant1", ""); err != nil {
+		t.Fatalf("SetBlock tenant1 failed: %v", err)
+	}
+	if err := svc.SetBlock(tenantID2, "working_context", "WC tenant2", ""); err != nil {
+		t.Fatalf("SetBlock tenant2 failed: %v", err)
+	}
+
+	// Each tenant should have its own working_context
+	content1, _, err := svc.GetBlock(tenantID1, "working_context", "")
+	if err != nil {
+		t.Fatalf("GetBlock tenant1 failed: %v", err)
+	}
+	content2, _, err := svc.GetBlock(tenantID2, "working_context", "")
+	if err != nil {
+		t.Fatalf("GetBlock tenant2 failed: %v", err)
+	}
+
+	if content1 == content2 {
+		t.Errorf("Working context should be per-tenant, got same: %q", content1)
+	}
+	if content1 != "WC tenant1" {
+		t.Errorf("Expected 'WC tenant1', got: %q", content1)
+	}
+	if content2 != "WC tenant2" {
+		t.Errorf("Expected 'WC tenant2', got: %q", content2)
+	}
+
+	// GetAllBlocks also returns different working_context
+	blocks1, _ := svc.GetAllBlocks(tenantID1, "")
+	blocks2, _ := svc.GetAllBlocks(tenantID2, "")
+	if blocks1["working_context"] == blocks2["working_context"] {
+		t.Error("GetAllBlocks working_context should be different per tenant")
+	}
+}
+
+// TestCoreMemoryService_ReadWriteConsistency tests that data written can be read back.
+func TestCoreMemoryService_ReadWriteConsistency(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID := int64(100)
+	userID := "ou_123"
+
+	if err := svc.InitBlocks(tenantID, userID); err != nil {
+		t.Fatalf("InitBlocks failed: %v", err)
+	}
+
+	// Test all three block types
+	testCases := []struct {
+		blockName string
+		content   string
+		userID    string
+	}{
+		{"persona", "Test persona", ""},
+		{"human", "Test human", userID},
+		{"working_context", "Test working context", ""},
+	}
+
+	for _, tc := range testCases {
+		if err := svc.SetBlock(tenantID, tc.blockName, tc.content, tc.userID); err != nil {
+			t.Fatalf("SetBlock %s failed: %v", tc.blockName, err)
+		}
+
+		got, _, err := svc.GetBlock(tenantID, tc.blockName, tc.userID)
+		if err != nil {
+			t.Fatalf("GetBlock %s failed: %v", tc.blockName, err)
+		}
+		if got != tc.content {
+			t.Errorf("%s: expected %q, got %q", tc.blockName, tc.content, got)
+		}
+	}
+
+	// Test GetAllBlocks
+	blocks, err := svc.GetAllBlocks(tenantID, userID)
+	if err != nil {
+		t.Fatalf("GetAllBlocks failed: %v", err)
+	}
+	if blocks["persona"] != "Test persona" {
+		t.Errorf("GetAllBlocks persona: expected 'Test persona', got: %q", blocks["persona"])
+	}
+	if blocks["human"] != "Test human" {
+		t.Errorf("GetAllBlocks human: expected 'Test human', got: %q", blocks["human"])
+	}
+	if blocks["working_context"] != "Test working context" {
+		t.Errorf("GetAllBlocks working_context: expected 'Test working context', got: %q", blocks["working_context"])
+	}
+}
+
+// TestCoreMemoryService_DefaultBlocks tests that default char limits are set correctly.
+func TestCoreMemoryService_DefaultBlocks(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID := int64(100)
+	userID := "ou_123"
+
+	if err := svc.InitBlocks(tenantID, userID); err != nil {
+		t.Fatalf("InitBlocks failed: %v", err)
+	}
+
+	// Check default char limits
+	_, charLimit, err := svc.GetBlock(tenantID, "persona", "")
+	if err != nil {
+		t.Fatalf("GetBlock persona failed: %v", err)
+	}
+	if charLimit != 2000 {
+		t.Errorf("Expected persona char_limit 2000, got: %d", charLimit)
+	}
+
+	_, charLimit, err = svc.GetBlock(tenantID, "human", userID)
+	if err != nil {
+		t.Fatalf("GetBlock human failed: %v", err)
+	}
+	if charLimit != 2000 {
+		t.Errorf("Expected human char_limit 2000, got: %d", charLimit)
+	}
+
+	_, charLimit, err = svc.GetBlock(tenantID, "working_context", "")
+	if err != nil {
+		t.Fatalf("GetBlock working_context failed: %v", err)
+	}
+	if charLimit != 4000 {
+		t.Errorf("Expected working_context char_limit 4000, got: %d", charLimit)
+	}
+}
+
+// TestCoreMemoryService_CharLimit tests content length validation.
+func TestCoreMemoryService_CharLimit(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID := int64(100)
+
+	if err := svc.InitBlocks(tenantID, ""); err != nil {
+		t.Fatalf("InitBlocks failed: %v", err)
+	}
+
+	// persona limit is 2000
+	longContent := ""
+	for i := 0; i < 2001; i++ {
+		longContent += "a"
+	}
+
+	err = svc.SetBlock(tenantID, "persona", longContent, "")
+	if err == nil {
+		t.Error("Expected error when content exceeds limit, got nil")
+	}
+}
+
+// TestCoreMemoryService_DifferentUsersDifferentHuman tests that different users have different human blocks.
+func TestCoreMemoryService_DifferentUsersDifferentHuman(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	svc := NewCoreMemoryService(db)
+
+	tenantID := int64(100)
+	userID1 := "ou_123"
+	userID2 := "ou_456"
+
+	// Initialize for both users
+	if err := svc.InitBlocks(tenantID, userID1); err != nil {
+		t.Fatalf("InitBlocks user1 failed: %v", err)
+	}
+	if err := svc.InitBlocks(tenantID, userID2); err != nil {
+		t.Fatalf("InitBlocks user2 failed: %v", err)
+	}
+
+	// Set different human content
+	if err := svc.SetBlock(tenantID, "human", "Human for user1", userID1); err != nil {
+		t.Fatalf("SetBlock human user1 failed: %v", err)
+	}
+	if err := svc.SetBlock(tenantID, "human", "Human for user2", userID2); err != nil {
+		t.Fatalf("SetBlock human user2 failed: %v", err)
+	}
+
+	// Each user should have their own human block
+	content1, _, err := svc.GetBlock(tenantID, "human", userID1)
+	if err != nil {
+		t.Fatalf("GetBlock human user1 failed: %v", err)
+	}
+	content2, _, err := svc.GetBlock(tenantID, "human", userID2)
+	if err != nil {
+		t.Fatalf("GetBlock human user2 failed: %v", err)
+	}
+
+	if content1 == content2 {
+		t.Errorf("Different users should have different human blocks")
+	}
+	if content1 != "Human for user1" {
+		t.Errorf("Expected 'Human for user1', got: %q", content1)
+	}
+	if content2 != "Human for user2" {
+		t.Errorf("Expected 'Human for user2', got: %q", content2)
+	}
+}
+
+// TestCoreMemoryService_MigrationKeepsLongest tests that migration keeps the longest content.
+func TestCoreMemoryService_MigrationKeepsLongest(t *testing.T) {
+	dbPath := t.TempDir() + "/test.db"
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	conn := db.Conn()
+
+	// Create table manually (simulating old schema)
+	_, err = conn.Exec(`
+		CREATE TABLE IF NOT EXISTS core_memory_blocks (
+			tenant_id INTEGER NOT NULL,
+			block_name TEXT NOT NULL,
+			user_id TEXT NOT NULL DEFAULT '',
+			content TEXT DEFAULT '',
+			char_limit INTEGER DEFAULT 2000,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (tenant_id, block_name, user_id)
+		)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert legacy persona data in different tenants
+	_, err = conn.Exec(`
+		INSERT INTO core_memory_blocks (tenant_id, block_name, user_id, content, char_limit)
+		VALUES (1, 'persona', '', 'Short', 2000)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert persona1: %v", err)
+	}
+	_, err = conn.Exec(`
+		INSERT INTO core_memory_blocks (tenant_id, block_name, user_id, content, char_limit)
+		VALUES (2, 'persona', '', 'Much longer persona content', 2000)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert persona2: %v", err)
+	}
+
+	// Insert legacy human data for same user in different tenants
+	_, err = conn.Exec(`
+		INSERT INTO core_memory_blocks (tenant_id, block_name, user_id, content, char_limit)
+		VALUES (1, 'human', 'ou_123', 'Short human', 2000)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert human1: %v", err)
+	}
+	_, err = conn.Exec(`
+		INSERT INTO core_memory_blocks (tenant_id, block_name, user_id, content, char_limit)
+		VALUES (2, 'human', 'ou_123', 'Much longer human content here', 2000)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert human2: %v", err)
+	}
+
+	// Now create service and init (triggers migration)
+	svc := NewCoreMemoryService(db)
+	tenantID := int64(100)
+	userID := "ou_123"
+
+	if err := svc.InitBlocks(tenantID, userID); err != nil {
+		t.Fatalf("InitBlocks failed: %v", err)
+	}
+
+	// Check migration result - should keep longest
+	personaContent, _, err := svc.GetBlock(tenantID, "persona", "")
+	if err != nil {
+		t.Fatalf("GetBlock persona failed: %v", err)
+	}
+	if personaContent != "Much longer persona content" {
+		t.Errorf("Expected longest persona, got: %q", personaContent)
+	}
+
+	humanContent, _, err := svc.GetBlock(tenantID, "human", userID)
+	if err != nil {
+		t.Fatalf("GetBlock human failed: %v", err)
+	}
+	if humanContent != "Much longer human content here" {
+		t.Errorf("Expected longest human, got: %q", humanContent)
+	}
+
+	// Verify old data is cleaned up
+	var count int
+	err = conn.QueryRow(`
+		SELECT COUNT(*) FROM core_memory_blocks 
+		WHERE block_name IN ('persona', 'human') AND tenant_id != 0
+	`).Scan(&count)
+	if err != nil && err != sql.ErrNoRows {
+		t.Fatalf("Failed to check old data: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 legacy records, got: %d", count)
+	}
+}


### PR DESCRIPTION
- Add 8 regression tests covering:
  - Persona global (tenantID=0)
  - Human cross-tenant (tenantID=0 + userID)
  - Working context per-tenant isolation
  - Read/write consistency
  - Default char limits
  - Char limit validation
  - Different users have different human blocks
  - Migration keeps longest content
- Add design doc explaining isolation strategy