### PR TITLE
feat: 飞书交互式 Settings 卡片 — 模型选择 / Agent 配置 / Registry 市场

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -267,6 +267,32 @@ func (a *Agent) SetRegistryManager(rm *RegistryManager) { a.registryManager = rm
 // SetSettingsService sets the SettingsService (for external injection or override).
 func (a *Agent) SetSettingsService(svc *SettingsService) { a.settingsSvc = svc }
 
+// LLMFactory returns the Agent's LLMFactory (for external injection of callbacks).
+func (a *Agent) LLMFactory() *LLMFactory { return a.llmFactory }
+
+// RegistryManager returns the Agent's RegistryManager (for external injection of callbacks).
+func (a *Agent) RegistryManager() *RegistryManager { return a.registryManager }
+
+// SettingsService returns the Agent's SettingsService (for external injection of callbacks).
+func (a *Agent) SettingsService() *SettingsService { return a.settingsSvc }
+
+// SetUserModel sets the model for a user's LLM configuration (used by settings card callback).
+func (a *Agent) SetUserModel(senderID, model string) error {
+	cfg, err := a.llmConfigSvc.GetConfig(senderID)
+	if err != nil {
+		return fmt.Errorf("get LLM config: %w", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("user has no custom LLM config; use /set-llm first")
+	}
+	cfg.Model = model
+	if err := a.llmConfigSvc.SetConfig(cfg); err != nil {
+		return fmt.Errorf("save model: %w", err)
+	}
+	a.llmFactory.Invalidate(senderID)
+	return nil
+}
+
 // SetChannelFinder sets the channel finder callback (for external injection).
 // Also propagates to SettingsService so it can resolve channels by name.
 func (a *Agent) SetChannelFinder(fn func(name string) (channel.Channel, bool)) {

--- a/agent/command_builtin.go
+++ b/agent/command_builtin.go
@@ -2,11 +2,13 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"xbot/bus"
+	"xbot/channel"
 	"xbot/version"
 )
 
@@ -534,7 +536,28 @@ func (c *settingsCmd) Execute(ctx context.Context, a *Agent, msg bus.InboundMess
 		return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("✅ %s = %s", key, value)}, nil
 	}
 
-	// /settings (list) — now uses channelName string directly
+	// /settings (list) — 检测飞书渠道使用交互式卡片，其他渠道使用 markdown
+	if a.channelFinder != nil {
+		if ch, ok := a.channelFinder(msg.Channel); ok {
+			if fc, ok := ch.(*channel.FeishuChannel); ok {
+				card, err := fc.BuildSettingsCard(ctx, msg.SenderID, msg.ChatID, "basic")
+				if err != nil {
+					return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("构建设置卡片失败：%v", err)}, nil
+				}
+				cardJSON, err := json.Marshal(card)
+				if err != nil {
+					return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("序列化设置卡片失败：%v", err)}, nil
+				}
+				return &bus.OutboundMessage{
+					Channel: msg.Channel,
+					ChatID:  msg.ChatID,
+					Content: "__FEISHU_CARD__::" + string(cardJSON),
+				}, nil
+			}
+		}
+	}
+
+	// Fallback: 非 Feishu 渠道使用 markdown UI
 	ui, err := a.settingsSvc.GetSettingsUI(msg.Channel, msg.SenderID)
 	if err != nil {
 		return &bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: fmt.Sprintf("获取设置失败：%v", err)}, nil

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -14,6 +14,7 @@ import (
 
 	"xbot/bus"
 	log "xbot/logger"
+	"xbot/storage/sqlite"
 	"xbot/tools"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
@@ -32,6 +33,17 @@ type FeishuConfig struct {
 	EncryptKey        string   // 事件订阅加密 Key（可选）
 	VerificationToken string   // 事件订阅验证 Token（可选）
 	AllowFrom         []string // 允许的用户 open_id 白名单（空则允许所有人）
+}
+
+// SettingsCallbacks holds the callback functions for settings card interaction.
+// Injected from Agent to decouple channel from agent packages.
+type SettingsCallbacks struct {
+	LLMList         func(senderID string) ([]string, string) // returns (models, currentModel)
+	LLMSet          func(senderID, model string) error
+	RegistryBrowse  func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error)
+	RegistryInstall func(entryType string, id int64, senderID string) error
+	SettingsGet     func(channelName, senderID string) (map[string]string, error)
+	SettingsSet     func(channelName, senderID, key, value string) error
 }
 
 // FeishuChannel 飞书渠道实现
@@ -59,6 +71,9 @@ type FeishuChannel struct {
 
 	// CardBuilder for card callback handling
 	cardBuilder *tools.CardBuilder
+
+	// Settings card callbacks (injected from Agent via main.go)
+	settingsCallbacks SettingsCallbacks
 }
 
 // NewFeishuChannel 创建飞书渠道
