### PR TITLE
feat: LLM 重试时通知用户

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1607,6 +1608,35 @@ func (a *Agent) maybeConsolidate(ctx context.Context, tenantSession *session.Ten
 	}()
 }
 
+// summarizeRetryError 将 LLM 错误简化为用户友好的描述。
+func summarizeRetryError(err error) string {
+	if err == nil {
+		return "未知错误"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "TLS handshake timeout"):
+		return "网络超时"
+	case strings.Contains(msg, "connection refused"):
+		return "连接被拒绝"
+	case strings.Contains(msg, "429") || strings.Contains(msg, "rate limit"):
+		return "请求限流"
+	case strings.Contains(msg, "502") || strings.Contains(msg, "503"):
+		return "服务暂时不可用"
+	case strings.Contains(msg, "500") || strings.Contains(msg, "504"):
+		return "服务端错误"
+	default:
+		var netErr net.Error
+		if errors.As(err, &netErr) {
+			if netErr.Timeout() {
+				return "网络超时"
+			}
+			return "网络错误"
+		}
+		return "临时错误"
+	}
+}
+
 // runLoop 执行 Agent 迭代循环（LLM -> 工具调用 -> LLM ...）
 // autoNotify 为 true 时，累积显示模型中间内容和工具调用状态，实时更新同一条消息
 // tenantSession 用于自动压缩后持久化压缩结果（可传 nil）
@@ -1739,6 +1769,17 @@ func (a *Agent) runLoop(ctx context.Context, messages []llm.ChatMessage, channel
 		}
 	}
 
+	// 注入 LLM 重试通知回调：重试时实时更新用户可见的进度消息
+	retryCtx := llm.WithRetryNotify(ctx, func(attempt, max uint, err error) {
+		if !autoNotify {
+			return
+		}
+		reason := summarizeRetryError(err)
+		progressLines = append(progressLines,
+			fmt.Sprintf("> ⚠️ LLM 请求失败 (%s)，重试中 %d/%d ...", reason, attempt, max))
+		notifyProgress("")
+	})
+
 	for i := 0; i < a.maxIterations; i++ {
 		// 每次 LLM 调用前检测是否需要压缩
 		maybeCompress()
@@ -1759,7 +1800,7 @@ func (a *Agent) runLoop(ctx context.Context, messages []llm.ChatMessage, channel
 		if systemCount != 1 {
 			panic("assert: LLM messages must have exactly one system message; got " + fmt.Sprint(systemCount))
 		}
-		response, err := llmClient.Generate(ctx, model, messages, toolDefs)
+		response, err := llmClient.Generate(retryCtx, model, messages, toolDefs)
 		if err != nil && llm.IsInputTooLongError(err) && len(messages) > 3 {
 			log.Ctx(ctx).WithError(err).Warn("Input too long for LLM, forcing context compression and retrying")
 			if autoNotify {
@@ -1790,7 +1831,7 @@ func (a *Agent) runLoop(ctx context.Context, messages []llm.ChatMessage, channel
 					}
 				}
 			}
-			response, err = llmClient.Generate(ctx, model, messages, toolDefs)
+			response, err = llmClient.Generate(retryCtx, model, messages, toolDefs)
 		}
 		if err != nil {
 			return "", toolsUsed, false, fmt.Errorf("%w: %w", ErrLLMGenerate, err)

--- a/agent/retry_notify_test.go
+++ b/agent/retry_notify_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestSummarizeRetryError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, "未知错误"},
+		{"TLS handshake timeout", errors.New("TLS handshake timeout"), "网络超时"},
+		{"connection refused", errors.New("dial tcp: connection refused"), "连接被拒绝"},
+		{"429", errors.New(`POST "url": 429 Too Many Requests`), "请求限流"},
+		{"rate limit", errors.New("rate limit exceeded"), "请求限流"},
+		{"502", errors.New(`POST "url": 502 Bad Gateway`), "服务暂时不可用"},
+		{"503", errors.New("CodeBuddy API error: status=503"), "服务暂时不可用"},
+		{"500", errors.New(`POST "url": 500 Internal Server Error`), "服务端错误"},
+		{"504", errors.New(`POST "url": 504 Gateway Timeout`), "服务端错误"},
+		{"net.OpError timeout", &net.OpError{Op: "dial", Net: "tcp", Err: &timeoutErr{}}, "网络超时"},
+		{"net.OpError non-timeout", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}, "网络错误"},
+		{"generic error", errors.New("something went wrong"), "临时错误"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeRetryError(tt.err)
+			if got != tt.want {
+				t.Errorf("summarizeRetryError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// timeoutErr 实现 net.Error 接口，Timeout() 返回 true
+type timeoutErr struct{}
+
+func (e *timeoutErr) Error() string   { return "i/o timeout" }
+func (e *timeoutErr) Timeout() bool   { return true }
+func (e *timeoutErr) Temporary() bool { return true }

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -12,6 +12,24 @@ import (
 	logrus "xbot/logger"
 )
 
+// RetryNotifyFunc 重试通知回调。
+// attempt: 当前重试次数（从 1 开始），maxAttempts: 最大尝试次数，err: 触发重试的错误。
+type RetryNotifyFunc func(attempt, maxAttempts uint, err error)
+
+type retryNotifyKey struct{}
+
+// WithRetryNotify 将重试通知回调注入 context。
+// RetryLLM 在每次重试时会调用该回调，调用方可借此向用户推送进度。
+func WithRetryNotify(ctx context.Context, fn RetryNotifyFunc) context.Context {
+	return context.WithValue(ctx, retryNotifyKey{}, fn)
+}
+
+// getRetryNotify 从 context 获取通知回调（可能为 nil）。
+func getRetryNotify(ctx context.Context) RetryNotifyFunc {
+	fn, _ := ctx.Value(retryNotifyKey{}).(RetryNotifyFunc)
+	return fn
+}
+
 // RetryConfig 重试配置
 type RetryConfig struct {
 	Attempts uint          // 最大尝试次数（含首次），默认 3
@@ -114,6 +132,11 @@ func (r *RetryLLM) retryOptions(ctx context.Context, label string) []retry.Optio
 				"max":     r.config.Attempts,
 				"error":   err.Error(),
 			}).Warn("[LLM] " + label)
+
+			// 通知调用方（如 agent runLoop）以便向用户推送进度
+			if notify := getRetryNotify(ctx); notify != nil {
+				notify(n+1, r.config.Attempts, err)
+			}
 		}),
 	}
 }

