### PR TITLE
fix: offload_recall 分页 + settings 卡片 V2 兼容

### DIFF
--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -185,11 +185,7 @@ func buildTabButtons(currentTab string) []map[string]any {
 		})
 	}
 
-	elements = append(elements, map[string]any{
-		"tag":     "action",
-		"layout":  "flow",
-		"actions": actions,
-	})
+	elements = append(elements, wrapButtonsAsColumnSet(actions))
 
 	return elements
 }
@@ -258,11 +254,7 @@ func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[s
 						},
 					})
 				}
-				elements = append(elements, map[string]any{
-					"tag":     "action",
-					"layout":  "flow",
-					"actions": actions,
-				})
+				elements = append(elements, wrapButtonsAsColumnSet(actions))
 
 			case SettingTypeToggle:
 				isOn := currentValue == "true"
@@ -278,27 +270,23 @@ func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[s
 				if isOn {
 					toggleValue = "false"
 				}
-				elements = append(elements, map[string]any{
-					"tag":    "action",
-					"layout": "flow",
-					"actions": []map[string]any{
-						{
-							"tag": "button",
-							"text": map[string]any{
-								"tag":     "plain_text",
-								"content": "切换",
-							},
-							"type": "default",
-							"value": map[string]string{
-								"action_data": mustMapToJSON(map[string]string{
-									"action": "settings_set",
-									"key":    def.Key,
-									"value":  toggleValue,
-								}),
-							},
+				elements = append(elements, wrapButtonsAsColumnSet([]map[string]any{
+					{
+						"tag": "button",
+						"text": map[string]any{
+							"tag":     "plain_text",
+							"content": "切换",
+						},
+						"type": "default",
+						"value": map[string]string{
+							"action_data": mustMapToJSON(map[string]string{
+								"action": "settings_set",
+								"key":    def.Key,
+								"value":  toggleValue,
+							}),
 						},
 					},
-				})
+				}))
 			}
 		}
 	}
@@ -362,11 +350,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		})
 	}
 
