### PR TITLE
fix: Registry.Clone() must also copy coreTools

### DIFF
--- a/tools/interface.go
+++ b/tools/interface.go
@@ -337,6 +337,9 @@ func (r *Registry) Clone() *Registry {
 	for name, tool := range r.globalTools {
 		clone.globalTools[name] = tool
 	}
+	for name := range r.coreTools {
+		clone.coreTools[name] = true
+	}
 	return clone
 }
 
@@ -539,7 +542,7 @@ func (r *Registry) GetToolSchemasForChannel(sessionKey string, toolNames []strin
 						ServerName:  p.mcpServerName(),
 						Description: p.fullDescription(),
 						Params:      p.fullParams(),
-					})
+				})
 				}
 			}
 		}


### PR DESCRIPTION
## 问题

`Registry.Clone()` 只复制了 `globalTools`（工具实例），**没有复制 `coreTools`（核心工具标记）**。

## 影响

SubAgent 通过 `buildSubAgentRunConfig` → `a.tools.Clone()` 获取工具注册表后，`AsDefinitionsForSession` 的判断逻辑 `coreTools[name] || active[name]` 全部为 false（coreTools 空 + SubAgent 无 session 激活），导致 **SubAgent 的 LLM 收到 0 个工具定义**，只能输出纯文本无法调用任何工具。

这就是太子（crown-prince）"嘴上说分发到中书省，实际没调 SubAgent" 的根因。

## 修复

`Clone()` 增加 3 行，将 `coreTools` map 也复制过去。

```go
for name := range r.coreTools {
    clone.coreTools[name] = true
}
```