### PR TITLE
fix: set-llm incorrectly reports 'Request cancelled by user'

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -712,7 +712,9 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 			}
 		}()
 
-		// defer 确保 cancelCh 清理：即使 processMessage panic 也不会泄漏
+		// 执行消息处理，完成后检查是否被取消
+		// 注意：必须在 reqCancel() 调用前检查，否则 reqCtx.Err() 总是返回 Canceled
+		wasCancelled := reqCtx.Err() == context.Canceled
 		func() {
 			defer func() {
 				reqCancel()
@@ -720,9 +722,13 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 				<-sem // 释放槽位
 			}()
 			response, err = a.processMessage(reqCtx, msg)
+			// 在 defer 执行前检查是否被取消（processMessage 过程中用户可能 /cancel）
+			if reqCtx.Err() == context.Canceled {
+				wasCancelled = true
+			}
 		}()
 
-		if reqCtx.Err() == context.Canceled && ctx.Err() == nil {
+		if wasCancelled && ctx.Err() == nil {
 			// 请求被用户 /cancel 取消（而非全局 ctx 关闭）
 			log.WithFields(log.Fields{"request_id": msg.RequestID, "chat": chatKey}).Info("Request cancelled by user")
 			continue


### PR DESCRIPTION
## Problem

当用户执行 `/set-llm` 不带参数（期望查看帮助信息）或其他非取消操作时，系统错误地输出 "Request cancelled by user"。

## Root Cause

`chatProcessLoop` 中的 bug：

```go
// 错误代码：
func() {
    defer func() {
        reqCancel()  // 先执行了 cancel
        a.chatCancelCh.Delete(cancelKey)
        <-sem
    }()
    response, err = a.processMessage(reqCtx, msg)
}()

// defer 执行后 reqCtx.Err() 总是返回 Canceled
wasCancelled := reqCtx.Err() == context.Canceled
```

`reqCancel()` 在 `wasCancelled` 检查之前执行，导致 `reqCtx.Err()` 总是返回 `context.Canceled`。

## Fix

在 defer 执行前先检查 cancel 状态，用变量记录：

```go
wasCancelled := reqCtx.Err() == context.Canceled
func() {
    defer func() {
        reqCancel()
        a.chatCancelCh.Delete(cancelKey)
        <-sem
    }()
    response, err = a.processMessage(reqCtx, msg)
    // 处理过程中也可能被取消
    if reqCtx.Err() == context.Canceled {
        wasCancelled = true
    }
}()

if wasCancelled && ctx.Err() == nil {
    // 只有真正被用户 /cancel 取消时才打印日志
    log.Info("Request cancelled by user")
}
```

## Testing

- `/set-llm` 不带参数 → 正确输出帮助信息
- `/set-llm provider=...` → 正确设置 LLM 配置
- `/cancel` → 正确取消当前请求