### PR TITLE
fix: remove hardcoded .claude/skills path

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -65,31 +65,15 @@ func resolveDataPath(workDir, filename string) string {
 	return newPath
 }
 
-func resolveGlobalSkillsDirs(workDir, legacySkillsDir string) []string {
-	dirs := []string{
-		filepath.Join(workDir, ".claude", "skills"),
+func resolveGlobalSkillsDirs(legacySkillsDir string) []string {
+	if legacySkillsDir == "" {
+		return nil
 	}
-	if legacySkillsDir != "" {
-		dirs = append(dirs, legacySkillsDir)
+	abs, err := filepath.Abs(legacySkillsDir)
+	if err != nil {
+		return nil
 	}
-
-	seen := make(map[string]struct{})
-	result := make([]string, 0, len(dirs))
-	for _, dir := range dirs {
-		if dir == "" {
-			continue
-		}
-		abs, err := filepath.Abs(dir)
-		if err != nil {
-			continue
-		}
-		if _, ok := seen[abs]; ok {
-			continue
-		}
-		seen[abs] = struct{}{}
-		result = append(result, abs)
-	}
-	return result
+	return []string{abs}
 }
 
 // indexGlobalMCPTools indexes global MCP tools and built-in tool groups for search
@@ -314,7 +298,7 @@ func New(cfg Config) *Agent {
 		cfg.CompressionThreshold = 0.8
 	}
 
-	globalSkillDirs := resolveGlobalSkillsDirs(cfg.WorkDir, cfg.SkillsDir)
+	globalSkillDirs := resolveGlobalSkillsDirs(cfg.SkillsDir)
 	skillStore := NewSkillStore(cfg.WorkDir, globalSkillDirs)
 
 	// 加载 agent 角色定义（从 .xbot/agents/ 目录）


### PR DESCRIPTION
## What

Remove the hardcoded `.claude/skills/` global skill directory from `resolveGlobalSkillsDirs`.

## Why

This path was introduced in PR #43 referencing Claude Code's directory convention, but:
- `/work/.claude/skills/` has never been created or used
- xbot has its own skill directory at `.xbot/skills/`
- The dedup logic around it was unnecessary complexity

## Changes

- Simplified `resolveGlobalSkillsDirs` to only use the legacy skills dir (`.xbot/skills/`)
- Removed `workDir` parameter since it's no longer needed
- Removed the dedup map logic (single dir doesn't need dedup)