@@ -89,6 +104,11 @@ func (f *FeishuChannel) ChannelSystemParts(ctx context.Context, chatID, senderID
 // SetCardBuilder sets the CardBuilder for card callback handling.
 func (f *FeishuChannel) SetCardBuilder(builder *tools.CardBuilder) {
 	f.cardBuilder = builder
+}
+
+// SetSettingsCallbacks injects settings card callbacks from Agent.
+func (f *FeishuChannel) SetSettingsCallbacks(cb SettingsCallbacks) {
+	f.settingsCallbacks = cb
 }
 
 // Start 启动飞书 WebSocket 长连接
@@ -1002,11 +1022,20 @@ func (f *FeishuChannel) onCardAction(ctx context.Context, event *callback.CardAc
 		senderID = *event.Event.Operator.UserID
 	}
 
-	// 查找 card_id：优先从 actionData（按钮 value），否则通过 message_id 反查
+	// 获取 message_id（settings 卡片拦截和 CardBuilder 路由都需要）
 	messageID := ""
 	if event.Event.Context != nil {
 		messageID = event.Event.Context.OpenMessageID
 	}
+
+	// 拦截 settings 卡片按钮点击（在 CardBuilder 路由之前）
+	if parsed := parseActionDataFromMap(actionData); parsed != nil {
+		if actionName := parsed["action"]; strings.HasPrefix(actionName, settingsCardActionPrefix) {
+			return f.handleSettingsCardAction(ctx, actionData, chatID, senderID, messageID)
+		}
+	}
+
+	// 查找 card_id：优先从 actionData（按钮 value），否则通过 message_id 反查
 	cardID := ""
 	if id, ok := actionData["card_id"].(string); ok {
 		cardID = id
@@ -1021,6 +1050,54 @@ func (f *FeishuChannel) onCardAction(ctx context.Context, event *callback.CardAc
 	}
 
 	return f.handleCardBuilderAction(cardID, actionData, action, chatID, senderID, messageID, requestID)
+}
+
+// handleSettingsCardAction handles settings card button clicks.
+// It processes the action, rebuilds the card, and patches the original message.
+func (f *FeishuChannel) handleSettingsCardAction(ctx context.Context, actionData map[string]any, chatID, senderID, messageID string) (*callback.CardActionTriggerResponse, error) {
+	updatedCard, err := f.HandleSettingsAction(ctx, actionData, senderID, chatID, messageID)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"chat_id":   chatID,
+			"sender_id": senderID,
+		}).Warn("Settings card action failed")
+		return &callback.CardActionTriggerResponse{
+			Toast: &callback.Toast{
+				Type:    "error",
+				Content: "操作失败: " + err.Error(),
+			},
+		}, nil
+	}
+
+	// Patch the updated card back to the original message
+	if messageID != "" {
+		cardJSON, err := json.Marshal(updatedCard)
+		if err != nil {
+			log.WithError(err).Warn("Failed to marshal settings card")
+			return &callback.CardActionTriggerResponse{
+				Toast: &callback.Toast{
+					Type:    "error",
+					Content: "卡片序列化失败",
+				},
+			}, nil
+		}
+		if err := f.patchMessage(messageID, cardJSON); err != nil {
+			log.WithError(err).WithField("message_id", messageID).Warn("Failed to patch settings card")
+			return &callback.CardActionTriggerResponse{
+				Toast: &callback.Toast{
+					Type:    "error",
+					Content: "卡片更新失败",
+				},
+			}, nil
+		}
+	}
+
+	return &callback.CardActionTriggerResponse{
+		Toast: &callback.Toast{
+			Type:    "success",
+			Content: "已更新",
+		},
+	}, nil
 }
 
 // handleCardBuilderAction handles card actions from Card Builder MCP cards.
