### PR TITLE
fix: 压缩时保留完整的 tool_calls/tool_result 配对链

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1241,87 +1241,7 @@ func max(a, b int) int {
 // 2. 把压缩后的摘要作为 user prompt 直接调用 LLM
 // 3. 保留 system 消息和最近的对话轮次
 func (a *Agent) compressContext(ctx context.Context, messages []llm.ChatMessage, model string) ([]llm.ChatMessage, error) {
-	// 第一步：分离消息类型
-	var systemMsgs []llm.ChatMessage       // system 消息
-	var toolMsgs []llm.ChatMessage         // tool 消息（完整保留）
-	var conversationMsgs []llm.ChatMessage // user/assistant 消息（需要压缩的部分）
-	var recentMsgs []llm.ChatMessage       // 最近 2 轮对话（保留）
-
-	for i, msg := range messages {
-		switch msg.Role {
-		case "system":
-			systemMsgs = append(systemMsgs, msg)
-		case "tool":
-			toolMsgs = append(toolMsgs, msg)
-		case "user", "assistant":
-			// 保留最近 2 轮完整对话（user + assistant + tool 结果）
-			// 这样可以保持对话的连续性，LLM 能理解最近在讨论什么
-			if i >= len(messages)-6 { // 约最近 2-3 轮
-				recentMsgs = append(recentMsgs, msg)
-			} else {
-				conversationMsgs = append(conversationMsgs, msg)
-			}
-		}
-	}
-
-	// 如果没有需要压缩的内容，直接返回原消息
-	if len(conversationMsgs) == 0 {
-		return messages, nil
-	}
-
-	// 第二步：构建压缩 prompt（只压缩对话部分，tool 信息完整保留）
-	var historyText strings.Builder
-	for _, msg := range conversationMsgs {
-		role := strings.ToUpper(msg.Role)
-		// 按 rune 截断，避免中文乱码
-		content := msg.Content
-		if len([]rune(content)) > 800 {
-			content = string([]rune(content)[:800]) + "..."
-		}
-		fmt.Fprintf(&historyText, "[%s] %s\n\n", role, content)
-	}
-
-	// Claude 风格的压缩 prompt
-	compressionPrompt := `You are a context compression expert. Your task is to compress the conversation history into a concise summary while retaining ALL important information.
-
-## Compression Rules
-1. Retain ALL key facts, decisions, and important details
-2. Keep track of what the user has asked for and what has been done
-3. Preserve any file paths, code snippets, or technical details
-4. Maintain the logical flow and context of the conversation
-5. Note any errors or issues that were encountered
-
-## Important
-- This is NOT a summary - it's a compressed version that preserves context
-- Include specific details like file names, function names, variable names
-- Note what tools were used and their results if relevant
-
-## Conversation History (to compress)
-` + historyText.String() + `
-
-Output the compressed content directly, preserving as much context as possible.`
-
-	// 第三步：调用 LLM 压缩
-	resp, err := a.llmClient.Generate(ctx, model, []llm.ChatMessage{
-		llm.NewSystemMessage("You are a context compression expert."),
-		llm.NewUserMessage(compressionPrompt),
-	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("LLM compress failed: %w", err)
-	}
-
-	compressed := llm.StripThinkBlocks(resp.Content)
-
-	// 第四步：构建压缩后的消息结构
-	// 结构：[system, user(压缩摘要), tool(完整历史), recent(最近对话)]
-	var result []llm.ChatMessage
-
-	// 保留 system 消息
-	if len(systemMsgs) > 0 {
-		result = append(result, systemMsgs...)
-	}
-
-	// 保留尾部的完整 tool_calls/tool_result 链
+	// 第一步：找到尾部安全切割点
 	// API 要求：assistant 的 tool_calls 必须紧跟对应的 tool result 消息
 	// 从后往前扫描，找到最后一个"安全切割点"：
 	//   - user 消息是安全切割点
@@ -1346,7 +1266,88 @@ Output the compressed content directly, preserving as much context as possible.`
 		}
 	}
 
-	// 保留从 tailStart 到末尾的所有消息
+	// 第二步：分离消息
+	// system 消息单独保留，tailStart 之前的非 system 消息需要压缩
+	var systemMsgs []llm.ChatMessage
+	var toCompress []llm.ChatMessage
+
+	for i, msg := range messages {
+		if i >= tailStart {
+			break // 尾部消息原样保留，不参与分类
+		}
+		if msg.Role == "system" {
+			systemMsgs = append(systemMsgs, msg)
+		} else {
+			toCompress = append(toCompress, msg)
+		}
+	}
+
+	// 如果没有需要压缩的内容，直接返回原消息
+	if len(toCompress) == 0 {
+		return messages, nil
+	}
+
+	// 第三步：构建压缩 prompt
+	var historyText strings.Builder
+	for _, msg := range toCompress {
+		role := strings.ToUpper(msg.Role)
+		content := msg.Content
+		// 对 tool_calls 也记录函数名，帮助 LLM 理解上下文
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			var toolNames []string
+			for _, tc := range msg.ToolCalls {
+				toolNames = append(toolNames, tc.Name)
+			}
+			content += fmt.Sprintf(" [called tools: %s]", strings.Join(toolNames, ", "))
+		}
+		// 按 rune 截断，避免中文乱码
+		if len([]rune(content)) > 800 {
+			content = string([]rune(content)[:800]) + "..."
+		}
+		fmt.Fprintf(&historyText, "[%s] %s\n\n", role, content)
+	}
+
+	compressionPrompt := `You are a context compression expert. Your task is to compress the conversation history into a concise summary while retaining ALL important information.
+
+## Compression Rules
+1. Retain ALL key facts, decisions, and important details
+2. Keep track of what the user has asked for and what has been done
+3. Preserve any file paths, code snippets, or technical details
+4. Maintain the logical flow and context of the conversation
+5. Note any errors or issues that were encountered
+
+## Important
+- This is NOT a summary - it's a compressed version that preserves context
+- Include specific details like file names, function names, variable names
+- Note what tools were used and their results if relevant
+
+## Conversation History (to compress)
+` + historyText.String() + `
+
+Output the compressed content directly, preserving as much context as possible.`
+
+	// 第四步：调用 LLM 压缩
+	resp, err := a.llmClient.Generate(ctx, model, []llm.ChatMessage{
+		llm.NewSystemMessage("You are a context compression expert."),
+		llm.NewUserMessage(compressionPrompt),
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("LLM compress failed: %w", err)
+	}
+
+	compressed := llm.StripThinkBlocks(resp.Content)
+
+	// 第五步：构建压缩后的消息结构
+	// 结构：[system, user(压缩摘要), 尾部原始消息(tool_calls/tool_result 配对完整)]
+	var result []llm.ChatMessage
+
+	// 保留 system 消息
+	result = append(result, systemMsgs...)
+
+	// 将压缩摘要作为 user 消息插入
+	result = append(result, llm.NewUserMessage("[Previous conversation context]\n\n"+compressed))
+
+	// 保留从 tailStart 到末尾的所有原始消息（tool_calls/tool_result 配对完整）
 	if tailStart < len(messages) {
 		result = append(result, messages[tailStart:]...)
 	}


### PR DESCRIPTION
## 问题

`compressContext` 压缩后只保留 system message + 最后一条 user/assistant 消息，会破坏 tool_calls/tool_result 的配对关系：

1. **assistant(tool_calls) 保留但 tool result 丢弃** → LLM API 报错（要求 tool_calls 必须紧跟对应的 tool result）
2. **尾部 tool 链被截断** → 正在进行的工具调用上下文丢失

### 典型场景

压缩前：
```
[system] ...
[user] 帮我查一下...
[assistant tool_calls] search_tools(...)
[tool] result...
[assistant tool_calls] Shell(...)   ← 之前只保留这条
[tool] result...                    ← 被丢弃！API 报错
[assistant] 结果是...
```

## 修复

从后往前扫描找到**安全切割点**：
- `user` 消息 → 安全
- 不带 `tool_calls` 的 `assistant` 消息 → 安全
- `tool` result 或 `assistant(tool_calls)` → 继续往前找，确保配对完整

保留从切割点到末尾的所有消息，确保 tool_calls 和 tool result 始终成对出现。

边界处理：如果整个对话（除 system 外）都是 tool 链，全部保留。