--- a/llm/retry_test.go
+++ b/llm/retry_test.go
@@ -333,3 +333,85 @@ func (n *nonStreamingLLM) Generate(ctx context.Context, model string, messages [
 func (n *nonStreamingLLM) ListModels() []string {
 	return []string{"non-streaming"}
 }
+
+// ---------------------------------------------------------------------------
+// WithRetryNotify 回调测试
+// ---------------------------------------------------------------------------
+
+func TestRetryLLM_Generate_NotifiesOnRetry(t *testing.T) {
+	// 前 2 次返回 502，第 3 次成功
+	retryableErr := errors.New(`POST "url": 502 Bad Gateway`)
+	inner := newFailNLLM(2, retryableErr)
+	cfg := RetryConfig{Attempts: 3, Delay: 10 * time.Millisecond, MaxDelay: 50 * time.Millisecond}
+	r := NewRetryLLM(inner, cfg)
+
+	var notifications []struct {
+		attempt, max uint
+		err          error
+	}
+	ctx := WithRetryNotify(context.Background(), func(attempt, max uint, err error) {
+		notifications = append(notifications, struct {
+			attempt, max uint
+			err          error
+		}{attempt, max, err})
+	})
+
+	resp, err := r.Generate(ctx, "test", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Errorf("content = %q, want %q", resp.Content, "ok")
+	}
+
+	// 应该收到 2 次通知（第 1 次和第 2 次失败后各一次）
+	if len(notifications) != 2 {
+		t.Fatalf("notifications count = %d, want 2", len(notifications))
+	}
+	if notifications[0].attempt != 1 || notifications[0].max != 3 {
+		t.Errorf("notification[0]: attempt=%d, max=%d, want 1, 3", notifications[0].attempt, notifications[0].max)
+	}
+	if notifications[1].attempt != 2 || notifications[1].max != 3 {
+		t.Errorf("notification[1]: attempt=%d, max=%d, want 2, 3", notifications[1].attempt, notifications[1].max)
+	}
+}
+
+func TestRetryLLM_Generate_NoNotifyWithoutCallback(t *testing.T) {
+	// 没有注入回调时不应 panic
+	retryableErr := errors.New(`POST "url": 502 Bad Gateway`)
+	inner := newFailNLLM(1, retryableErr)
+	cfg := RetryConfig{Attempts: 3, Delay: 10 * time.Millisecond, MaxDelay: 50 * time.Millisecond}
+	r := NewRetryLLM(inner, cfg)
+
+	resp, err := r.Generate(context.Background(), "test", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Errorf("content = %q, want %q", resp.Content, "ok")
+	}
+}
+
+func TestRetryLLM_GenerateStream_NotifiesOnRetry(t *testing.T) {
+	retryableErr := errors.New(`POST "url": 503 Service Unavailable`)
+	inner := newFailNLLM(1, retryableErr)
+	cfg := RetryConfig{Attempts: 3, Delay: 10 * time.Millisecond, MaxDelay: 50 * time.Millisecond}
+	r := NewRetryLLM(inner, cfg)
+
+	var notified atomic.Int32
+	ctx := WithRetryNotify(context.Background(), func(attempt, max uint, err error) {
+		notified.Add(1)
+	})
+
+	ch, err := r.GenerateStream(ctx, "test", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// drain channel
+	for range ch {
+	}
+
+	if notified.Load() != 1 {
+		t.Errorf("notified = %d, want 1", notified.Load())
+	}
+}


### PR DESCRIPTION
## 问题

`RetryLLM` 重试时只写日志，用户完全不知道发生了什么。实际案例中用户等了 30s+ 没有任何反馈。

## 方案

**方案 A：通过 `context.Context` 传递重试通知回调**

`RetryLLM` 是全局单例（所有会话共享），但 context 是每次调用独立的，天然支持多会话并发通知到各自的聊天窗口。

## 改动

### `llm/retry.go`
- 新增 `RetryNotifyFunc` 回调类型
- `WithRetryNotify(ctx, fn)` / `getRetryNotify(ctx)` context helpers
- `OnRetry` 中调用回调（如果存在）

### `agent/agent.go`
- `runLoop` 在循环前注入回调，重试时实时更新进度消息
- `summarizeRetryError()` 将原始错误映射为用户友好描述：
  - TLS handshake timeout → 网络超时
  - connection refused → 连接被拒绝
  - 429 / rate limit → 请求限流
  - 502/503 → 服务暂时不可用
  - 500/504 → 服务端错误
  - net.Error → 网络超时/网络错误
  - 其他 → 临时错误

### 用户看到的效果
```
> ⏳ Shell ...
> ✅ Shell (0.3s)
> 💭 思考中...
> ⚠️ LLM 请求失败 (网络超时)，重试中 1/3 ...
```

## 测试
- `llm/`: 3 new tests（回调触发、无回调安全、stream 回调）
- `agent/`: 1 new test（summarizeRetryError 12 cases）

+192/-2, 4 files