### PR TITLE
fix: Registry.Clone() missing coreTools copy causes SubAgent zero tools

### DIFF
--- a/tools/interface.go
+++ b/tools/interface.go
@@ -337,6 +337,9 @@ func (r *Registry) Clone() *Registry {
 	for name, tool := range r.globalTools {
 		clone.globalTools[name] = tool
 	}
+	for name := range r.coreTools {
+		clone.coreTools[name] = true
+	}
 	return clone
 }
 


### PR DESCRIPTION
## Problem

`Registry.Clone()` only copied `globalTools` but not `coreTools`. When SubAgent was created via `buildSubAgentRunConfig` → `a.tools.Clone()`, the cloned registry had an empty `coreTools` map.

`AsDefinitionsForSession` includes a tool only when `coreTools[name] || active[name]`. With empty `coreTools` and no session activation in SubAgent, **LLM received 0 tool definitions** → SubAgent could only output plain text, never call any tool.

This is why "太子" (crown-prince) would say "dispatched to 中书省" but never actually spawn a SubAgent.

## Fix

Add 3 lines to `Clone()` to also copy `coreTools`.