@@ -1767,17 +1844,17 @@ func feishuSettingsSchema() []SettingDefinition {
 			DefaultValue: "detailed",
 		},
 		{
-			Key:         "language",
-			Label:       "语言",
-			Description: "机器人回复的首选语言",
+			Key:         "context_mode",
+			Label:       "上下文模式",
+			Description: "控制上下文压缩方式",
 			Type:        SettingTypeSelect,
 			Category:    "对话",
 			Options: []SettingOption{
-				{Label: "中文", Value: "zh"},
-				{Label: "English", Value: "en"},
-				{Label: "日本語", Value: "ja"},
+				{Label: "渐进压缩", Value: "phase2"},
+				{Label: "双视图", Value: "phase1"},
+				{Label: "禁用", Value: "none"},
 			},
-			DefaultValue: "zh",
+			DefaultValue: "phase1",
 		},
 		{
 			Key:          "notify_on_complete",

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -1,0 +1,536 @@
+package channel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	log "xbot/logger"
+)
+
+// settingsCardActionPrefix is the prefix for all settings card callback actions.
+const settingsCardActionPrefix = "settings_"
+
+// BuildSettingsCard constructs an interactive Feishu card JSON for settings.
+// tab: "basic" | "model" | "market"
+// senderID: current user ID (needed for model listing)
+// chatID: current chat ID
+func (f *FeishuChannel) BuildSettingsCard(ctx context.Context, senderID, chatID, tab string) (map[string]any, error) {
+	if tab == "" {
+		tab = "basic"
+	}
+
+	// Fetch current settings
+	var settings map[string]string
+	if f.settingsCallbacks.SettingsGet != nil {
+		var err error
+		settings, err = f.settingsCallbacks.SettingsGet(f.Name(), senderID)
+		if err != nil {
+			log.WithError(err).Warn("BuildSettingsCard: failed to get settings")
+			settings = make(map[string]string)
+		}
+	}
+
+	// Build header elements
+	elements := []map[string]any{
+		{
+			"tag":     "markdown",
+			"content": "**⚙️ 设置面板**",
+		},
+		{"tag": "hr"},
+	}
+
+	// Tab buttons
+	elements = append(elements, buildTabButtons(tab)...)
+	elements = append(elements, map[string]any{"tag": "hr"})
+
+	// Tab content
+	switch tab {
+	case "basic":
+		elements = append(elements, f.buildBasicTabContent(settings)...)
+	case "model":
+		elements = append(elements, f.buildModelTabContent(ctx, senderID)...)
+	case "market":
+		elements = append(elements, f.buildMarketTabContent(ctx, senderID)...)
+	}
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{
+			"wide_screen_mode": true,
+			"update_multi":     true,
+		},
+		"header": map[string]any{
+			"title": map[string]any{
+				"tag":     "plain_text",
+				"content": "⚙️ 设置",
+			},
+			"template": "blue",
+		},
+		"body": map[string]any{
+			"elements": elements,
+		},
+	}
+
+	return card, nil
+}
+
+// HandleSettingsAction processes settings card callback actions.
+// It returns the updated card JSON that should be patched back to the message.
+func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map[string]any, senderID, chatID, messageID string) (map[string]any, error) {
+	// Extract action_data JSON string
+	actionDataJSON, _ := actionData["action_data"].(string)
+	if actionDataJSON == "" {
+		return nil, fmt.Errorf("missing action_data")
+	}
+
+	parsed := parseActionData(actionDataJSON)
+	if parsed == nil {
+		return nil, fmt.Errorf("invalid action_data format")
+	}
+
+	action := parsed["action"]
+	switch action {
+	case "settings_tab":
+		tab := parsed["tab"]
+		return f.BuildSettingsCard(ctx, senderID, chatID, tab)
+
+	case "settings_set":
+		key := parsed["key"]
+		value := parsed["value"]
+		if key == "" {
+			return nil, fmt.Errorf("missing key in settings_set action")
+		}
+		if f.settingsCallbacks.SettingsSet != nil {
+			if err := f.settingsCallbacks.SettingsSet(f.Name(), senderID, key, value); err != nil {
+				log.WithError(err).Warnf("HandleSettingsAction: failed to set %s=%s", key, value)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "basic")
+
+	case "settings_set_model":
+		model := parsed["model"]
+		if model == "" {
+			return nil, fmt.Errorf("missing model in settings_set_model action")
+		}
+		if f.settingsCallbacks.LLMSet != nil {
+			if err := f.settingsCallbacks.LLMSet(senderID, model); err != nil {
+				log.WithError(err).Warnf("HandleSettingsAction: failed to set model %s", model)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
+
+	case "settings_install":
+		entryType := parsed["entry_type"]
+		entryIDStr := parsed["entry_id"]
+		if entryType == "" || entryIDStr == "" {
+			return nil, fmt.Errorf("missing entry_type or entry_id in settings_install action")
+		}
+		entryID, err := strconv.ParseInt(entryIDStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid entry_id: %s", entryIDStr)
+		}
+		if f.settingsCallbacks.RegistryInstall != nil {
+			if err := f.settingsCallbacks.RegistryInstall(entryType, entryID, senderID); err != nil {
+				log.WithError(err).Warnf("HandleSettingsAction: failed to install %s/%d", entryType, entryID)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "market")
+
+	default:
+		return nil, fmt.Errorf("unknown settings action: %s", action)
+	}
+}
+
+// --- Tab content builders ---
+
+// buildTabButtons creates the three tab switching buttons.
+func buildTabButtons(currentTab string) []map[string]any {
+	tabs := []struct {
+		key   string
+		label string
+	}{
+		{"basic", "🎯 基础"},
+		{"model", "🤖 模型"},
+		{"market", "📦 市场"},
+	}
+
+	var elements []map[string]any
+	var actions []map[string]any
+	for _, t := range tabs {
+		isActive := t.key == currentTab
+		btnType := "default"
+		if isActive {
+			btnType = "primary"
+		}
+		label := t.label
+		if isActive {
+			label = "▶ " + t.label
+		}
+		actions = append(actions, map[string]any{
+			"tag": "button",
+			"text": map[string]any{
+				"tag":     "plain_text",
+				"content": label,
+			},
+			"type": btnType,
+			"value": map[string]string{
+				"action_data": mustMapToJSON(map[string]string{
+					"action": "settings_tab",
+					"tab":    t.key,
+				}),
+			},
+		})
+	}
+
+	elements = append(elements, map[string]any{
+		"tag":     "action",
+		"layout":  "flow",
+		"actions": actions,
+	})
+
+	return elements
+}
+
+// buildBasicTabContent builds the basic settings tab content.
+func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[string]any {
+	schema := feishuSettingsSchema()
+	var elements []map[string]any
+
+	// Group by category
+	categories := make(map[string][]SettingDefinition)
+	var catOrder []string
+	for _, def := range schema {
+		cat := def.Category
+		if cat == "" {
+			cat = "通用"
+		}
+		if _, exists := categories[cat]; !exists {
+			catOrder = append(catOrder, cat)
+		}
+		categories[cat] = append(categories[cat], def)
+	}
+
+	for _, cat := range catOrder {
+		defs := categories[cat]
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**%s**", cat),
+		})
+
+		for _, def := range defs {
+			currentValue := settings[def.Key]
+			if currentValue == "" {
+				currentValue = def.DefaultValue
+			}
+
+			switch def.Type {
+			case SettingTypeSelect:
+				// Show current value as markdown
+				displayVal := formatCurrentValue(currentValue, def)
+				elements = append(elements, map[string]any{
+					"tag":     "markdown",
+					"content": fmt.Sprintf("- %s：**%s**", def.Label, displayVal),
+				})
+				// Option buttons
+				var actions []map[string]any
+				for _, opt := range def.Options {
+					isActive := opt.Value == currentValue
+					btnType := "default"
+					if isActive {
+						btnType = "primary"
+					}
+					actions = append(actions, map[string]any{
+						"tag": "button",
+						"text": map[string]any{
+							"tag":     "plain_text",
+							"content": opt.Label,
+						},
+						"type": btnType,
+						"value": map[string]string{
+							"action_data": mustMapToJSON(map[string]string{
+								"action": "settings_set",
+								"key":    def.Key,
+								"value":  opt.Value,
+							}),
+						},
+					})
+				}
+				elements = append(elements, map[string]any{
+					"tag":     "action",
+					"layout":  "flow",
+					"actions": actions,
+				})
+
+			case SettingTypeToggle:
+				isOn := currentValue == "true"
+				displayLabel := "❌ 关"
+				if isOn {
+					displayLabel = "✅ 开"
+				}
+				elements = append(elements, map[string]any{
+					"tag":     "markdown",
+					"content": fmt.Sprintf("- %s：**%s**", def.Label, displayLabel),
+				})
+				toggleValue := "true"
+				if isOn {
+					toggleValue = "false"
+				}
+				elements = append(elements, map[string]any{
+					"tag":    "action",
+					"layout": "flow",
+					"actions": []map[string]any{
+						{
+							"tag": "button",
+							"text": map[string]any{
+								"tag":     "plain_text",
+								"content": "切换",
+							},
+							"type": "default",
+							"value": map[string]string{
+								"action_data": mustMapToJSON(map[string]string{
+									"action": "settings_set",
+									"key":    def.Key,
+									"value":  toggleValue,
+								}),
+							},
+						},
+					},
+				})
+			}
+		}
+	}
+
+	return elements
+}
+
+// buildModelTabContent builds the model selection tab content.
+func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID string) []map[string]any {
+	var elements []map[string]any
+
+	var models []string
+	currentModel := ""
+	if f.settingsCallbacks.LLMList != nil {
+		models, currentModel = f.settingsCallbacks.LLMList(senderID)
+	}
+
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": fmt.Sprintf("**当前模型：** `%s`", currentModel),
+	})
+
+	if len(models) == 0 {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": "_暂无可用模型。请先使用 `/set-llm` 配置自定义 LLM。_",
+		})
+		return elements
+	}
+
+	// Model selection buttons (limit to avoid oversized card)
+	maxModels := 10
+	if len(models) > maxModels {
+		models = models[:maxModels]
+	}
+
+	var actions []map[string]any
+	for _, model := range models {
+		isActive := model == currentModel
+		btnType := "default"
+		if isActive {
+			btnType = "primary"
+		}
+		label := model
+		if isActive {
+			label = "✅ " + model
+		}
+		actions = append(actions, map[string]any{
+			"tag": "button",
+			"text": map[string]any{
+				"tag":     "plain_text",
+				"content": label,
+			},
+			"type": btnType,
+			"value": map[string]string{
+				"action_data": mustMapToJSON(map[string]string{
+					"action": "settings_set_model",
+					"model":  model,
+				}),
+			},
+		})
+	}
+
+	elements = append(elements, map[string]any{
+		"tag":     "action",
+		"layout":  "flow",
+		"actions": actions,
+	})
+
+	if len(models) > 0 {
+		elements = append(elements, map[string]any{
+			"tag": "note",
+			"elements": []map[string]any{
+				{
+					"tag":     "plain_text",
+					"content": "💡 点击模型名称即可切换。使用 `/llm` 查看完整 LLM 配置。",
+				},
+			},
+		})
+	}
+
+	return elements
+}
+
+// buildMarketTabContent builds the registry/market browsing tab content.
+func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID string) []map[string]any {
+	var elements []map[string]any
+
+	if f.settingsCallbacks.RegistryBrowse == nil {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": "_Registry 功能未启用_",
+		})
+		return elements
+	}
+
+	// Browse skills
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": "**📦 Skills 市场**",
+	})
+
+	skillEntries, err := f.settingsCallbacks.RegistryBrowse("skill", 10, 0)
+	if err != nil {
+		log.WithError(err).Warn("BuildSettingsCard: failed to browse skills")
+	}
+	if len(skillEntries) == 0 {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": "_暂无公开的 Skill_",
+		})
+	} else {
+		for _, entry := range skillEntries {
+			elements = append(elements, map[string]any{
+				"tag":    "action",
+				"layout": "flow",
+				"actions": []map[string]any{
+					{
+						"tag": "button",
+						"text": map[string]any{
+							"tag":     "plain_text",
+							"content": fmt.Sprintf("📥 %s", entry.Name),
+						},
+						"type": "default",
+						"value": map[string]string{
+							"action_data": mustMapToJSON(map[string]string{
+								"action":     "settings_install",
+								"entry_type": "skill",
+								"entry_id":   fmt.Sprintf("%d", entry.ID),
+							}),
+						},
+					},
+				},
+			})
+		}
+	}
+
+	// Browse agents
+	elements = append(elements, map[string]any{"tag": "hr"})
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": "**🤖 Agents 市场**",
+	})
+
+	agentEntries, err := f.settingsCallbacks.RegistryBrowse("agent", 10, 0)
+	if err != nil {
+		log.WithError(err).Warn("BuildSettingsCard: failed to browse agents")
+	}
+	if len(agentEntries) == 0 {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": "_暂无公开的 Agent_",
+		})
+	} else {
+		for _, entry := range agentEntries {
+			elements = append(elements, map[string]any{
+				"tag":    "action",
+				"layout": "flow",
+				"actions": []map[string]any{
+					{
+						"tag": "button",
+						"text": map[string]any{
+							"tag":     "plain_text",
+							"content": fmt.Sprintf("📥 %s", entry.Name),
+						},
+						"type": "default",
+						"value": map[string]string{
+							"action_data": mustMapToJSON(map[string]string{
+								"action":     "settings_install",
+								"entry_type": "agent",
+								"entry_id":   fmt.Sprintf("%d", entry.ID),
+							}),
+						},
+					},
+				},
+			})
+		}
+	}
+
+	elements = append(elements, map[string]any{
+		"tag": "note",
+		"elements": []map[string]any{
+			{
+				"tag":     "plain_text",
+				"content": "💡 也可以使用 `/browse` 和 `/install` 命令管理市场资源。",
+			},
+		},
+	})
+
+	return elements
+}
+
+// --- Helpers ---
+
+// formatCurrentValue returns the display label for the current setting value.
+func formatCurrentValue(value string, def SettingDefinition) string {
+	for _, opt := range def.Options {
+		if opt.Value == value {
+			return opt.Label
+		}
+	}
+	return value
+}
+
+// mustMapToJSON serializes a flat map[string]string to a compact JSON string.
+func mustMapToJSON(m map[string]string) string {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}
+
+// parseActionData parses a JSON action_data string to map[string]string.
+func parseActionData(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var result map[string]string
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+// parseActionDataFromMap extracts action_data from a raw action data map
+// and parses it to map[string]string.
+func parseActionDataFromMap(actionData map[string]any) map[string]string {
+	raw, ok := actionData["action_data"].(string)
+	if !ok {
+		return nil
+	}
+	return parseActionData(raw)
+}

--- a/channel/feishu_settings_test.go
+++ b/channel/feishu_settings_test.go
@@ -1,0 +1,587 @@
+package channel
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"xbot/bus"
+	"xbot/storage/sqlite"
+)
+
+// newTestFeishuChannel creates a FeishuChannel with minimal config for testing.
+func newTestFeishuChannel() *FeishuChannel {
+	return NewFeishuChannel(FeishuConfig{}, bus.NewMessageBus())
+}
+
+// helper to extract elements slice from a card body
+func getCardElements(card map[string]any) ([]map[string]any, bool) {
+	body, ok := card["body"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	elements, ok := body["elements"].([]map[string]any)
+	return elements, ok
+}
+
+// helper to find action values from card elements
+func collectActionDataFromCard(card map[string]any) []string {
+	var results []string
+	elements, ok := getCardElements(card)
+	if !ok {
+		return results
+	}
+	for _, elem := range elements {
+		actions, ok := elem["actions"].([]map[string]any)
+		if !ok {
+			continue
+		}
+		for _, act := range actions {
+			value, ok := act["value"].(map[string]string)
+			if !ok {
+				continue
+			}
+			if ad := value["action_data"]; ad != "" {
+				results = append(results, ad)
+			}
+		}
+	}
+	return results
+}
+
+// --- parseActionData tests ---
+
+func TestParseActionData(t *testing.T) {
+	t.Run("valid JSON", func(t *testing.T) {
+		result := parseActionData(`{"action":"settings_tab","tab":"model"}`)
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result["action"] != "settings_tab" {
+			t.Errorf("expected action=settings_tab, got %q", result["action"])
+		}
+		if result["tab"] != "model" {
+			t.Errorf("expected tab=model, got %q", result["tab"])
+		}
+	})
+
+	t.Run("empty string returns nil", func(t *testing.T) {
+		result := parseActionData("")
+		if result != nil {
+			t.Errorf("expected nil for empty string, got %v", result)
+		}
+	})
+
+	t.Run("whitespace string returns nil", func(t *testing.T) {
+		result := parseActionData("   ")
+		if result != nil {
+			t.Errorf("expected nil for whitespace string, got %v", result)
+		}
+	})
+
+	t.Run("invalid JSON returns nil", func(t *testing.T) {
+		result := parseActionData("{not valid json")
+		if result != nil {
+			t.Errorf("expected nil for invalid JSON, got %v", result)
+		}
+	})
+
+	t.Run("JSON array returns nil", func(t *testing.T) {
+		result := parseActionData(`[1,2,3]`)
+		if result != nil {
+			t.Errorf("expected nil for JSON array, got %v", result)
+		}
+	})
+}
+
+// --- parseActionDataFromMap tests ---
+
+func TestParseActionDataFromMap(t *testing.T) {
+	t.Run("valid action_data string in map", func(t *testing.T) {
+		m := map[string]any{
+			"action_data": `{"action":"settings_set_model","model":"gpt-4"}`,
+		}
+		result := parseActionDataFromMap(m)
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result["action"] != "settings_set_model" {
+			t.Errorf("expected action=settings_set_model, got %q", result["action"])
+		}
+		if result["model"] != "gpt-4" {
+			t.Errorf("expected model=gpt-4, got %q", result["model"])
+		}
+	})
+
+	t.Run("action_data is not string returns nil", func(t *testing.T) {
+		m := map[string]any{
+			"action_data": 12345,
+		}
+		result := parseActionDataFromMap(m)
+		if result != nil {
+			t.Errorf("expected nil when action_data is not string, got %v", result)
+		}
+	})
+
+	t.Run("missing action_data field returns nil", func(t *testing.T) {
+		m := map[string]any{
+			"other_key": "some_value",
+		}
+		result := parseActionDataFromMap(m)
+		if result != nil {
+			t.Errorf("expected nil when action_data is missing, got %v", result)
+		}
+	})
+
+	t.Run("empty action_data returns nil", func(t *testing.T) {
+		m := map[string]any{
+			"action_data": "",
+		}
+		result := parseActionDataFromMap(m)
+		if result != nil {
+			t.Errorf("expected nil for empty action_data, got %v", result)
+		}
+	})
+}
+
+// --- mustMapToJSON tests ---
+
+func TestMustMapToJSON(t *testing.T) {
+	result := mustMapToJSON(map[string]string{"key": "value", "action": "test"})
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("expected valid JSON, got error: %v", err)
+	}
+	if parsed["key"] != "value" {
+		t.Errorf("expected key=value, got %q", parsed["key"])
+	}
+	if parsed["action"] != "test" {
+		t.Errorf("expected action=test, got %q", parsed["action"])
+	}
+}
+
+// --- BuildSettingsCard tests ---
+
+func TestBuildSettingsCard_BasicTab(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	settingsGetCalled := false
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
+			settingsGetCalled = true
+			return map[string]string{
+				"reply_style":        "concise",
+				"context_mode":       "phase2",
+				"notify_on_complete": "true",
+			}, nil
+		},
+	})
+
+	ctx := context.Background()
+	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "basic")
+	if err != nil {
+		t.Fatalf("BuildSettingsCard returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+
+	// Verify card structure
+	if card["schema"] != "2.0" {
+		t.Errorf("expected schema=2.0, got %v", card["schema"])
+	}
+
+	header, ok := card["header"].(map[string]any)
+	if !ok {
+		t.Fatal("expected header to be a map")
+	}
+	titleMap, ok := header["title"].(map[string]any)
+	if !ok {
+		t.Fatal("expected header.title to be a map")
+	}
+	if titleMap["content"] != "⚙️ 设置" {
+		t.Errorf("expected header title '⚙️ 设置', got %v", titleMap["content"])
+	}
+
+	elements, ok := getCardElements(card)
+	if !ok {
+		t.Fatal("expected body.elements to be a []map[string]any")
+	}
+
+	// Verify that there are markdown elements and button elements
+	hasMarkdown := false
+	hasButton := false
+	hasSettingsAction := false
+	for _, elem := range elements {
+		if elem["tag"] == "markdown" {
+			hasMarkdown = true
+		}
+		if elem["tag"] == "action" {
+			actions, ok := elem["actions"].([]map[string]any)
+			if !ok {
+				continue
+			}
+			for _, act := range actions {
+				if act["tag"] == "button" {
+					hasButton = true
+					value, ok := act["value"].(map[string]string)
+					if !ok {
+						continue
+					}
+					actionData := value["action_data"]
+					if strings.Contains(actionData, "settings_") {
+						hasSettingsAction = true
+					}
+				}
+			}
+		}
+	}
+
+	if !hasMarkdown {
+		t.Error("expected at least one markdown element in card")
+	}
+	if !hasButton {
+		t.Error("expected at least one button element in card")
+	}
+	if !hasSettingsAction {
+		t.Error("expected button value to contain 'settings_' action prefix")
+	}
+	if !settingsGetCalled {
+		t.Error("expected SettingsGet callback to be called")
+	}
+}
+
+func TestBuildSettingsCard_ModelTab(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		LLMList: func(senderID string) ([]string, string) {
+			return []string{"gpt-4", "gpt-3.5-turbo", "claude-3"}, "gpt-4"
+		},
+	})
+
+	ctx := context.Background()
+	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "model")
+	if err != nil {
+		t.Fatalf("BuildSettingsCard returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+
+	elements, ok := getCardElements(card)
+	if !ok {
+		t.Fatal("expected body.elements to be a []map[string]any")
+	}
+
+	// Verify current model info is in card
+	cardJSON, _ := json.Marshal(card)
+	cardStr := string(cardJSON)
+	if !strings.Contains(cardStr, "gpt-4") {
+		t.Error("expected card to contain current model 'gpt-4'")
+	}
+
+	// Verify model selection buttons contain settings_set_model action
+	actionDataList := collectActionDataFromCard(card)
+	hasSetModelAction := false
+	for _, ad := range actionDataList {
+		if strings.Contains(ad, "settings_set_model") {
+			hasSetModelAction = true
+		}
+	}
+	if !hasSetModelAction {
+		t.Error("expected model tab buttons to contain 'settings_set_model' action")
+	}
+
+	// Verify there are markdown elements for model display
+	hasModelMarkdown := false
+	for _, elem := range elements {
+		if elem["tag"] == "markdown" {
+			content, _ := elem["content"].(string)
+			if strings.Contains(content, "gpt-4") {
+				hasModelMarkdown = true
+			}
+		}
+	}
+	if !hasModelMarkdown {
+		t.Error("expected markdown element showing current model")
+	}
+}
+
+// --- HandleSettingsAction tests ---
+
+func TestHandleSettingsAction_TabSwitch(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		LLMList: func(senderID string) ([]string, string) {
+			return []string{"gpt-4", "claude-3"}, "gpt-4"
+		},
+	})
+
+	actionData := map[string]any{
+		"action_data": `{"action":"settings_tab","tab":"model"}`,
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("HandleSettingsAction returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+
+	// Verify the returned card is for the model tab (contains model info)
+	cardJSON, _ := json.Marshal(card)
+	cardStr := string(cardJSON)
+	if !strings.Contains(cardStr, "gpt-4") {
+		t.Error("expected switched card to contain model info")
+	}
+}
+
+func TestHandleSettingsAction_SetValue(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	var setKey, setValue string
+	settingsSetCalled := false
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		SettingsSet: func(channelName, senderID, key, value string) error {
+			settingsSetCalled = true
+			setKey = key
+			setValue = value
+			return nil
+		},
+		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
+			return map[string]string{
+				"reply_style": "concise",
+			}, nil
+		},
+	})
+
+	actionData := map[string]any{
+		"action_data": `{"action":"settings_set","key":"reply_style","value":"detailed"}`,
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("HandleSettingsAction returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card after settings_set action")
+	}
+
+	if !settingsSetCalled {
+		t.Error("expected SettingsSet callback to be called")
+	}
+	if setKey != "reply_style" {
+		t.Errorf("expected key=reply_style, got %q", setKey)
+	}
+	if setValue != "detailed" {
+		t.Errorf("expected value=detailed, got %q", setValue)
+	}
+
+	// Verify returned card is valid (basic tab after set)
+	if card["schema"] != "2.0" {
+		t.Errorf("expected returned card schema=2.0, got %v", card["schema"])
+	}
+}
+
+func TestHandleSettingsAction_SetModel(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	var setModel string
+	llmSetCalled := false
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		LLMSet: func(senderID, model string) error {
+			llmSetCalled = true
+			setModel = model
+			return nil
+		},
+		LLMList: func(senderID string) ([]string, string) {
+			return []string{"gpt-4", "claude-3"}, "gpt-4"
+		},
+	})
+
+	actionData := map[string]any{
+		"action_data": `{"action":"settings_set_model","model":"claude-3"}`,
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("HandleSettingsAction returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card after settings_set_model action")
+	}
+
+	if !llmSetCalled {
+		t.Error("expected LLMSet callback to be called")
+	}
+	if setModel != "claude-3" {
+		t.Errorf("expected model=claude-3, got %q", setModel)
+	}
+}
+
+func TestHandleSettingsAction_Install(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	var installedType string
+	var installedID int64
+	var installedSender string
+	installCalled := false
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
+			return []sqlite.SharedEntry{
+				{ID: 42, Type: "skill", Name: "test-skill"},
+			}, nil
+		},
+		RegistryInstall: func(entryType string, id int64, senderID string) error {
+			installCalled = true
+			installedType = entryType
+			installedID = id
+			installedSender = senderID
+			return nil
+		},
+	})
+
+	actionData := map[string]any{
+		"action_data": `{"action":"settings_install","entry_type":"skill","entry_id":"42"}`,
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("HandleSettingsAction returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card after settings_install action")
+	}
+
+	if !installCalled {
+		t.Error("expected RegistryInstall callback to be called")
+	}
+	if installedType != "skill" {
+		t.Errorf("expected entry_type=skill, got %q", installedType)
+	}
+	if installedID != 42 {
+		t.Errorf("expected entry_id=42, got %d", installedID)
+	}
+	if installedSender != "user1" {
+		t.Errorf("expected senderID=user1, got %q", installedSender)
+	}
+}
+
+func TestHandleSettingsAction_UnknownAction(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	actionData := map[string]any{
+		"action_data": `{"action":"unknown_action"}`,
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err == nil {
+		t.Error("expected error for unknown action")
+	}
+	if card != nil {
+		t.Error("expected nil card for unknown action")
+	}
+}
+
+func TestHandleSettingsAction_MissingActionData(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	actionData := map[string]any{}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err == nil {
+		t.Error("expected error for missing action_data")
+	}
+	if card != nil {
+		t.Error("expected nil card for missing action_data")
+	}
+}
+
+func TestBuildSettingsCard_MarketTab(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
+			return []sqlite.SharedEntry{
+				{ID: 1, Type: "skill", Name: "my-skill"},
+				{ID: 2, Type: "agent", Name: "my-agent"},
+			}, nil
+		},
+	})
+
+	ctx := context.Background()
+	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "market")
+	if err != nil {
+		t.Fatalf("BuildSettingsCard returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+
+	cardJSON, _ := json.Marshal(card)
+	cardStr := string(cardJSON)
+
+	if !strings.Contains(cardStr, "my-skill") {
+		t.Error("expected market tab to contain skill entry 'my-skill'")
+	}
+	if !strings.Contains(cardStr, "my-agent") {
+		t.Error("expected market tab to contain agent entry 'my-agent'")
+	}
+}
+
+func TestBuildSettingsCard_DefaultTab(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	})
+
+	// Pass empty tab — should default to "basic"
+	ctx := context.Background()
+	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "")
+	if err != nil {
+		t.Fatalf("BuildSettingsCard returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+
+	// Basic tab should have "设置面板" title
+	cardJSON, _ := json.Marshal(card)
+	cardStr := string(cardJSON)
+	if !strings.Contains(cardStr, "设置面板") {
+		t.Error("expected default tab card to contain '设置面板'")
+	}
+}
+
+func TestBuildSettingsCard_NilCallbacks(t *testing.T) {
+	f := newTestFeishuChannel()
+	// No callbacks set — should not panic
+
+	ctx := context.Background()
+	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "basic")
+	if err != nil {
+		t.Fatalf("BuildSettingsCard returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card even without callbacks")
+	}
+	if card["schema"] != "2.0" {
+		t.Errorf("expected schema=2.0, got %v", card["schema"])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -223,6 +223,29 @@ func main() {
 	if feishuCh != nil {
 		feishuCh.SetCardBuilder(agentLoop.GetCardBuilder())
 
+		// 注入设置卡片回调（让飞书渠道能访问 Agent 的 LLM/Registry/Settings 功能）
+		feishuCh.SetSettingsCallbacks(channel.SettingsCallbacks{
+			LLMList: func(senderID string) ([]string, string) {
+				llmClient, currentModel, _, _ := agentLoop.LLMFactory().GetLLM(senderID)
+				return llmClient.ListModels(), currentModel
+			},
+			LLMSet: func(senderID, model string) error {
+				return agentLoop.SetUserModel(senderID, model)
+			},
+			RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
+				return agentLoop.RegistryManager().Browse(entryType, limit, offset)
+			},
+			RegistryInstall: func(entryType string, id int64, senderID string) error {
+				return agentLoop.RegistryManager().Install(entryType, id, senderID)
+			},
+			SettingsGet: func(channelName, senderID string) (map[string]string, error) {
+				return agentLoop.SettingsService().GetSettings(channelName, senderID)
+			},
+			SettingsSet: func(channelName, senderID, key, value string) error {
+				return agentLoop.SettingsService().SetSetting(channelName, senderID, key, value)
+			},
+		})
+
 		// 注入飞书渠道特化 prompt 提供者
 		agentLoop.SetChannelPromptProviders(&feishuPromptAdapter{ch: feishuCh})
 	}

--- a/tools/feishu_mcp/wiki.go
+++ b/tools/feishu_mcp/wiki.go
@@ -507,7 +507,7 @@ func (t *SendCardTool) Execute(ctx *tools.ToolContext, input string) (*tools.Too
 		chatID = ctx.ChatID
 	}
 
-	if err := ctx.SendFunc(ctx.Channel, chatID, "__FEISHU_CARD__:"+args.Card); err != nil {
+	if err := ctx.SendFunc(ctx.Channel, chatID, "__FEISHU_CARD__::"+args.Card); err != nil {
 		return nil, fmt.Errorf("send card: %w", err)
 	}
 

--- a/tools/oauth.go
+++ b/tools/oauth.go
@@ -78,7 +78,7 @@ func (t *OAuthTool) Execute(ctx *ToolContext, input string) (*ToolResult, error)
 
 	// Build authorization card with proper prefix
 	cardJSON := t.buildAuthCard(args.Provider, args.Reason, authURL, state)
-	cardContent := "__FEISHU_CARD__:" + cardJSON
+	cardContent := "__FEISHU_CARD__::" + cardJSON
 
 	// Send card
 	if err := ctx.SendFunc(ctx.Channel, ctx.ChatID, cardContent); err != nil {


### PR DESCRIPTION
## 飞书交互式 Settings 卡片

### 概述
重构飞书渠道 Settings 为交互式卡片，支持按钮/下拉切换设置项，替代原有纯文本交互。

### 功能
| Tab | 内容 | 交互方式 |
|-----|------|---------|
| 🎯 基础设置 | 回复风格、完成通知、上下文模式 | 按钮组 |
| 🤖 模型选择 | LLM 模型列表 | 按钮列表，点击切换 |
| 📦 市场 | Registry 中的 skill/agent | 列表 + 安装按钮 |

### 交互机制
- 所有按钮点击 → `settings_` 前缀回调拦截
- 执行修改后 **patch 原消息**（不发新消息）
- 支持 Tab 切换

### 改动
| 文件 | 说明 |
|------|------|
| `channel/feishu_settings.go` | **新建** — 卡片构建 + 回调处理 |
| `channel/feishu_settings_test.go` | **新建** — 13 个测试用例 |
| `channel/feishu.go` | SettingsCallbacks + 回调拦截 |
| `agent/command_builtin.go` | 飞书渠道走卡片路径 |
| `agent/agent.go` | channelFinder accessor |
| `main.go` | 回调注入 |
| `tools/oauth.go` | `__FEISHU_CARD__::` 双冒号修复 |
| `tools/feishu_mcp/wiki.go` | 同上 |

### 验证
- ✅ gofmt / go vet / golangci-lint v2.10.1 / go test -race 全量通过