### PR TITLE
fix: Phase 2 compress death loop — cooldown broken + eviction ineffective

### DIFF
--- a/agent/compress.go
+++ b/agent/compress.go
@@ -567,6 +567,64 @@ func thinTail(tail []llm.ChatMessage, keepGroups int) []llm.ChatMessage {
 	return result
 }
 
+// aggressiveThinTail 激进版 thinTail，用于 normal thinTail 压缩不足时的回退。
+// 与 thinTail 相同逻辑，但截断长度更短（100 vs 300），且对 assistant(tool_calls)
+// 消息也完全清空 Content（只保留 tool_calls 结构）。
+func aggressiveThinTail(tail []llm.ChatMessage, keepGroups int) []llm.ChatMessage {
+	const (
+		thinContentMax = 100
+		thinArgsMax    = 80
+	)
+	if keepGroups <= 0 {
+		keepGroups = 1
+	}
+
+	type toolGroup struct{ start, end int }
+	var groups []toolGroup
+	for i := range tail {
+		if tail[i].Role == "assistant" && len(tail[i].ToolCalls) > 0 {
+			g := toolGroup{start: i, end: i}
+			for j := i + 1; j < len(tail) && tail[j].Role == "tool"; j++ {
+				g.end = j
+			}
+			groups = append(groups, g)
+		}
+	}
+
+	thinCount := len(groups) - keepGroups
+	if thinCount <= 0 {
+		return tail
+	}
+
+	result := make([]llm.ChatMessage, len(tail))
+	copy(result, tail)
+
+	for g := range thinCount {
+		grp := groups[g]
+		for j := grp.start; j <= grp.end; j++ {
+			msg := result[j]
+			switch msg.Role {
+			case "assistant":
+				msg.Content = ""
+				if len(msg.ToolCalls) > 0 {
+					tcs := make([]llm.ToolCall, len(msg.ToolCalls))
+					copy(tcs, msg.ToolCalls)
+					for k := range tcs {
+						tcs[k].Arguments = truncateRunes(tcs[k].Arguments, thinArgsMax)
+					}
+					msg.ToolCalls = tcs
+				}
+			case "tool":
+				msg.Content = truncateRunes(msg.Content, thinContentMax)
+				msg.ToolArguments = truncateRunes(msg.ToolArguments, thinArgsMax)
+			}
+			result[j] = msg
+		}
+	}
+
+	return result
+}
+
 // truncateRunes 截断到 maxLen 个 rune（多字节安全）。
 func truncateRunes(s string, maxLen int) string {
 	runes := []rune(s)
@@ -623,10 +681,13 @@ func compressMessagesWithFingerprint(ctx context.Context, messages []llm.ChatMes
 		}
 	}
 
-	// 第二步：精简尾部旧工具组（保留最近 3 组完整，截断更早的组）
+	// 第二步：精简尾部旧工具组（保留最近 1 组完整，截断更早的组）
+	// BUG FIX: keepGroups 从 3 降到 1。
+	// 之前保留 3 组完整，当 tool 结果很大时，thinnedTail 仍占大量 token，
+	// 导致 LLM 压缩后 new_tokens ≈ original_tokens（压缩无效）。
 	var thinnedTail []llm.ChatMessage
 	if tailStart < len(messages) {
-		thinnedTail = thinTail(messages[tailStart:], 3)
+		thinnedTail = thinTail(messages[tailStart:], 1)
 	}
 
 	// 第三步：分离消息
