### PR TITLE
refactor: enhance SubAgent role definitions and directory structure

### DIFF
--- a/.xbot.example/README.md
+++ b/.xbot.example/README.md
@@ -10,7 +10,7 @@ cp -r .xbot.example /path/to/workdir/.xbot
 
 ```
 .xbot/
-├── agents/          # SubAgent 角色定义（Markdown + YAML frontmatter）
+├── agents/          # 全局 SubAgent 角色定义（所有用户共享）
 │   └── *.md
 ├── skills/          # 技能目录（每个技能一个子目录）
 │   └── <name>/
@@ -20,7 +20,7 @@ cp -r .xbot.example /path/to/workdir/.xbot
 
 ## Agents
 
-SubAgent 角色定义，格式兼容 Claude Code：
+SubAgent 角色定义文件（`*.md`），YAML frontmatter + Markdown body：
 
 ```markdown
 ---
@@ -37,6 +37,21 @@ System prompt for the agent...
 - `name`：角色标识，主 agent 通过此名称调用
 - `tools`：工具白名单（可选，不设则允许所有）
 
+### 个人 Agent
+
+每个用户的个人 agent 存放在其 **workspace 根目录** 的 `agents/` 目录下：
+
+```
+{workspace}/agents/*.md
+```
+
+个人 agent 会覆盖同名全局 agent。agent 可通过 `agent-creator` skill 在此目录创建新角色。
+
+### 加载优先级
+
+1. **个人 agents** — `{workspace}/agents/*.md`（同名覆盖全局）
+2. **全局 agents** — `.xbot/agents/*.md`（所有用户共享）
+
 ## Skills
 
 技能通过 `SKILL.md` 定义，启动时扫描注册，按需加载：
@@ -52,6 +67,7 @@ Detailed instructions...
 
 ## 自定义
 
-- 添加 agent：`agents/` 下创建 `.md` 文件
+- 添加个人 agent：在 workspace 的 `agents/` 下创建 `.md` 文件
+- 添加全局 agent：在 `.xbot/agents/` 下创建 `.md` 文件
 - 添加 skill：`skills/` 下创建子目录，放入 `SKILL.md`
 - 技能可包含 `scripts/`、`references/`、`assets/` 辅助目录

--- a/.xbot.example/skills/agent-creator/SKILL.md
+++ b/.xbot.example/skills/agent-creator/SKILL.md
@@ -18,7 +18,7 @@ Ask the user:
 
 ### Step 2: Create Agent File
 
