### PR TITLE
feat: add cd command detection and tips in ShellTool

### DIFF
--- a/tools/shell.go
+++ b/tools/shell.go
@@ -170,7 +170,6 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	}
 
 	if result == "" {
-
 		if envPersisted {
 			return NewResult("Command executed successfully. Environment variables persisted to ~/.xbot_env"), nil
 		}
@@ -181,7 +180,11 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 		result += "\n[Environment variables persisted to ~/.xbot_env]"
 	}
 
-	return NewResult(result), nil
+	res := NewResult(result)
+	if tip := detectCdTip(params.Command); tip != "" {
+		res = res.WithTips(tip)
+	}
+	return res, nil
 }
 
 // persistEnvFromCommand 从命令中提取 export 语句并持久化到 ~/.xbot_env
@@ -247,6 +250,18 @@ func (t *ShellTool) persistEnvFromCommand(toolCtx *ToolContext, command string) 
 	RunInSandboxWithShell(toolCtx, ensureBashrcCmd)
 
 	return true
+}
+
+// cdPattern detects standalone cd commands (not inside subshells, comments, or strings).
+// Matches: "cd foo", "cd /path", "cd ..", "cd ~", as well as "cd foo && ls" etc.
+var cdPattern = regexp.MustCompile(`(?:^|&&|\|\||;)\s*cd\s+`)
+
+// detectCdTip returns a tip string if the command contains a cd that won't persist.
+func detectCdTip(command string) string {
+	if !cdPattern.MatchString(command) {
+		return ""
+	}
+	return `NOTE: "cd" inside Shell only affects this single command — the working directory resets on the next tool call. Use the Cd tool to persistently change directory.`
 }
 
 // dangerPatterns 定义绝对禁止执行的命令模式（黑名单拦截，直接拒绝）

--- a/tools/shell_test.go
+++ b/tools/shell_test.go
@@ -190,6 +190,40 @@ func TestEnvMergeDeduplication(t *testing.T) {
 	}
 }
 
+func TestDetectCdTip(t *testing.T) {
+	tests := []struct {
+		command string
+		hasTip  bool
+	}{
+		// Should detect
+		{"cd /tmp", true},
+		{"cd src && ls", true},
+		{"cd src/components", true},
+		{"cd ..", true},
+		{"cd ~", true},
+		{"ls && cd subdir", true},
+		{"echo hi; cd foo", true},
+		{"false || cd bar", true},
+
+		// Should NOT detect
+		{"ls -la", false},
+		{"echo cd is cool", false},
+		{"mkdir -p foo", false},
+		{"echo 'cd /tmp'", false}, // inside string — regex is simple, may match; acceptable tradeoff
+		{"abcd /tmp", false},      // "abcd" is not "cd"
+		{"git checkout develop", false},
+		{"grep cd file.txt", false},
+	}
+
+	for _, tt := range tests {
+		tip := detectCdTip(tt.command)
+		got := tip != ""
+		if got != tt.hasTip {
+			t.Errorf("detectCdTip(%q) = %v, want hasTip=%v", tt.command, got, tt.hasTip)
+		}
+	}
+}
+
 // TestEnvPersistIntegration 集成测试：模拟完整的 export 命令处理流程
 func TestEnvPersistIntegration(t *testing.T) {
 	exportPattern := regexp.MustCompile(`export\s+((?:[A-Za-z_][A-Za-z0-9_]*=\S+\s*)+)`)


### PR DESCRIPTION
- Implemented `detectCdTip` function to identify standalone `cd` commands in user input.
- Enhanced `ShellTool.Execute` method to provide tips when a `cd` command is detected, informing users that the change in directory is temporary.
- Added unit tests for `detectCdTip` to ensure accurate detection of `cd` commands in various scenarios.

These changes improve user experience by clarifying the behavior of `cd` commands within the shell tool.