@@ -744,11 +805,35 @@ Output the compressed content directly, preserving as much context as possible.`
 	llmView = append(llmView, summaryMsg)
 	llmView = append(llmView, thinnedTail...)
 
+	// BUG FIX: 最低缩减保证。
+	// 如果 LLM compress + thinTail 后缩减不到 20%，说明 tail 中的 tool 消息过大。
+	// 此时做激进截断：将 thinnedTail 中的旧 tool 组进一步压缩到 100 字符。
+	originalTokens, _ := llm.CountMessagesTokens(messages, model)
+	resultTokens, _ := llm.CountMessagesTokens(llmView, model)
+	minTarget := int(float64(originalTokens) * 0.8) // 至少缩减 20%
+	if resultTokens > minTarget && minTarget > 0 {
+		aggressiveTail := aggressiveThinTail(messages[tailStart:], 1)
+		llmView = make([]llm.ChatMessage, 0, len(systemMsgs)+1+len(aggressiveTail))
+		llmView = append(llmView, systemMsgs...)
+		llmView = append(llmView, summaryMsg)
+		llmView = append(llmView, aggressiveTail...)
+		aggressiveTokens, _ := llm.CountMessagesTokens(llmView, model)
+		log.Ctx(ctx).WithFields(map[string]interface{}{
+			"original_tokens":   originalTokens,
+			"normal_tokens":     resultTokens,
+			"aggressive_tokens": aggressiveTokens,
+			"min_target":        minTarget,
+		}).Info("Phase 2 compress: normal result insufficient, using aggressive thinning")
+	}
+
 	// Session View: 压缩摘要 + 尾部对话摘要（纯 user/assistant）
-	tailSummary := extractDialogueFromTail(thinnedTail)
-	sessionView := make([]llm.ChatMessage, 0, 1+len(tailSummary))
+	var sessionTailSummary []llm.ChatMessage
+	if len(llmView) > len(systemMsgs)+1 {
+		sessionTailSummary = extractDialogueFromTail(llmView[len(systemMsgs)+1:])
+	}
+	sessionView := make([]llm.ChatMessage, 0, 1+len(sessionTailSummary))
 	sessionView = append(sessionView, summaryMsg)
-	sessionView = append(sessionView, tailSummary...)
+	sessionView = append(sessionView, sessionTailSummary...)
 
 	return &CompressResult{
 		LLMView:     llmView,

--- a/agent/context_manager_phase2.go
+++ b/agent/context_manager_phase2.go
@@ -73,7 +73,10 @@ func (m *phase2Manager) Compress(ctx context.Context, messages []llm.ChatMessage
 	}).Info("Phase 2 compress: starting eviction")
 
 	// Phase 1: Evict（信息密度驱逐）
-	evicted := evictByDensity(messages, 3, targetTokens, model)
+	// BUG FIX: keepGroups 从 3 降到 1。
+	// 之前保留最后 3 组完整，当 conversation 只有 ≤3 组 tool 时直接返回 0 驱逐。
+	// 保留 1 组足够 LLM 继续当前工具对话，其余全走密度评分驱逐。
+	evicted := evictByDensity(messages, 1, targetTokens, model)
 	evictTokens, _ := llm.CountMessagesTokens(evicted, model)
 	evictedCount := countEvictedMessages(messages, evicted)
 
@@ -166,7 +169,7 @@ func (m *phase2Manager) ManualCompress(ctx context.Context, messages []llm.ChatM
 	targetTokens := int(float64(m.config.MaxContextTokens) * 0.7)
 
 	// Phase 1: Evict
-	evicted := evictByDensity(messages, 3, targetTokens, model)
+	evicted := evictByDensity(messages, 1, targetTokens, model)
 	evictTokens, _ := llm.CountMessagesTokens(evicted, model)
 
 	log.Ctx(ctx).WithFields(map[string]interface{}{

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -272,6 +272,27 @@ func Run(ctx context.Context, cfg RunConfig) *RunOutput {
 			"new_tokens": newTokenCount,
 		}).Info("Auto context compression completed")
 
+		// BUG FIX: 记录压缩迭代号 + 有效性检测。
+		// 之前从未调用 RecordCompress，导致 Cooldown.ShouldTrigger 永远返回 true，
+		// 每次迭代都触发压缩，压缩无效时形成死循环。
+		// 新增：缩减率 <10% 视为低效，连续 2 次低效后加大冷却期到 10 次迭代。
+		if smart, ok := cm.(SmartCompressor); ok && smart.TriggerProvider() != nil {
+			smart.TriggerProvider().Cooldown.RecordCompress(iteration)
+			if oldTokenCount > 0 {
+				reductionRate := 1.0 - float64(newTokenCount)/float64(oldTokenCount)
+				if reductionRate < 0.10 {
+					log.Ctx(ctx).WithFields(log.Fields{
+						"old_tokens": oldTokenCount,
+						"new_tokens": newTokenCount,
+						"reduction":  fmt.Sprintf("%.1f%%", reductionRate*100),
+					}).Warn("Phase 2 compress: ineffective (reduction < 10%), increasing cooldown")
+					smart.TriggerProvider().Cooldown.RecordIneffective()
+				} else {
+					smart.TriggerProvider().Cooldown.RecordEffective()
+				}
+			}
+		}
+
 		// 持久化压缩结果到 session
 		if cfg.Session != nil {
 			if err := cfg.Session.Clear(); err != nil {

--- a/agent/trigger.go
+++ b/agent/trigger.go
@@ -119,9 +119,12 @@ func (t *TokenGrowthTracker) Reset() {
 }
 
 // CompressCooldown 压缩冷却期管理器，防止短时间内重复压缩。
+// 内置死循环检测：连续压缩缩减率低于 10% 时，自动加大冷却期。
 type CompressCooldown struct {
 	lastCompressIteration int
 	cooldownIterations    int // 默认 3
+	ineffectiveCount      int // 连续低效压缩计数
+	baseCooldown          int // 初始冷却期（用于重置）
 }
 
 // NewCompressCooldown 创建冷却期管理器，iterations 默认 3。
@@ -131,6 +134,7 @@ func NewCompressCooldown(iterations int) *CompressCooldown {
 	}
 	return &CompressCooldown{
 		cooldownIterations: iterations,
+		baseCooldown:       iterations,
 	}
 }
 
@@ -145,6 +149,28 @@ func (c *CompressCooldown) ShouldTrigger(currentIteration int) bool {
 // RecordCompress 记录一次压缩发生的迭代号。
 func (c *CompressCooldown) RecordCompress(iteration int) {
 	c.lastCompressIteration = iteration
+}
+
+// RecordIneffective 记录一次低效压缩（缩减率 <10%）。
+// 连续 2 次低效后加大冷却期到 10 次迭代，防止死循环。
+func (c *CompressCooldown) RecordIneffective() {
+	c.ineffectiveCount++
+	if c.ineffectiveCount >= 2 {
+		c.cooldownIterations = 10
+	}
+}
+
+// RecordEffective 记录一次有效压缩（缩减率 >=10%），重置低效计数和冷却期。
+func (c *CompressCooldown) RecordEffective() {
+	c.ineffectiveCount = 0
+	if c.cooldownIterations > c.baseCooldown {
+		c.cooldownIterations = c.baseCooldown
+	}
+}
+
+// IneffectiveCount 返回当前连续低效压缩次数。
+func (c *CompressCooldown) IneffectiveCount() int {
+	return c.ineffectiveCount
 }
 
 // Reset 重置冷却状态。


### PR DESCRIPTION
## Phase 2 Compress Death Loop — 4 Bugs Fixed

### Problem
Phase 2 上下文压缩出现死循环：压缩无效（token 不减反增）→ 再次触发压缩 → 仍然无效 → 无限循环。

症状：`evicted_msgs=0`, `new_tokens=97630` (与 original 相同), `quality_score=0.227`

### Root Cause Analysis

| # | Bug | 严重性 | 影响 |
|---|-----|--------|------|
| 1 | `RecordCompress` 从未被调用 | 🔴 Critical | 冷却期失效，每次迭代都触发压缩 |
| 2 | `evictByDensity` keepGroups=3 | 🔴 High | ≤3 个 tool group 时 0 驱逐 |
| 3 | `thinTail` keepGroups=3 | 🟡 Medium | LLM view 保留 3 组完整 tool 结果，压缩结果几乎不缩减 |
| 4 | 无死循环检测 | 🟡 Medium | 压缩无效时无法自我修正 |

### Fixes

**Bug 1 — engine.go**: 压缩成功后调用 `RecordCompress(iteration)` 激活冷却期

**Bug 2 — context_manager_phase2.go**: `evictByDensity` 的 keepGroups 从 3 降到 1（Auto + Manual 均修复）

**Bug 3 — compress.go**: 
- `thinTail` keepGroups 从 3 降到 1
- 新增 `aggressiveThinTail` 回退机制：当 LLM compress + thinTail 后缩减不到 20% 时，自动用更激进的截断（100 字符 vs 300 字符）

**Bug 4 — trigger.go + engine.go**:
- `CompressCooldown` 新增 `RecordIneffective/RecordEffective`
- 连续 2 次低效压缩（缩减率 <10%）→ 冷却期 3→10 次迭代
- 有效压缩（≥10%）→ 重置冷却期

### Files Changed
- `agent/engine.go` — RecordCompress + 有效性检测
- `agent/compress.go` — aggressiveThinTail + keepGroups 3→1
- `agent/context_manager_phase2.go` — evictByDensity keepGroups 3→1
- `agent/trigger.go` — CompressCooldown 死循环检测

### Testing
- ✅ `go build ./...` — 通过
- ✅ `go vet ./...` — 0 issues
- ✅ `go test ./...` — 全部通过
- ✅ gofmt + golangci-lint — pre-push checks passed