-Create `agents/{agent-name}.md` in the workspace root (the file will be loaded from the `agents/` directory automatically).
+Create `agents/{agent-name}.md` in the workspace root. This is the user's personal agents directory — files here are loaded automatically and override same-name global agents.
 
 Agent definition uses YAML frontmatter + Markdown body:
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -206,7 +206,7 @@ type Agent struct {
 	singleUser      bool             // 单用户模式
 	maxConcurrency  int              // 最大并发会话处理数
 	globalSkillDirs []string         // 全局 skill 目录（宿主机路径）
-	agentsDir       string           // 全局 agents 目录（宿主机路径）
+	agentsDir       string
 
 	// 上下文压缩配置
 	maxContextTokens     int
@@ -342,7 +342,6 @@ func New(cfg Config) *Agent {
 	globalSkillDirs := resolveGlobalSkillsDirs(cfg.WorkDir, cfg.SkillsDir)
 	skillStore := NewSkillStore(cfg.WorkDir, globalSkillDirs)
 
-	// 加载 agent 角色定义（从 .xbot/agents/ 目录）
 	agentsDir := filepath.Join(cfg.WorkDir, ".xbot", "agents")
 	if err := tools.InitAgentRoles(agentsDir); err != nil {
 		log.WithError(err).Warn("Failed to load agent roles, SubAgent will have no predefined roles")

--- a/agent/agents.go
+++ b/agent/agents.go
@@ -11,11 +11,9 @@ import (
 )
 
 // AgentStore scans agent directories and generates a catalog for the system prompt.
-// Agents are predefined SubAgent roles loaded from .xbot/agents/*.md files.
-// Supports global + user-private merge strategy (like SkillStore).
 type AgentStore struct {
-	globalDir string // 全局 agents 目录 (e.g. {WorkDir}/.xbot/agents)
-	workDir   string // 用于派生用户私有 agents 目录
+	globalDir string
+	workDir   string
 }
 
 // NewAgentStore creates an AgentStore

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -42,13 +42,13 @@ type RunConfig struct {
 	SandboxWorkDir   string   // 沙箱内工作目录（如 /workspace）
 	ReadOnlyRoots    []string // 额外只读目录
 	SkillsDirs       []string // 全局 skill 目录列表
-	AgentsDir        string   // 全局 agents 目录
-	MCPConfigPath    string   // 用户 MCP 配置路径
-	GlobalMCPConfig  string   // 全局 MCP 配置路径（只读）
-	DataDir          string   // 数据持久化目录
-	SandboxEnabled   bool     // 是否启用命令沙箱
-	PreferredSandbox string   // 沙箱类型（docker 优先）
-	InitialCWD       string   // 初始当前工作目录（宿主机路径，用于 SubAgent 继承父 Agent 的 CWD）
+	AgentsDir        string
+	MCPConfigPath    string // 用户 MCP 配置路径
+	GlobalMCPConfig  string // 全局 MCP 配置路径（只读）
+	DataDir          string // 数据持久化目录
+	SandboxEnabled   bool   // 是否启用命令沙箱
+	PreferredSandbox string // 沙箱类型（docker 优先）
+	InitialCWD       string // 初始当前工作目录（宿主机路径，用于 SubAgent 继承父 Agent 的 CWD）
 
 	// === 循环控制 ===
 	MaxIterations int // 0 = 使用默认值 100

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -112,7 +112,7 @@ func GetExtraTyped[T any](mc *MessageContext, key string) (T, bool) {
 //
 //	"00_base"    - 基础提示词模板
 //	"10_skills"  - Skills 目录
-//	"15_agents"  - Agents 目录
+//	"15_agents"  - Agents catalog
 //	"20_memory"  - 记忆内容
 //	"30_sender"  - 发送者信息
 //	"90_time"    - 时间戳（变化最频繁，放最后以优化 KV-cache）

--- a/agent/middleware_builtin.go
+++ b/agent/middleware_builtin.go
@@ -53,7 +53,7 @@ func (m *SkillsCatalogMiddleware) Process(mc *MessageContext) error {
 	return nil
 }
 
-// AgentsCatalogMiddleware 注入 Agents 目录。
+// AgentsCatalogMiddleware injects available agents catalog.
 // 从 MessageContext.Extra[ExtraKeyAgentsCatalog] 读取动态内容。
 type AgentsCatalogMiddleware struct{}
 

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -17,13 +17,13 @@ type SessionMCPManagerProvider interface {
 
 // ToolContext 工具执行上下文
 type ToolContext struct {
-	Ctx                     context.Context                                 // 可取消的上下文，用于响应 stop 信号
-	WorkingDir              string                                          // Agent 的工作目录
-	WorkspaceRoot           string                                          // 当前用户可读写工作区根目录（宿主机路径）
-	SandboxWorkDir          string                                          // 沙箱内工作目录（如 Docker 为 /workspace，非沙箱时与 WorkspaceRoot 相同）
-	ReadOnlyRoots           []string                                        // 当前用户额外可读目录（只读）
-	SkillsDirs              []string                                        // 全局 skill 目录列表（宿主机路径，同步源）
-	AgentsDir               string                                          // 全局 agents 目录（宿主机路径，同步源）
+	Ctx                     context.Context // 可取消的上下文，用于响应 stop 信号
+	WorkingDir              string          // Agent 的工作目录
+	WorkspaceRoot           string          // 当前用户可读写工作区根目录（宿主机路径）
+	SandboxWorkDir          string          // 沙箱内工作目录（如 Docker 为 /workspace，非沙箱时与 WorkspaceRoot 相同）
+	ReadOnlyRoots           []string        // 当前用户额外可读目录（只读）
+	SkillsDirs              []string        // 全局 skill 目录列表（宿主机路径，同步源）
+	AgentsDir               string
 	MCPConfigPath           string                                          // 当前用户 MCP 配置路径
 	GlobalMCPConfigPath     string                                          // 全局 MCP 配置路径（只读）
 	SandboxEnabled          bool                                            // 是否启用命令沙箱

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -86,8 +86,6 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 	// Ensure global agents are synced to workspace
 	EnsureSynced(ctx)
 
-	// Search order: user private > synced global > host global
-	// Use OriginUserID for user private agents (original user's directory)
 	var userAgentDirs []string
 	originUserID := ctx.OriginUserID
 	if originUserID == "" {

--- a/tools/subagent_roles.go
+++ b/tools/subagent_roles.go
@@ -14,8 +14,6 @@ type SubAgentRole struct {
 	SystemPrompt string
 	AllowedTools []string
 
-	// Capabilities 声明 SubAgent 可获得的能力（Phase 3）
-	// 在 .xbot/agents/*.md frontmatter 中通过 capabilities 字段声明
 	Capabilities SubAgentCapabilities
 }
 
@@ -52,14 +50,13 @@ func CapabilitiesFromMap(m map[string]bool) SubAgentCapabilities {
 	return caps
 }
 
-// agentsDir 存储全局 agents 目录路径，供运行时按需加载
 var agentsDir string
 
-// InitAgentRoles 设置全局 agents 目录路径（启动时调用一次）
-// 实际加载在每次 GetSubAgentRole 调用时按需进行
+// InitAgentRoles sets the global agents directory (called once at startup).
+// Actual loading happens on-demand in each GetSubAgentRole call.
 func InitAgentRoles(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles available")
+		log.WithField("dir", dir).Info("Agents directory not found, no predefined roles")
 		return nil
 	}
 	agentsDir = dir

--- a/tools/workspace_scope.go
+++ b/tools/workspace_scope.go
@@ -44,7 +44,7 @@ func UserMCPConfigPath(workDir, senderID string) string {
 	return filepath.Join(UserRoot(workDir, senderID), "mcp.json")
 }
 
-// UserAgentsRoot 返回用户私有 agents 目录：{workDir}/.xbot/users/{sender}/workspace/agents
+// UserAgentsRoot returns the user-private agents directory.
 func UserAgentsRoot(workDir, senderID string) string {
 	return filepath.Join(UserWorkspaceRoot(workDir, senderID), "agents")
 }


### PR DESCRIPTION
- Updated README.md to clarify the distinction between global and personal SubAgent roles, including their loading priority and directory structure.
- Modified SKILL.md to reflect changes in agent file creation, emphasizing the personal agents directory.
- Adjusted agent code to remove references to the global agents directory in favor of a more streamlined approach.
- Improved comments and documentation across various files to enhance clarity regarding agent and skills management.

These changes improve the organization and usability of SubAgent roles, ensuring better user understanding and interaction.