-	elements = append(elements, map[string]any{
-		"tag":     "action",
-		"layout":  "flow",
-		"actions": actions,
-	})
+	elements = append(elements, wrapButtonsAsColumnSet(actions))
 
 	if len(models) > 0 {
 		elements = append(elements, map[string]any{
@@ -412,27 +396,23 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 		})
 	} else {
 		for _, entry := range skillEntries {
-			elements = append(elements, map[string]any{
-				"tag":    "action",
-				"layout": "flow",
-				"actions": []map[string]any{
-					{
-						"tag": "button",
-						"text": map[string]any{
-							"tag":     "plain_text",
-							"content": fmt.Sprintf("📥 %s", entry.Name),
-						},
-						"type": "default",
-						"value": map[string]string{
-							"action_data": mustMapToJSON(map[string]string{
-								"action":     "settings_install",
-								"entry_type": "skill",
-								"entry_id":   fmt.Sprintf("%d", entry.ID),
-							}),
-						},
+			elements = append(elements, wrapButtonsAsColumnSet([]map[string]any{
+				{
+					"tag": "button",
+					"text": map[string]any{
+						"tag":     "plain_text",
+						"content": fmt.Sprintf("📥 %s", entry.Name),
+					},
+					"type": "default",
+					"value": map[string]string{
+						"action_data": mustMapToJSON(map[string]string{
+							"action":     "settings_install",
+							"entry_type": "skill",
+							"entry_id":   fmt.Sprintf("%d", entry.ID),
+						}),
 					},
 				},
-			})
+			}))
 		}
 	}
 
@@ -454,27 +434,23 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 		})
 	} else {
 		for _, entry := range agentEntries {
-			elements = append(elements, map[string]any{
-				"tag":    "action",
-				"layout": "flow",
-				"actions": []map[string]any{
-					{
-						"tag": "button",
-						"text": map[string]any{
-							"tag":     "plain_text",
-							"content": fmt.Sprintf("📥 %s", entry.Name),
-						},
-						"type": "default",
-						"value": map[string]string{
-							"action_data": mustMapToJSON(map[string]string{
-								"action":     "settings_install",
-								"entry_type": "agent",
-								"entry_id":   fmt.Sprintf("%d", entry.ID),
-							}),
-						},
+			elements = append(elements, wrapButtonsAsColumnSet([]map[string]any{
+				{
+					"tag": "button",
+					"text": map[string]any{
+						"tag":     "plain_text",
+						"content": fmt.Sprintf("📥 %s", entry.Name),
+					},
+					"type": "default",
+					"value": map[string]string{
+						"action_data": mustMapToJSON(map[string]string{
+							"action":     "settings_install",
+							"entry_type": "agent",
+							"entry_id":   fmt.Sprintf("%d", entry.ID),
+						}),
 					},
 				},
-			})
+			}))
 		}
 	}
 
@@ -492,6 +468,30 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 }
 
 // --- Helpers ---
+
+// wrapButtonsAsColumnSet wraps a slice of button elements in a Schema V2-compatible
+// column_set > column > interactive_container structure, replacing the deprecated
+// V1 "action" tag.
+func wrapButtonsAsColumnSet(buttons []map[string]any) map[string]any {
+	return map[string]any{
+		"tag":                "column_set",
+		"flex_mode":          "none",
+		"horizontal_spacing": "default",
+		"columns": []map[string]any{
+			{
+				"tag":    "column",
+				"width":  "weighted",
+				"weight": 1,
+				"elements": []map[string]any{
+					{
+						"tag":      "interactive_container",
+						"elements": buttons,
+					},
+				},
+			},
+		},
+	}
+}
 
 // formatCurrentValue returns the display label for the current setting value.
 func formatCurrentValue(value string, def SettingDefinition) string {

--- a/channel/feishu_settings_test.go
+++ b/channel/feishu_settings_test.go
@@ -25,29 +25,43 @@ func getCardElements(card map[string]any) ([]map[string]any, bool) {
 	return elements, ok
 }
 
-// helper to find action values from card elements
+// helper to find action values from card elements (supports V1 "action" and V2 "column_set" nesting)
 func collectActionDataFromCard(card map[string]any) []string {
 	var results []string
 	elements, ok := getCardElements(card)
 	if !ok {
 		return results
 	}
+	collectButtonsRecursive(elements, &results)
+	return results
+}
+
+// collectButtonsRecursive searches for buttons at any nesting depth within card elements.
+// Handles both V1 (action > button) and V2 (column_set > column > interactive_container > button).
+func collectButtonsRecursive(elements []map[string]any, results *[]string) {
 	for _, elem := range elements {
-		actions, ok := elem["actions"].([]map[string]any)
-		if !ok {
-			continue
-		}
-		for _, act := range actions {
-			value, ok := act["value"].(map[string]string)
-			if !ok {
-				continue
+		switch elem["tag"] {
+		case "action":
+			// V1: action > button[]
+			if actions, ok := elem["actions"].([]map[string]any); ok {
+				collectButtonsRecursive(actions, results)
 			}
-			if ad := value["action_data"]; ad != "" {
-				results = append(results, ad)
+		case "button":
+			if value, ok := elem["value"].(map[string]string); ok {
+				if ad := value["action_data"]; ad != "" {
+					*results = append(*results, ad)
+				}
+			}
+		case "column_set":
+			if columns, ok := elem["columns"].([]map[string]any); ok {
+				collectButtonsRecursive(columns, results)
+			}
+		case "column", "interactive_container", "form", "collapsible_panel":
+			if children, ok := elem["elements"].([]map[string]any); ok {
+				collectButtonsRecursive(children, results)
 			}
 		}
 	}
-	return results
 }
 
 // --- parseActionData tests ---
@@ -211,30 +225,17 @@ func TestBuildSettingsCard_BasicTab(t *testing.T) {
 
 	// Verify that there are markdown elements and button elements
 	hasMarkdown := false
-	hasButton := false
+	actionDataList := collectActionDataFromCard(card)
+	hasButton := len(actionDataList) > 0
 	hasSettingsAction := false
 	for _, elem := range elements {
 		if elem["tag"] == "markdown" {
 			hasMarkdown = true
 		}
-		if elem["tag"] == "action" {
-			actions, ok := elem["actions"].([]map[string]any)
-			if !ok {
-				continue
-			}
-			for _, act := range actions {
-				if act["tag"] == "button" {
-					hasButton = true
-					value, ok := act["value"].(map[string]string)
-					if !ok {
-						continue
-					}
-					actionData := value["action_data"]
-					if strings.Contains(actionData, "settings_") {
-						hasSettingsAction = true
-					}
-				}
-			}
+	}
+	for _, ad := range actionDataList {
+		if strings.Contains(ad, "settings_") {
+			hasSettingsAction = true
 		}
 	}
 

--- a/tools/offload_recall.go
+++ b/tools/offload_recall.go
@@ -12,27 +12,38 @@ type OffloadRecallStore interface {
 	Recall(sessionKey, id string) (string, error)
 }
 
-// OffloadRecallTool 召回已 offload 的工具结果完整内容。
+const (
+	offloadDefaultLimit  = 8000
+	offloadMaxLimit      = 16000
+	offloadDefaultOffset = 0
+)
+
+// OffloadRecallTool 召回已 offload 的工具结果完整内容，支持分页读取。
 type OffloadRecallTool struct {
 	Store OffloadRecallStore
 }
 
 // offloadRecallParams 是 offload_recall 工具的参数。
 type offloadRecallParams struct {
-	ID string `json:"id"`
+	ID     string `json:"id"`
+	Offset int    `json:"offset,omitempty"` // 起始位置（rune 偏移），默认 0
+	Limit  int    `json:"limit,omitempty"`  // 最大返回字符数（rune），默认 8000，最大 16000
 }
 
 func (t *OffloadRecallTool) Name() string { return "offload_recall" }
 
 func (t *OffloadRecallTool) Description() string {
-	return `Recall the full content of a previously offloaded tool result.
+	return `Retrieve the full content of a previously offloaded tool result.
 Use the offload ID (from 📂 markers in tool results) to retrieve the complete data.
-This is useful when you need to see the full output of a large tool result that was summarized.`
+Supports pagination via offset and limit parameters for large content.
+Default: offset=0, limit=8000. Max limit: 16000.`
 }
 
 func (t *OffloadRecallTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
 		{Name: "id", Type: "string", Description: "Offload ID (obtained from 📂 markers, e.g. ol_1234abcd)", Required: true},
+		{Name: "offset", Type: "integer", Description: "Rune offset to start reading from (default: 0)", Required: false},
+		{Name: "limit", Type: "integer", Description: "Max runes to return (default: 8000, max: 16000)", Required: false},
 	}
 }
 
@@ -49,6 +60,17 @@ func (t *OffloadRecallTool) Execute(ctx *ToolContext, args string) (*ToolResult,
 		return nil, fmt.Errorf("missing required parameter: id")
 	}
 
+	// 默认值填充
+	if params.Offset < 0 {
+		params.Offset = offloadDefaultOffset
+	}
+	if params.Limit <= 0 {
+		params.Limit = offloadDefaultLimit
+	}
+	if params.Limit > offloadMaxLimit {
+		params.Limit = offloadMaxLimit
+	}
+
 	// 构建 sessionKey
 	sessionKey := ctx.Channel + ":" + ctx.ChatID
 	if sessionKey == ":" {
@@ -60,11 +82,36 @@ func (t *OffloadRecallTool) Execute(ctx *ToolContext, args string) (*ToolResult,
 		return nil, fmt.Errorf("recall failed: %w", err)
 	}
 
-	// 截断到 8000 字符防止上下文爆炸（使用 []rune 避免 UTF-8 多字节截断）
-	const maxLen = 8000
-	if len([]rune(content)) > maxLen {
-		content = string([]rune(content)[:maxLen]) + "\n\n... (truncated, original " + fmt.Sprintf("%d", len(content)) + " bytes)"
+	runes := []rune(content)
+	totalRunes := len(runes)
+	totalBytes := len(content)
+
+	// offset 超出范围
+	if params.Offset >= totalRunes {
+		return NewResult(fmt.Sprintf("⚠️ offset %d exceeds total length %d runes (the content is fully read)", params.Offset, totalRunes)), nil
 	}
 
-	return NewResult(content), nil
+	end := params.Offset + params.Limit
+	hasMore := end < totalRunes
+	if end > totalRunes {
+		end = totalRunes
+	}
+
+	sliced := string(runes[params.Offset:end])
+
+	// 分页信息头
+	header := fmt.Sprintf("📂 [%s] bytes:%d runes:%d-%d/%d", params.ID, totalBytes, params.Offset, end, totalRunes)
+	if hasMore {
+		header += fmt.Sprintf(" | ▶️ Use offset=%d to read next page", end)
+	}
+	if params.Offset > 0 {
+		header += fmt.Sprintf(" | ◀️ offset=%d for previous", params.Offset)
+	}
+
+	result := header + "\n" + sliced
+	if hasMore {
+		result += "\n\n... (more content below, use offset=" + fmt.Sprintf("%d", end) + " to continue)"
+	}
+
+	return NewResult(result), nil
 }

--- a/tools/offload_recall_test.go
+++ b/tools/offload_recall_test.go
@@ -54,8 +54,8 @@ func TestOffloadRecallTool_Description(t *testing.T) {
 func TestOffloadRecallTool_Parameters(t *testing.T) {
 	tool := &OffloadRecallTool{}
 	params := tool.Parameters()
-	if len(params) != 1 {
-		t.Fatalf("expected 1 parameter, got %d", len(params))
+	if len(params) != 3 {
+		t.Fatalf("expected 3 parameters, got %d", len(params))
 	}
 	if params[0].Name != "id" {
 		t.Errorf("expected param name 'id', got %q", params[0].Name)
@@ -133,27 +133,100 @@ func TestOffloadRecallTool_Execute_NotFound(t *testing.T) {
 	}
 }
 
-func TestOffloadRecallTool_Execute_Truncation(t *testing.T) {
+func TestOffloadRecallTool_Execute_DefaultPagination(t *testing.T) {
 	store := newMockOffloadStore()
-	// Content larger than 8000 chars
 	largeContent := strings.Repeat("a", 10000)
-	store.store("cli:direct", "ol_truncate", largeContent)
+	store.store("cli:direct", "ol_page", largeContent)
 
 	tool := &OffloadRecallTool{Store: store}
-	ctx := &ToolContext{
-		Channel: "cli",
-		ChatID:  "direct",
-	}
+	ctx := &ToolContext{Channel: "cli", ChatID: "direct"}
 
-	result, err := tool.Execute(ctx, `{"id":"ol_truncate"}`)
+	// 默认 offset=0, limit=8000 → 应返回第一页，且有分页提示
+	result, err := tool.Execute(ctx, `{"id":"ol_page"}`)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if len(result.Summary) > 8100 { // 8000 + some overhead for truncation message
-		t.Errorf("result should be truncated, got %d bytes", len(result.Summary))
+	if !strings.Contains(result.Summary, "runes:0-8000/10000") {
+		t.Errorf("should show pagination range, got: %s", result.Summary)
 	}
-	if !strings.Contains(result.Summary, "truncated") {
-		t.Error("result should indicate truncation")
+	if !strings.Contains(result.Summary, "offset=8000") {
+		t.Error("should suggest next page offset")
+	}
+}
+
+func TestOffloadRecallTool_Execute_SecondPage(t *testing.T) {
+	store := newMockOffloadStore()
+	largeContent := strings.Repeat("a", 10000)
+	store.store("cli:direct", "ol_page2", largeContent)
+
+	tool := &OffloadRecallTool{Store: store}
+	ctx := &ToolContext{Channel: "cli", ChatID: "direct"}
+
+	// offset=8000 → 应返回剩余内容
+	result, err := tool.Execute(ctx, `{"id":"ol_page2","offset":8000}`)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !strings.Contains(result.Summary, "runes:8000-10000/10000") {
+		t.Errorf("should show second page range, got: %s", result.Summary)
+	}
+	if strings.Contains(result.Summary, "more content") {
+		t.Error("last page should not have 'more content' hint")
+	}
+	if !strings.Contains(result.Summary, "previous") {
+		t.Error("should have previous page hint when offset > 0")
+	}
+}
+
+func TestOffloadRecallTool_Execute_OverrunOffset(t *testing.T) {
+	store := newMockOffloadStore()
+	store.store("cli:direct", "ol_short", "hello")
+
+	tool := &OffloadRecallTool{Store: store}
+	ctx := &ToolContext{Channel: "cli", ChatID: "direct"}
+
+	result, err := tool.Execute(ctx, `{"id":"ol_short","offset":100}`)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !strings.Contains(result.Summary, "exceeds total length") {
+		t.Errorf("should warn about overrun offset, got: %s", result.Summary)
+	}
+}
+
+func TestOffloadRecallTool_Execute_CustomLimit(t *testing.T) {
+	store := newMockOffloadStore()
+	content := strings.Repeat("x", 5000)
+	store.store("cli:direct", "ol_limit", content)
+
+	tool := &OffloadRecallTool{Store: store}
+	ctx := &ToolContext{Channel: "cli", ChatID: "direct"}
+
+	// limit=1000 → 只返回 1000 个字符
+	result, err := tool.Execute(ctx, `{"id":"ol_limit","limit":1000}`)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !strings.Contains(result.Summary, "runes:0-1000/5000") {
+		t.Errorf("should respect custom limit, got: %s", result.Summary)
+	}
+}
+
+func TestOffloadRecallTool_Execute_LimitClamped(t *testing.T) {
+	store := newMockOffloadStore()
+	content := strings.Repeat("z", 20000)
+	store.store("cli:direct", "ol_clamp", content)
+
+	tool := &OffloadRecallTool{Store: store}
+	ctx := &ToolContext{Channel: "cli", ChatID: "direct"}
+
+	// limit=99999 → 应被限制到 16000
+	result, err := tool.Execute(ctx, `{"id":"ol_clamp","limit":99999}`)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !strings.Contains(result.Summary, "runes:0-16000/20000") {
+		t.Errorf("should clamp limit to 16000, got: %s", result.Summary)
 	}
 }
 
@@ -171,7 +244,7 @@ func TestOffloadRecallTool_Execute_SessionKeyFromContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if result.Summary != "content for custom session" {
-		t.Errorf("unexpected result: %s", result.Summary)
+	if !strings.Contains(result.Summary, "content for custom session") {
+		t.Errorf("result should contain stored content, got: %s", result.Summary)
 	}
 }


### PR DESCRIPTION
## 改动内容

### 1. offload_recall 分页支持
- 移除硬截断逻辑，新增 `offset` + `limit` 分页参数
- 默认 `limit=8000`，上限 16000，支持 rune 精确偏移
- 响应包含分页提示，LLM 可自动翻页，不再需要 shell 绕行

### 2. 飞书 Settings 卡片 V2 兼容
- 修复卡片 Schema V2 报错 `unsupported tag action`
- 新增 `wrapButtonsAsColumnSet()` 辅助函数
- 按钮包裹为 V2 兼容结构：`column_set > column > interactive_container > [buttons]`

## 文件改动
- `tools/offload_recall.go` — 分页逻辑
- `tools/offload_recall_test.go` — 5 个新分页测试
- `channel/feishu_settings.go` — V2 兼容修复
- `channel/feishu_settings_test.go` — 适配新结构

## 验证
- ✅ gofmt / go vet / golangci-lint / go test -race 全量通过