### PR TITLE
fix: settings panic — nil channel dereference + card robustness

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"xbot/bus"
+	"xbot/channel"
 	"xbot/cron"
 	"xbot/llm"
 	log "xbot/logger"
@@ -255,6 +256,9 @@ type Agent struct {
 
 	// SettingsService for per-user settings
 	settingsSvc *SettingsService
+
+	// channelFinder looks up a channel instance by name (injected from main.go).
+	channelFinder func(name string) (channel.Channel, bool)
 }
 
 // SetRegistryManager sets the RegistryManager (for external injection or override).
@@ -262,6 +266,15 @@ func (a *Agent) SetRegistryManager(rm *RegistryManager) { a.registryManager = rm
 
 // SetSettingsService sets the SettingsService (for external injection or override).
 func (a *Agent) SetSettingsService(svc *SettingsService) { a.settingsSvc = svc }
+
+// SetChannelFinder sets the channel finder callback (for external injection).
+// Also propagates to SettingsService so it can resolve channels by name.
+func (a *Agent) SetChannelFinder(fn func(name string) (channel.Channel, bool)) {
+	a.channelFinder = fn
+	if a.settingsSvc != nil {
+		a.settingsSvc.SetChannelFinder(fn)
+	}
+}
 
 func buildToolMessageContent(result *tools.ToolResult) string {
 	if result == nil {

--- a/agent/command_builtin.go
+++ b/agent/command_builtin.go
@@ -504,6 +504,29 @@ func (c *settingsCmd) Execute(ctx context.Context, a *Agent, msg bus.InboundMess
 		}
 		key := setParts[0]
 		value := strings.Join(setParts[1:], " ")
+
+		// Fix 4: Validate key against schema if channelFinder is available
+		schema := a.settingsSvc.GetSettingsSchema(msg.Channel)
+		if len(schema) > 0 {
+			valid := false
+			for _, def := range schema {
+				if def.Key == key {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				var validKeys []string
+				for _, def := range schema {
+					validKeys = append(validKeys, def.Key)
+				}
+				return &bus.OutboundMessage{
+					Channel: msg.Channel, ChatID: msg.ChatID,
+					Content: fmt.Sprintf("未知设置项: %q\n可用设置项: %s", key, strings.Join(validKeys, ", ")),
+				}, nil
+			}
+		}
+
 		err := a.settingsSvc.SetSetting(msg.Channel, msg.SenderID, key, value)
 		if err != nil {
 			return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("设置失败：%v", err)}, nil
@@ -511,8 +534,8 @@ func (c *settingsCmd) Execute(ctx context.Context, a *Agent, msg bus.InboundMess
 		return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("✅ %s = %s", key, value)}, nil
 	}
 
-	// /settings (list)
-	ui, err := a.settingsSvc.GetSettingsUI(nil, msg.SenderID)
+	// /settings (list) — now uses channelName string directly
+	ui, err := a.settingsSvc.GetSettingsUI(msg.Channel, msg.SenderID)
 	if err != nil {
 		return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("获取设置失败：%v", err)}, nil
 	}

--- a/agent/settings.go
+++ b/agent/settings.go
@@ -11,12 +11,18 @@ import (
 
 // SettingsService provides user settings management.
 type SettingsService struct {
-	store *sqlite.UserSettingsService
+	store         *sqlite.UserSettingsService
+	channelFinder func(string) (channel.Channel, bool)
 }
 
 // NewSettingsService creates a new SettingsService.
 func NewSettingsService(store *sqlite.UserSettingsService) *SettingsService {
 	return &SettingsService{store: store}
+}
+
+// SetChannelFinder sets the channel finder callback (injected from Agent or main.go).
+func (s *SettingsService) SetChannelFinder(fn func(string) (channel.Channel, bool)) {
+	s.channelFinder = fn
 }
 
 // GetSettings retrieves all settings for a user on a specific channel.
@@ -29,19 +35,42 @@ func (s *SettingsService) SetSetting(channelName, senderID, key, value string) e
 	return s.store.Set(channelName, senderID, key, value)
 }
 
+// GetSettingsSchema retrieves the settings schema for a channel.
+// Returns nil if the channel is not found or doesn't implement SettingsCapability.
+func (s *SettingsService) GetSettingsSchema(channelName string) []channel.SettingDefinition {
+	if s.channelFinder == nil {
+		return nil
+	}
+	ch, ok := s.channelFinder(channelName)
+	if !ok {
+		return nil
+	}
+	sc, ok := ch.(channel.SettingsCapability)
+	if !ok {
+		return nil
+	}
+	return sc.SettingsSchema()
+}
+
 // GetSettingsUI renders the settings UI for a channel.
-// If the channel implements UIBuilder, it uses the interactive card UI.
-// Otherwise, falls back to text-based settings list.
-func (s *SettingsService) GetSettingsUI(ch channel.Channel, senderID string) (string, error) {
-	settings, err := s.store.Get(ch.Name(), senderID)
+// It uses channelFinder internally to look up the channel instance.
+// If the channel is not found or has no schema, falls back to text UI.
+func (s *SettingsService) GetSettingsUI(channelName, senderID string) (string, error) {
+	settings, err := s.store.Get(channelName, senderID)
 	if err != nil {
 		return "", err
 	}
 
-	// Check if channel provides SettingsCapability
+	// Try to find the channel and get its schema
+	var ch channel.Channel
 	schema := []channel.SettingDefinition{}
-	if sc, ok := ch.(channel.SettingsCapability); ok {
-		schema = sc.SettingsSchema()
+	if s.channelFinder != nil {
+		if found, ok := s.channelFinder(channelName); ok {
+			ch = found
+			if sc, ok := found.(channel.SettingsCapability); ok {
+				schema = sc.SettingsSchema()
+			}
+		}
 	}
 
 	if len(schema) == 0 {
@@ -58,21 +87,26 @@ func (s *SettingsService) GetSettingsUI(ch channel.Channel, senderID string) (st
 }
 
 // SubmitSettings processes a settings submission.
+// It uses channelFinder internally to look up the channel instance.
 // For channels with SettingsCapability, it delegates to HandleSettingSubmit.
-// For text mode, it parses "key=value" format.
-func (s *SettingsService) SubmitSettings(ch channel.Channel, channelName, senderID, rawInput string) error {
-	// Check if channel provides SettingsCapability with interactive submit
-	if sc, ok := ch.(channel.SettingsCapability); ok {
-		values, err := sc.HandleSettingSubmit(context.Background(), rawInput)
-		if err != nil {
-			return err
-		}
-		for key, value := range values {
-			if err := s.store.Set(channelName, senderID, key, value); err != nil {
-				return fmt.Errorf("save setting %s: %w", key, err)
+// For text mode (no channel or no capability), it parses "key=value" format.
+func (s *SettingsService) SubmitSettings(channelName, senderID, rawInput string) error {
+	// Try to find the channel for interactive submit
+	if s.channelFinder != nil {
+		if ch, ok := s.channelFinder(channelName); ok {
+			if sc, ok := ch.(channel.SettingsCapability); ok {
+				values, err := sc.HandleSettingSubmit(context.Background(), rawInput)
+				if err != nil {
+					return err
+				}
+				for key, value := range values {
+					if err := s.store.Set(channelName, senderID, key, value); err != nil {
+						return fmt.Errorf("save setting %s: %w", key, err)
+					}
+				}
+				return nil
 			}
 		}
-		return nil
 	}
 
 	// Text mode: parse "key=value" format

--- a/agent/settings_test.go
+++ b/agent/settings_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"xbot/bus"
 	"xbot/storage/sqlite"
 )
 
@@ -47,12 +46,11 @@ func TestSettingsServiceGetSettingsUI(t *testing.T) {
 	store := sqlite.NewUserSettingsService(db)
 	svc := NewSettingsService(store)
 
-	// Use a mock channel that doesn't implement SettingsCapability
-	ui, err := svc.GetSettingsUI(&noCapabilityChannel{}, "user1")
+	// No channelFinder set — should return "no settings" fallback
+	ui, err := svc.GetSettingsUI("test", "user1")
 	if err != nil {
 		t.Fatalf("get settings ui: %v", err)
 	}
-	// Should return "no settings" since channel has no schema
 	if ui != "当前渠道没有可配置的设置项。" {
 		t.Errorf("expected no settings message, got %q", ui)
 	}
@@ -70,10 +68,8 @@ func TestSettingsServiceSubmitSettingsTextMode(t *testing.T) {
 	store := sqlite.NewUserSettingsService(db)
 	svc := NewSettingsService(store)
 
-	ch := &noCapabilityChannel{}
-
-	// Submit key=value pairs
-	err = svc.SubmitSettings(ch, "cli", "user1", "key1=value1\nkey2=value2")
+	// No channelFinder set — text mode fallback
+	err = svc.SubmitSettings("cli", "user1", "key1=value1\nkey2=value2")
 	if err != nil {
 		t.Fatalf("submit: %v", err)
 	}
@@ -87,18 +83,8 @@ func TestSettingsServiceSubmitSettingsTextMode(t *testing.T) {
 	}
 
 	// Test error on invalid format
-	err = svc.SubmitSettings(ch, "cli", "user1", "invalid_line_no_equals")
+	err = svc.SubmitSettings("cli", "user1", "invalid_line_no_equals")
 	if err == nil {
 		t.Error("expected error for invalid format")
 	}
-}
-
-// noCapabilityChannel is a minimal channel that doesn't implement SettingsCapability
-type noCapabilityChannel struct{}
-
-func (c *noCapabilityChannel) Name() string { return "test" }
-func (c *noCapabilityChannel) Start() error { return nil }
-func (c *noCapabilityChannel) Stop()        {}
-func (c *noCapabilityChannel) Send(msg bus.OutboundMessage) (string, error) {
-	return "", nil
 }

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -1603,7 +1603,8 @@ func (f *FeishuChannel) buildCard(content string) map[string]any {
 	return map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
-			"update_multi": true,
+			"wide_screen_mode": true,
+			"update_multi":     true,
 		},
 		"body": map[string]any{
 			"elements": []map[string]any{
@@ -1796,39 +1797,72 @@ func (f *FeishuChannel) SettingsSchema() []SettingDefinition {
 
 // HandleSettingSubmit parses a card callback JSON and returns key-value pairs.
 func (f *FeishuChannel) HandleSettingSubmit(ctx context.Context, rawInput string) (map[string]string, error) {
+	// Defensive: reject empty input
+	rawInput = strings.TrimSpace(rawInput)
+	if rawInput == "" {
+		return nil, fmt.Errorf("empty settings input")
+	}
+
 	result := make(map[string]string)
 
 	// Try parsing as JSON (from card callback)
 	var data map[string]any
 	if err := json.Unmarshal([]byte(rawInput), &data); err == nil {
+		// Defensive: check for empty JSON object
+		if len(data) == 0 {
+			return nil, fmt.Errorf("empty JSON object in settings input")
+		}
+
 		// Extract form values from card callback
 		for key, value := range data {
-			if key == "card_id" {
+			if key == "card_id" || key == "" {
 				continue
 			}
-			if s, ok := value.(string); ok {
-				result[key] = s
+			switch v := value.(type) {
+			case string:
+				result[key] = v
+			case bool:
+				result[key] = strconv.FormatBool(v)
+			case float64:
+				// Avoid scientific notation for whole numbers
+				if v == float64(int64(v)) {
+					result[key] = strconv.FormatInt(int64(v), 10)
+				} else {
+					result[key] = strconv.FormatFloat(v, 'f', -1, 64)
+				}
+			case nil:
+				// Skip nil values
+			default:
+				// For other types (arrays, nested objects), marshal to string
+				if b, err := json.Marshal(v); err == nil {
+					result[key] = string(b)
+				}
 			}
 		}
 		if len(result) > 0 {
 			return result, nil
 		}
+		// JSON parsed but no valid keys found — fall through to text parsing
 	}
 
 	// Fallback: parse as "key=value" text format
 	for _, line := range strings.Split(rawInput, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" {
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) == 2 {
-			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			if key != "" {
+				result[key] = value
+			}
 		}
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("no valid settings found in input")
+		return nil, fmt.Errorf("no valid settings found in input: %q", rawInput)
 	}
 	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func main() {
 
 	// 注入同步发送函数，使 Agent 可直接通过 Dispatcher 发送消息并获取 message_id
 	agentLoop.SetDirectSend(disp.SendDirect)
+	agentLoop.SetChannelFinder(disp.GetChannel)
 
 	// 设置飞书渠道的 CardBuilder（用于卡片回调处理）
 	if feishuCh != nil {


### PR DESCRIPTION
## Problem

`/settings` 命令在飞书渠道直接 panic：`GetSettingsUI(nil, ...)` 传入 nil channel，触发 nil dereference。

## Root Cause

- `SettingsService.GetSettingsUI` / `SubmitSettings` 签名要求 `channel.Channel` 实例，但 `/settings` 命令的调用方只持有 channel name string
- `HandleSettingSubmit` 对异常 JSON（空对象、nil value、非 string 类型）无防御
- `buildCard` 缺少 `wide_screen_mode` 字段

## Changes

| File | Change |
|------|--------|
| `agent/settings.go` | `GetSettingsUI` / `SubmitSettings` 改为 `(channelName string, ...)` 签名，内置 `channelFinder` 按需查找 channel |
| `agent/agent.go` | 新增 `SetChannelFinder`，自动传播到 `SettingsService` |
| `agent/command_builtin.go` | `/settings set` 增加 schema key 验证，无效 key 列出可用项 |
| `channel/feishu.go` | `HandleSettingSubmit` 全面防御：空 JSON / nil / bool / float64 / array；`buildCard` 添加 `wide_screen_mode` |
| `main.go` | 注入 `disp.GetChannel` 作为 channelFinder |

## Verification

- `go build / vet / test -race` ✅
- `golangci-lint v2.10.1` ✅ (0 issues)