### PR TITLE
feat(qq): send messages in markdown format

### DIFF
--- a/channel/qq.go
+++ b/channel/qq.go
@@ -1779,7 +1779,7 @@ func (q *QQChannel) isMarkdownUnsupported(err error) bool {
 		strings.Contains(errMsg, "msg_type") ||
 		strings.Contains(errMsg, "304003") || // 无权限
 		strings.Contains(errMsg, "304004") || // 消息类型不支持
-		strings.Contains(errMsg, "50006")     // 不支持的消息类型
+		strings.Contains(errMsg, "50006") // 不支持的消息类型
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 改动

QQ 渠道发送消息从纯文本 (`msg_type: 0`) 改为 markdown 格式 (`msg_type: 2`)。

### 变更点

- **sendC2CMessage / sendGroupMessage**: `msg_type` 从 `0` → `2`，增加 `markdown` 对象
- **自动降级**: 如果 markdown 发送失败（未开通权限），自动 fallback 到纯文本，并通过 `markdownDisabled` atomic flag 记住状态，后续消息直接用纯文本
- **Guild 消息不变**: 频道消息本身 content 字段就支持 markdown 渲染

### 新增方法

| 方法 | 说明 |
|------|------|
| `buildMarkdownBody()` | 构建 msg_type=2 的 markdown 消息体 |
| `buildTextBody()` | 构建 msg_type=0 的纯文本消息体 |
| `isMarkdownUnsupported()` | 判断 API 错误是否为 markdown 不支持 |

### QQ Markdown 支持格式

标题、加粗、斜体、删除线、链接、图片、有序/无序列表、块引用、分割线等标准 markdown 语法。

> 参考: https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/type/markdown.html
> 
> ⚠️ 沙箱环境可直接使用自定义 Markdown；其他环境需内邀开通。