### PR TITLE
fix: 上下文压缩修复 - token计算、准确阈值、实时压缩

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -939,13 +939,13 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 	// 注意：手动 /compress 命令不受 enableAutoCompress 开关限制
 	// 用户可能不想自动压缩但偶尔需要手动压缩一下
 
-	// 获取当前消息数
-	messages, err := tenantSession.GetMessages()
+	// 使用 buildPrompt 获取完整上下文（包含 system、skills、memory 等）
+	messages, err := a.buildPrompt(ctx, msg, tenantSession)
 	if err != nil {
 		return &bus.OutboundMessage{
 			Channel: msg.Channel,
 			ChatID:  msg.ChatID,
-			Content: "获取会话消息失败，请重试。",
+			Content: "获取上下文失败，请重试。",
 		}, nil
 	}
 
@@ -957,7 +957,7 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 		}, nil
 	}
 
-	// 计算当前 token 数
+	// 计算当前 token 数（完整上下文）
 	tokenCount, err := llm.CountMessagesTokens(messages, a.model)
 	if err != nil {
 		log.WithError(err).Warn("Failed to count tokens for compression")
@@ -974,8 +974,9 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 		}, nil
 	}
 
-	// 执行压缩
-	compressed, err := a.compressContext(ctx, messages, a.model)
+	// 执行压缩（只压缩 session 历史，压缩后重新构建完整上下文）
+	sessionMsgs, _ := tenantSession.GetMessages()
+	compressed, err := a.compressContext(ctx, sessionMsgs, a.model)
 	if err != nil {
 		return &bus.OutboundMessage{
 			Channel: msg.Channel,
@@ -1019,6 +1020,78 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 		ChatID:  msg.ChatID,
 		Content: fmt.Sprintf("上下文压缩完成 (内存): %d → %d tokens (%d 条消息)", tokenCount, newTokenCount, len(compressed)),
 	}, nil
+}
+
+// handleContext 处理 /context 命令：显示当前 token 数和组成
+func (a *Agent) handleContext(ctx context.Context, msg bus.InboundMessage, tenantSession *session.TenantSession) (*bus.OutboundMessage, error) {
+	// 使用 buildPrompt 获取完整上下文（包含 system、skills、memory 等）
+	messages, err := a.buildPrompt(ctx, msg, tenantSession)
+	if err != nil {
+		return &bus.OutboundMessage{
+			Channel: msg.Channel,
+			ChatID:  msg.ChatID,
+			Content: "获取上下文失败，请重试。",
+		}, nil
+	}
+
+	// 按角色统计 token 数
+	var systemTokens, userTokens, assistantTokens, toolTokens int
+
+	for _, m := range messages {
+		tokens, err := llm.CountMessagesTokens([]llm.ChatMessage{m}, a.model)
+		if err != nil {
+			continue
+		}
+		switch m.Role {
+		case "system":
+			systemTokens += tokens
+		case "user":
+			userTokens += tokens
+		case "assistant":
+			assistantTokens += tokens
+		case "tool":
+			toolTokens += tokens
+		}
+	}
+
+	total := systemTokens + userTokens + assistantTokens + toolTokens
+	threshold := int(float64(a.maxContextTokens) * a.compressionThreshold)
+
+	content := fmt.Sprintf(`📊 上下文 Token 统计
+
+| 角色 | Token | 占比 |
+|------|-------|------|
+| System | %d | %.1f%% |
+| User | %d | %.1f%% |
+| Assistant | %d | %.1f%% |
+| Tool | %d | %.1f%% |
+| **总计** | **%d** | 100%% |
+
+⚙️ 配置:
+- 最大上下文: %d tokens
+- 压缩阈值: %d tokens (%.0f%%)`,
+		systemTokens, float64(systemTokens)*100/float64(max(total, 1)),
+		userTokens, float64(userTokens)*100/float64(max(total, 1)),
+		assistantTokens, float64(assistantTokens)*100/float64(max(total, 1)),
+		toolTokens, float64(toolTokens)*100/float64(max(total, 1)),
+		total,
+		a.maxContextTokens,
+		threshold,
+		a.compressionThreshold*100,
+	)
+
+	return &bus.OutboundMessage{
+		Channel: msg.Channel,
+		ChatID:  msg.ChatID,
+		Content: content,
+	}, nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // compressContext 使用 LLM 压缩对话历史

--- a/agent/command_builtin.go
+++ b/agent/command_builtin.go
@@ -60,6 +60,7 @@ func (c *helpCmd) Execute(_ context.Context, _ *Agent, msg bus.InboundMessage) (
 			"/set-llm — 设置自定义 LLM API\n" +
 			"/llm — 查看当前 LLM 配置\n" +
 			"/compress — 手动触发上下文压缩\n" +
+			"/context — 查看当前 token 数和组成\n" +
 			"!<command> — 快捷执行命令（跳过 LLM，直接在 sandbox 中运行）",
 	}, nil
 }
