### PR TITLE
feat: single-user mode — normalize SenderID at bus entry point

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -194,6 +194,7 @@ type Agent struct {
 	pipeline        *MessagePipeline // 消息构建管道（持有实例，支持运行时动态增删中间件）
 	cronPipeline    *MessagePipeline // Cron 专用消息构建管道
 	sandboxMode     string           // "none" or "docker"
+	singleUser      bool             // 单用户模式
 	maxConcurrency  int              // 最大并发会话处理数
 	globalSkillDirs []string         // 全局 skill 目录（宿主机路径）
 	agentsDir       string           // 全局 agents 目录（宿主机路径）
@@ -257,6 +258,7 @@ type Config struct {
 	SkillsDir      string // Skills 目录
 	WorkDir        string // 工作目录（所有文件相对此目录）
 	PromptFile     string // 系统提示词模板文件路径（空则使用内置默认值）
+	SingleUser     bool   // 单用户模式：所有消息的 SenderID 归一化为 "default"
 
 	MemoryProvider     string // 记忆提供者: "flat" 或 "letta"
 	EmbeddingProvider  string // 嵌入提供者: "openai"(默认) 或 "ollama"
@@ -404,6 +406,7 @@ func New(cfg Config) *Agent {
 		workDir:              cfg.WorkDir,
 		promptLoader:         NewPromptLoader(cfg.PromptFile),
 		sandboxMode:          sandboxMode,
+		singleUser:           cfg.SingleUser,
 		globalSkillDirs:      globalSkillDirs,
 		maxContextTokens:     cfg.MaxContextTokens,
 		compressionThreshold: cfg.CompressionThreshold,
@@ -501,7 +504,10 @@ func (a *Agent) sendAck(channel, chatID string) {
 // 全局并发数由 AGENT_MAX_CONCURRENCY 控制（默认 3），避免 LLM 并发过高。
 // 用户设置了自己的 LLM 配置后，该用户的请求使用独立的信号量，不再占用全局资源。
 func (a *Agent) Run(ctx context.Context) error {
-	log.WithField("max_concurrency", a.maxConcurrency).Info("Agent loop started")
+	log.WithFields(log.Fields{
+		"max_concurrency": a.maxConcurrency,
+		"single_user":     a.singleUser,
+	}).Info("Agent loop started")
 
 	a.multiSession.StartCleanupRoutine()
 	a.cronSch.SetInjectFunc(a.injectInbound)
@@ -552,6 +558,9 @@ func (a *Agent) Run(ctx context.Context) error {
 			log.Info("Agent loop stopped")
 			return ctx.Err()
 		case msg := <-a.bus.Inbound:
+			// 单用户模式：在 bus 入口统一归一化 SenderID
+			msg.SenderID = a.normalizeSenderID(msg.SenderID)
+
 			// /cancel 拦截：不进入 chatWorker 队列，直接发 cancel 信号
 			if strings.TrimSpace(strings.ToLower(msg.Content)) == "/cancel" {
 				cancelKey := msg.Channel + ":" + msg.ChatID + ":" + msg.SenderID
@@ -585,6 +594,15 @@ func (a *Agent) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// normalizeSenderID returns the effective sender ID for the message.
+// In single-user mode, all sender IDs are mapped to "default".
+func (a *Agent) normalizeSenderID(senderID string) string {
+	if a.singleUser {
+		return "default"
+	}
+	return senderID
 }
 
 // isGroupChat 判断是否为群聊
@@ -1786,7 +1804,7 @@ func (a *Agent) addReaction(msg bus.InboundMessage) {
 func (a *Agent) ProcessDirect(ctx context.Context, content string) (string, error) {
 	msg := bus.InboundMessage{
 		Channel:   "cli",
-		SenderID:  "user",
+		SenderID:  a.normalizeSenderID("user"),
 		ChatID:    "direct",
 		Content:   content,
 		Time:      time.Now(),

--- a/agent/single_user_test.go
+++ b/agent/single_user_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import "testing"
+
+func TestNormalizeSenderID_SingleUser(t *testing.T) {
+	a := &Agent{singleUser: true}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ou_abc123", "default"},
+		{"user", "default"},
+		{"", "default"},
+		{"default", "default"},
+	}
+
+	for _, tt := range tests {
+		got := a.normalizeSenderID(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeSenderID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeSenderID_MultiUser(t *testing.T) {
+	a := &Agent{singleUser: false}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ou_abc123", "ou_abc123"},
+		{"user", "user"},
+		{"", ""},
+		{"default", "default"},
+	}
+
+	for _, tt := range tests {
+		got := a.normalizeSenderID(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeSenderID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ type AgentConfig struct {
 	MemoryProvider string // 记忆提供者: "flat" 或 "letta"（默认 "flat"）
 	WorkDir        string // 工作目录（所有文件相对此目录存放）
 	PromptFile     string // 系统提示词模板文件路径（空则使用内置默认值）
+	SingleUser     bool   // 单用户模式：所有消息的 SenderID 归一化为 "default"
 
 	// MCP 会话管理配置
 	MCPInactivityTimeout time.Duration // MCP 不活跃超时时间（默认 30 分钟）
@@ -192,6 +193,7 @@ func Load() *Config {
 			MemoryProvider:       getEnvOrDefault("MEMORY_PROVIDER", "flat"),
 			WorkDir:              getEnvOrDefault("WORK_DIR", "."),
 			PromptFile:           getEnvOrDefault("PROMPT_FILE", "prompt.md"),
+			SingleUser:           getEnvBoolOrDefault("SINGLE_USER", false),
 			MCPInactivityTimeout: getEnvDurationOrDefault("MCP_INACTIVITY_TIMEOUT", 30*time.Minute),
 			MCPCleanupInterval:   getEnvDurationOrDefault("MCP_CLEANUP_INTERVAL", 5*time.Minute),
 			SessionCacheTimeout:  getEnvDurationOrDefault("SESSION_CACHE_TIMEOUT", 24*time.Hour),

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func main() {
 		SkillsDir:            filepath.Join(xbotDir, "skills"),
 		WorkDir:              workDir,
 		PromptFile:           cfg.Agent.PromptFile,
+		SingleUser:           cfg.Agent.SingleUser,
 		MemoryProvider:       cfg.Agent.MemoryProvider,
 		EmbeddingProvider:    cfg.Embedding.Provider,
 		EmbeddingBaseURL:     embBaseURL,


### PR DESCRIPTION
## 概述

单用户模式：在 bus 入口统一将所有 `SenderID` 归一化为 `"default"`，下游零改动。

## 设计

- `SINGLE_USER=true` 环境变量启用
- 在 `Run()` 的 inbound channel 取出消息后、分发前，统一拦截 `normalizeSenderID`
- 单用户模式下所有用户共享同一个 workspace / session / MCP config（路径中使用 `default`）
- `ProcessDirect()` (CLI) 同样拦截

## 改动

| 文件 | 改动 |
|------|------|
| `config/config.go` | `AgentConfig.SingleUser` + `SINGLE_USER` 环境变量 |
| `agent/agent.go` | `singleUser` 字段 + `normalizeSenderID()` + `Run()` / `ProcessDirect()` 入口拦截 |
| `main.go` | 传递 `SingleUser` 到 agent.Config |
| `agent/single_user_test.go` | 单元测试 |

## 与 PR #150 的区别

PR #150 在多个下游路径分别处理（processMessage、processCronMessage、chatProcessLoop 等），需要特殊处理 skill catalog。本方案 **只在一个点拦截**，下游自然走 `default` 用户路径。

Closes #149