@@ -126,6 +127,22 @@ func (c *compressCmd) Execute(ctx context.Context, a *Agent, msg bus.InboundMess
 	return a.handleCompress(ctx, msg, tenantSession)
 }
 
+// --- /context ---
+
+type contextCmd struct{}
+
+func (c *contextCmd) Name() string        { return "/context" }
+func (c *contextCmd) Aliases() []string   { return nil }
+func (c *contextCmd) Match(s string) bool { return strings.ToLower(s) == "/context" }
+
+func (c *contextCmd) Execute(ctx context.Context, a *Agent, msg bus.InboundMessage) (*bus.OutboundMessage, error) {
+	tenantSession, err := a.multiSession.GetOrCreateSession(msg.Channel, msg.ChatID)
+	if err != nil {
+		return nil, err
+	}
+	return a.handleContext(ctx, msg, tenantSession)
+}
+
 // --- ! (bang command) ---
 
 type bangCmd struct{}
@@ -151,5 +168,6 @@ func registerBuiltinCommands(r *CommandRegistry) {
 	r.Register(&setLLMCmd{})
 	r.Register(&getLLMCmd{})
 	r.Register(&compressCmd{})
+	r.Register(&contextCmd{})
 	r.Register(&bangCmd{})
 }

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -84,8 +84,8 @@ func TestCommandRegistry_Commands(t *testing.T) {
 	registerBuiltinCommands(r)
 
 	cmds := r.Commands()
-	if len(cmds) != 8 {
-		t.Errorf("Commands() returned %d commands, want 8", len(cmds))
+	if len(cmds) != 9 {
+		t.Errorf("Commands() returned %d commands, want 9", len(cmds))
 	}
 
 	// Verify all expected commands are registered
@@ -93,7 +93,7 @@ func TestCommandRegistry_Commands(t *testing.T) {
 	for _, cmd := range cmds {
 		names[cmd.Name()] = true
 	}
-	expected := []string{"/new", "/version", "/help", "/prompt", "/set-llm", "/llm", "/compress", "!"}
+	expected := []string{"/new", "/version", "/help", "/prompt", "/set-llm", "/llm", "/compress", "/context", "!"}
 	for _, name := range expected {
 		if !names[name] {
 			t.Errorf("Command %q not found in registry", name)


### PR DESCRIPTION
## 修复内容

### Issue
- 修复 compress 指令 token 计算不准确问题
- 修复阈值 6400 太低问题（现代大模型都是 200k 级别）
- 修复只有对话结束才触发压缩问题

### 修改

1. **默认值改为 100k**
   - `MaxContextTokens` 默认值从 8000 改为 100000
   - 阈值比例保持 0.8（与 Claude 一致）

2. **Token 计算准确**
   - `/compress` 使用 `buildPrompt` 构建完整上下文再计算 token
   - 现在计算包含 system prompt、skills、agents 等所有内容

3. **实时压缩检测**
   - 对话开始前检测一次
   - 每次工具调用后也检测（不只是对话结束时）
   - 压缩同步执行并发送进度信息

### 测试
- [x] `go build ./...` 通过
- [x] `go test ./agent/...` 通过