### PR TITLE
refactor: update Feishu settings card for V2 compatibility

### DIFF
--- a/agent/settings_test.go
+++ b/agent/settings_test.go
@@ -20,7 +20,7 @@ func TestSettingsServiceGetSettings(t *testing.T) {
 	svc := NewSettingsService(store)
 
 	// Set some values
-	if err := svc.SetSetting("feishu", "user1", "reply_style", "concise"); err != nil {
+	if err := svc.SetSetting("feishu", "user1", "context_mode", "phase2"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
 
@@ -29,8 +29,8 @@ func TestSettingsServiceGetSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if settings["reply_style"] != "concise" {
-		t.Errorf("expected 'concise', got %q", settings["reply_style"])
+	if settings["context_mode"] != "phase2" {
+		t.Errorf("expected 'phase2', got %q", settings["context_mode"])
 	}
 }
 

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -1028,9 +1028,15 @@ func (f *FeishuChannel) onCardAction(ctx context.Context, event *callback.CardAc
 		messageID = event.Event.Context.OpenMessageID
 	}
 
-	// 拦截 settings 卡片按钮点击（在 CardBuilder 路由之前）
+	// 拦截 settings 卡片交互（按钮点击和下拉选择，在 CardBuilder 路由之前）
 	if parsed := parseActionDataFromMap(actionData); parsed != nil {
 		if actionName := parsed["action"]; strings.HasPrefix(actionName, settingsCardActionPrefix) {
+			if action.Option != "" {
+				if actionData == nil {
+					actionData = make(map[string]any)
+				}
+				actionData["selected_option"] = action.Option
+			}
 			return f.handleSettingsCardAction(ctx, actionData, chatID, senderID, messageID)
 		}
 	}
@@ -1052,8 +1058,8 @@ func (f *FeishuChannel) onCardAction(ctx context.Context, event *callback.CardAc
 	return f.handleCardBuilderAction(cardID, actionData, action, chatID, senderID, messageID, requestID)
 }
 
-// handleSettingsCardAction handles settings card button clicks.
-// It processes the action, rebuilds the card, and patches the original message.
+// handleSettingsCardAction handles settings card interactions (buttons & selects).
+// Returns the updated card directly in the callback response for instant UI refresh.
 func (f *FeishuChannel) handleSettingsCardAction(ctx context.Context, actionData map[string]any, chatID, senderID, messageID string) (*callback.CardActionTriggerResponse, error) {
 	updatedCard, err := f.HandleSettingsAction(ctx, actionData, senderID, chatID, messageID)
 	if err != nil {
@@ -1069,33 +1075,10 @@ func (f *FeishuChannel) handleSettingsCardAction(ctx context.Context, actionData
 		}, nil
 	}
 
-	// Patch the updated card back to the original message
-	if messageID != "" {
-		cardJSON, err := json.Marshal(updatedCard)
-		if err != nil {
-			log.WithError(err).Warn("Failed to marshal settings card")
-			return &callback.CardActionTriggerResponse{
-				Toast: &callback.Toast{
-					Type:    "error",
-					Content: "卡片序列化失败",
-				},
-			}, nil
-		}
-		if err := f.patchMessage(messageID, cardJSON); err != nil {
-			log.WithError(err).WithField("message_id", messageID).Warn("Failed to patch settings card")
-			return &callback.CardActionTriggerResponse{
-				Toast: &callback.Toast{
-					Type:    "error",
-					Content: "卡片更新失败",
-				},
-			}, nil
-		}
-	}
-
 	return &callback.CardActionTriggerResponse{
-		Toast: &callback.Toast{
-			Type:    "success",
-			Content: "已更新",
+		Card: &callback.Card{
+			Type: "raw",
+			Data: updatedCard,
 		},
 	}, nil
 }
@@ -1830,19 +1813,6 @@ func limitMarkdownTables(content string, maxTables int) string {
 // feishuSettingsSchema returns the settings definitions for Feishu channel.
 func feishuSettingsSchema() []SettingDefinition {
 	return []SettingDefinition{
-		{
-			Key:         "reply_style",
-			Label:       "回复风格",
-			Description: "控制机器人的回复风格",
-			Type:        SettingTypeSelect,
-			Category:    "对话",
-			Options: []SettingOption{
-				{Label: "简洁", Value: "concise"},
-				{Label: "详细", Value: "detailed"},
-				{Label: "技术", Value: "technical"},
-			},
-			DefaultValue: "detailed",
-		},
 		{
 			Key:         "context_mode",
 			Label:       "上下文模式",

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -33,20 +33,9 @@ func (f *FeishuChannel) BuildSettingsCard(ctx context.Context, senderID, chatID,
 		}
 	}
 
-	// Build header elements
-	elements := []map[string]any{
-		{
-			"tag":     "markdown",
-			"content": "**⚙️ 设置面板**",
-		},
-		{"tag": "hr"},
-	}
-
-	// Tab buttons
-	elements = append(elements, buildTabButtons(tab)...)
+	elements := buildTabButtons(tab)
 	elements = append(elements, map[string]any{"tag": "hr"})
 
-	// Tab content
 	switch tab {
 	case "basic":
 		elements = append(elements, f.buildBasicTabContent(settings)...)
@@ -67,7 +56,7 @@ func (f *FeishuChannel) BuildSettingsCard(ctx context.Context, senderID, chatID,
 				"tag":     "plain_text",
 				"content": "⚙️ 设置",
 			},
-			"template": "blue",
+			"template": "indigo",
 		},
 		"body": map[string]any{
 			"elements": elements,
@@ -78,9 +67,8 @@ func (f *FeishuChannel) BuildSettingsCard(ctx context.Context, senderID, chatID,
 }
 
 // HandleSettingsAction processes settings card callback actions.
-// It returns the updated card JSON that should be patched back to the message.
+// It returns the updated card JSON that should be returned in the callback response.
 func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map[string]any, senderID, chatID, messageID string) (map[string]any, error) {
-	// Extract action_data JSON string
 	actionDataJSON, _ := actionData["action_data"].(string)
 	if actionDataJSON == "" {
 		return nil, fmt.Errorf("missing action_data")
@@ -100,6 +88,11 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 	case "settings_set":
 		key := parsed["key"]
 		value := parsed["value"]
+		if value == "" {
+			if opt, ok := actionData["selected_option"].(string); ok {
+				value = opt
+			}
+		}
 		if key == "" {
 			return nil, fmt.Errorf("missing key in settings_set action")
 		}
@@ -112,6 +105,11 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 
 	case "settings_set_model":
 		model := parsed["model"]
+		if model == "" {
+			if opt, ok := actionData["selected_option"].(string); ok {
+				model = opt
+			}
+		}
 		if model == "" {
 			return nil, fmt.Errorf("missing model in settings_set_model action")
 		}
@@ -146,7 +144,7 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 
 // --- Tab content builders ---
 
-// buildTabButtons creates the three tab switching buttons.
+// buildTabButtons creates the tab switching buttons in a horizontal layout.
 func buildTabButtons(currentTab string) []map[string]any {
 	tabs := []struct {
 		key   string
@@ -157,23 +155,18 @@ func buildTabButtons(currentTab string) []map[string]any {
 		{"market", "📦 市场"},
 	}
 
-	var elements []map[string]any
-	var actions []map[string]any
+	var buttons []map[string]any
 	for _, t := range tabs {
 		isActive := t.key == currentTab
 		btnType := "default"
 		if isActive {
 			btnType = "primary"
 		}
-		label := t.label
-		if isActive {
-			label = "▶ " + t.label
-		}
-		actions = append(actions, map[string]any{
+		buttons = append(buttons, map[string]any{
 			"tag": "button",
 			"text": map[string]any{
 				"tag":     "plain_text",
-				"content": label,
+				"content": t.label,
 			},
 			"type": btnType,
 			"value": map[string]string{
@@ -185,17 +178,14 @@ func buildTabButtons(currentTab string) []map[string]any {
 		})
 	}
 
-	elements = append(elements, wrapButtonsAsColumnSet(actions))
-
-	return elements
+	return []map[string]any{wrapButtonsInColumns(buttons)}
 }
 
-// buildBasicTabContent builds the basic settings tab content.
+// buildBasicTabContent builds the basic settings tab with select dropdowns and toggles.
 func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[string]any {
 	schema := feishuSettingsSchema()
 	var elements []map[string]any
 
-	// Group by category
 	categories := make(map[string][]SettingDefinition)
 	var catOrder []string
 	for _, def := range schema {
@@ -224,60 +214,33 @@ func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[s
 
 			switch def.Type {
 			case SettingTypeSelect:
-				// Show current value as markdown
-				displayVal := formatCurrentValue(currentValue, def)
-				elements = append(elements, map[string]any{
-					"tag":     "markdown",
-					"content": fmt.Sprintf("- %s：**%s**", def.Label, displayVal),
-				})
-				// Option buttons
-				var actions []map[string]any
-				for _, opt := range def.Options {
-					isActive := opt.Value == currentValue
-					btnType := "default"
-					if isActive {
-						btnType = "primary"
-					}
-					actions = append(actions, map[string]any{
-						"tag": "button",
-						"text": map[string]any{
-							"tag":     "plain_text",
-							"content": opt.Label,
-						},
-						"type": btnType,
-						"value": map[string]string{
-							"action_data": mustMapToJSON(map[string]string{
-								"action": "settings_set",
-								"key":    def.Key,
-								"value":  opt.Value,
-							}),
-						},
-					})
-				}
-				elements = append(elements, wrapButtonsAsColumnSet(actions))
+				elements = append(elements, buildSelectSetting(def, currentValue))
 
 			case SettingTypeToggle:
 				isOn := currentValue == "true"
-				displayLabel := "❌ 关"
-				if isOn {
-					displayLabel = "✅ 开"
-				}
-				elements = append(elements, map[string]any{
-					"tag":     "markdown",
-					"content": fmt.Sprintf("- %s：**%s**", def.Label, displayLabel),
-				})
 				toggleValue := "true"
 				if isOn {
 					toggleValue = "false"
 				}
-				elements = append(elements, wrapButtonsAsColumnSet([]map[string]any{
-					{
+
+				statusIcon := "🔴"
+				statusText := "关闭"
+				if isOn {
+					statusIcon = "🟢"
+					statusText = "开启"
+				}
+
+				elements = append(elements, buildSettingRow(
+					fmt.Sprintf("%s %s", def.Label, def.Description),
+					fmt.Sprintf("%s %s", statusIcon, statusText),
+					map[string]any{
 						"tag": "button",
 						"text": map[string]any{
 							"tag":     "plain_text",
 							"content": "切换",
 						},
 						"type": "default",
+						"size": "small",
 						"value": map[string]string{
 							"action_data": mustMapToJSON(map[string]string{
 								"action": "settings_set",
@@ -286,7 +249,7 @@ func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[s
 							}),
 						},
 					},
-				}))
+				))
 			}
 		}
 	}
@@ -294,7 +257,7 @@ func (f *FeishuChannel) buildBasicTabContent(settings map[string]string) []map[s
 	return elements
 }
 
-// buildModelTabContent builds the model selection tab content.
+// buildModelTabContent builds the model selection tab with a dropdown.
 func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID string) []map[string]any {
 	var elements []map[string]any
 
@@ -304,70 +267,57 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		models, currentModel = f.settingsCallbacks.LLMList(senderID)
 	}
 
-	elements = append(elements, map[string]any{
-		"tag":     "markdown",
-		"content": fmt.Sprintf("**当前模型：** `%s`", currentModel),
-	})
-
 	if len(models) == 0 {
 		elements = append(elements, map[string]any{
 			"tag":     "markdown",
-			"content": "_暂无可用模型。请先使用 `/set-llm` 配置自定义 LLM。_",
+			"content": "**当前模型：** `" + currentModel + "`\n\n_暂无可用模型。请先使用 `/set-llm` 配置自定义 LLM。_",
 		})
 		return elements
 	}
 
-	// Model selection buttons (limit to avoid oversized card)
-	maxModels := 10
+	maxModels := 20
 	if len(models) > maxModels {
 		models = models[:maxModels]
 	}
 
-	var actions []map[string]any
+	var options []map[string]any
 	for _, model := range models {
-		isActive := model == currentModel
-		btnType := "default"
-		if isActive {
-			btnType = "primary"
-		}
-		label := model
-		if isActive {
-			label = "✅ " + model
-		}
-		actions = append(actions, map[string]any{
-			"tag": "button",
+		options = append(options, map[string]any{
 			"text": map[string]any{
 				"tag":     "plain_text",
-				"content": label,
+				"content": model,
 			},
-			"type": btnType,
-			"value": map[string]string{
-				"action_data": mustMapToJSON(map[string]string{
-					"action": "settings_set_model",
-					"model":  model,
-				}),
-			},
+			"value": model,
 		})
 	}
 
-	elements = append(elements, wrapButtonsAsColumnSet(actions))
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": fmt.Sprintf("当前模型：**%s**", currentModel),
+	})
 
-	if len(models) > 0 {
-		elements = append(elements, map[string]any{
-			"tag": "note",
-			"elements": []map[string]any{
-				{
-					"tag":     "plain_text",
-					"content": "💡 点击模型名称即可切换。使用 `/llm` 查看完整 LLM 配置。",
-				},
-			},
-		})
-	}
+	elements = append(elements, map[string]any{
+		"tag":            "select_static",
+		"name":           "settings_model_select",
+		"placeholder":    map[string]any{"tag": "plain_text", "content": "选择模型..."},
+		"initial_option": currentModel,
+		"options":        options,
+		"value": map[string]string{
+			"action_data": mustMapToJSON(map[string]string{
+				"action": "settings_set_model",
+			}),
+		},
+	})
+
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": "💡 选择即可切换。使用 `/llm` 查看完整 LLM 配置。",
+	})
 
 	return elements
 }
 
-// buildMarketTabContent builds the registry/market browsing tab content.
+// buildMarketTabContent builds the registry/market browsing tab.
 func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID string) []map[string]any {
 	var elements []map[string]any
 
@@ -379,10 +329,10 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 		return elements
 	}
 
-	// Browse skills
+	// Skills section
 	elements = append(elements, map[string]any{
 		"tag":     "markdown",
-		"content": "**📦 Skills 市场**",
+		"content": "**📦 Skills**",
 	})
 
 	skillEntries, err := f.settingsCallbacks.RegistryBrowse("skill", 10, 0)
@@ -395,32 +345,33 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 			"content": "_暂无公开的 Skill_",
 		})
 	} else {
+		var buttons []map[string]any
 		for _, entry := range skillEntries {
-			elements = append(elements, wrapButtonsAsColumnSet([]map[string]any{
-				{
-					"tag": "button",
-					"text": map[string]any{
-						"tag":     "plain_text",
-						"content": fmt.Sprintf("📥 %s", entry.Name),
-					},
-					"type": "default",
-					"value": map[string]string{
-						"action_data": mustMapToJSON(map[string]string{
-							"action":     "settings_install",
-							"entry_type": "skill",
-							"entry_id":   fmt.Sprintf("%d", entry.ID),
-						}),
-					},
+			buttons = append(buttons, map[string]any{
+				"tag": "button",
+				"text": map[string]any{
+					"tag":     "plain_text",
+					"content": fmt.Sprintf("📥 %s", entry.Name),
 				},
-			}))
+				"type": "default",
+				"size": "small",
+				"value": map[string]string{
+					"action_data": mustMapToJSON(map[string]string{
+						"action":     "settings_install",
+						"entry_type": "skill",
+						"entry_id":   fmt.Sprintf("%d", entry.ID),
+					}),
+				},
+			})
 		}
+		elements = append(elements, wrapButtonsInColumns(buttons))
 	}
 
-	// Browse agents
+	// Agents section
 	elements = append(elements, map[string]any{"tag": "hr"})
 	elements = append(elements, map[string]any{
 		"tag":     "markdown",
-		"content": "**🤖 Agents 市场**",
+		"content": "**🤖 Agents**",
 	})
 
 	agentEntries, err := f.settingsCallbacks.RegistryBrowse("agent", 10, 0)
@@ -433,35 +384,31 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 			"content": "_暂无公开的 Agent_",
 		})
 	} else {
+		var buttons []map[string]any
 		for _, entry := range agentEntries {
-			elements = append(elements, wrapButtonsAsColumnSet([]map[string]any{
-				{
-					"tag": "button",
-					"text": map[string]any{
-						"tag":     "plain_text",
-						"content": fmt.Sprintf("📥 %s", entry.Name),
-					},
-					"type": "default",
-					"value": map[string]string{
-						"action_data": mustMapToJSON(map[string]string{
-							"action":     "settings_install",
-							"entry_type": "agent",
-							"entry_id":   fmt.Sprintf("%d", entry.ID),
-						}),
-					},
+			buttons = append(buttons, map[string]any{
+				"tag": "button",
+				"text": map[string]any{
+					"tag":     "plain_text",
+					"content": fmt.Sprintf("📥 %s", entry.Name),
 				},
-			}))
+				"type": "default",
+				"size": "small",
+				"value": map[string]string{
+					"action_data": mustMapToJSON(map[string]string{
+						"action":     "settings_install",
+						"entry_type": "agent",
+						"entry_id":   fmt.Sprintf("%d", entry.ID),
+					}),
+				},
+			})
 		}
+		elements = append(elements, wrapButtonsInColumns(buttons))
 	}
 
 	elements = append(elements, map[string]any{
-		"tag": "note",
-		"elements": []map[string]any{
-			{
-				"tag":     "plain_text",
-				"content": "💡 也可以使用 `/browse` 和 `/install` 命令管理市场资源。",
-			},
-		},
+		"tag":     "markdown",
+		"content": "💡 也可以使用 `/browse` 和 `/install` 命令管理市场资源。",
 	})
 
 	return elements
@@ -469,10 +416,72 @@ func (f *FeishuChannel) buildMarketTabContent(ctx context.Context, senderID stri
 
 // --- Helpers ---
 
-// wrapButtonsAsColumnSet wraps a slice of button elements in a Schema V2-compatible
-// column_set > column > interactive_container structure, replacing the deprecated
-// V1 "action" tag.
-func wrapButtonsAsColumnSet(buttons []map[string]any) map[string]any {
+// buildSelectSetting builds a select_static dropdown for a setting definition.
+func buildSelectSetting(def SettingDefinition, currentValue string) map[string]any {
+	var options []map[string]any
+	for _, opt := range def.Options {
+		options = append(options, map[string]any{
+			"text": map[string]any{
+				"tag":     "plain_text",
+				"content": opt.Label,
+			},
+			"value": opt.Value,
+		})
+	}
+
+	return buildSettingRow(
+		fmt.Sprintf("%s %s", def.Label, def.Description),
+		formatCurrentValue(currentValue, def),
+		map[string]any{
+			"tag":            "select_static",
+			"name":           "settings_" + def.Key,
+			"placeholder":    map[string]any{"tag": "plain_text", "content": "选择..."},
+			"initial_option": currentValue,
+			"options":        options,
+			"value": map[string]string{
+				"action_data": mustMapToJSON(map[string]string{
+					"action": "settings_set",
+					"key":    def.Key,
+				}),
+			},
+		},
+	)
+}
+
+// buildSettingRow creates a two-column layout with label on the left and control on the right.
+func buildSettingRow(label, currentDisplay string, control map[string]any) map[string]any {
+	return map[string]any{
+		"tag":                "column_set",
+		"flex_mode":          "none",
+		"horizontal_spacing": "default",
+		"columns": []map[string]any{
+			{
+				"tag":            "column",
+				"width":          "weighted",
+				"weight":         1,
+				"vertical_align": "center",
+				"elements": []map[string]any{
+					{
+						"tag":     "markdown",
+						"content": fmt.Sprintf("%s　**%s**", label, currentDisplay),
+					},
+				},
+			},
+			{
+				"tag":            "column",
+				"width":          "weighted",
+				"weight":         1,
+				"vertical_align": "center",
+				"elements": []map[string]any{
+					control,
+				},
+			},
+		},
+	}
+}
+
+// wrapButtonsInColumns wraps button elements in a V2-compatible column_set layout.
+func wrapButtonsInColumns(buttons []map[string]any) map[string]any {
 	return map[string]any{
 		"tag":                "column_set",
 		"flex_mode":          "none",

--- a/channel/feishu_settings_test.go
+++ b/channel/feishu_settings_test.go
@@ -25,43 +25,84 @@ func getCardElements(card map[string]any) ([]map[string]any, bool) {
 	return elements, ok
 }
 
-// helper to find action values from card elements (supports V1 "action" and V2 "column_set" nesting)
+// helper to find action values from card elements (supports V2 column_set nesting)
 func collectActionDataFromCard(card map[string]any) []string {
 	var results []string
 	elements, ok := getCardElements(card)
 	if !ok {
 		return results
 	}
-	collectButtonsRecursive(elements, &results)
+	collectInteractiveRecursive(elements, &results, nil)
 	return results
 }
 
-// collectButtonsRecursive searches for buttons at any nesting depth within card elements.
-// Handles both V1 (action > button) and V2 (column_set > column > interactive_container > button).
-func collectButtonsRecursive(elements []map[string]any, results *[]string) {
+// collectInteractiveRecursive searches for buttons and selects at any nesting depth.
+func collectInteractiveRecursive(elements []map[string]any, buttonResults *[]string, selectResults *[]string) {
 	for _, elem := range elements {
 		switch elem["tag"] {
-		case "action":
-			// V1: action > button[]
-			if actions, ok := elem["actions"].([]map[string]any); ok {
-				collectButtonsRecursive(actions, results)
-			}
 		case "button":
 			if value, ok := elem["value"].(map[string]string); ok {
 				if ad := value["action_data"]; ad != "" {
-					*results = append(*results, ad)
+					*buttonResults = append(*buttonResults, ad)
+				}
+			}
+		case "select_static":
+			if selectResults != nil {
+				if value, ok := elem["value"].(map[string]string); ok {
+					if ad := value["action_data"]; ad != "" {
+						*selectResults = append(*selectResults, ad)
+					}
 				}
 			}
 		case "column_set":
 			if columns, ok := elem["columns"].([]map[string]any); ok {
-				collectButtonsRecursive(columns, results)
+				collectInteractiveRecursive(columns, buttonResults, selectResults)
 			}
 		case "column", "interactive_container", "form", "collapsible_panel":
 			if children, ok := elem["elements"].([]map[string]any); ok {
-				collectButtonsRecursive(children, results)
+				collectInteractiveRecursive(children, buttonResults, selectResults)
 			}
 		}
 	}
+}
+
+// collectSelectsFromCard collects action_data from select_static elements.
+func collectSelectsFromCard(card map[string]any) []string {
+	var buttons, selects []string
+	elements, ok := getCardElements(card)
+	if !ok {
+		return selects
+	}
+	collectInteractiveRecursive(elements, &buttons, &selects)
+	return selects
+}
+
+// cardContainsTag checks if a card contains any element with the given tag (recursively).
+func cardContainsTag(card map[string]any, tag string) bool {
+	elements, ok := getCardElements(card)
+	if !ok {
+		return false
+	}
+	return containsTagRecursive(elements, tag)
+}
+
+func containsTagRecursive(elements []map[string]any, tag string) bool {
+	for _, elem := range elements {
+		if elem["tag"] == tag {
+			return true
+		}
+		if columns, ok := elem["columns"].([]map[string]any); ok {
+			if containsTagRecursive(columns, tag) {
+				return true
+			}
+		}
+		if children, ok := elem["elements"].([]map[string]any); ok {
+			if containsTagRecursive(children, tag) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // --- parseActionData tests ---
@@ -185,7 +226,6 @@ func TestBuildSettingsCard_BasicTab(t *testing.T) {
 		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
 			settingsGetCalled = true
 			return map[string]string{
-				"reply_style":        "concise",
 				"context_mode":       "phase2",
 				"notify_on_complete": "true",
 			}, nil
@@ -201,7 +241,6 @@ func TestBuildSettingsCard_BasicTab(t *testing.T) {
 		t.Fatal("expected non-nil card")
 	}
 
-	// Verify card structure
 	if card["schema"] != "2.0" {
 		t.Errorf("expected schema=2.0, got %v", card["schema"])
 	}
@@ -218,38 +257,40 @@ func TestBuildSettingsCard_BasicTab(t *testing.T) {
 		t.Errorf("expected header title '⚙️ 设置', got %v", titleMap["content"])
 	}
 
-	elements, ok := getCardElements(card)
-	if !ok {
-		t.Fatal("expected body.elements to be a []map[string]any")
+	// Verify select_static elements for select-type settings
+	selects := collectSelectsFromCard(card)
+	hasSettingsSelect := false
+	for _, ad := range selects {
+		if strings.Contains(ad, "settings_set") {
+			hasSettingsSelect = true
+		}
+	}
+	if !hasSettingsSelect {
+		t.Error("expected select_static element with 'settings_set' action for select-type settings")
 	}
 
-	// Verify that there are markdown elements and button elements
-	hasMarkdown := false
+	// Verify tab buttons exist
 	actionDataList := collectActionDataFromCard(card)
-	hasButton := len(actionDataList) > 0
-	hasSettingsAction := false
-	for _, elem := range elements {
-		if elem["tag"] == "markdown" {
-			hasMarkdown = true
+	hasTabButton := false
+	for _, ad := range actionDataList {
+		if strings.Contains(ad, "settings_tab") {
+			hasTabButton = true
 		}
 	}
-	for _, ad := range actionDataList {
-		if strings.Contains(ad, "settings_") {
-			hasSettingsAction = true
-		}
+	if !hasTabButton {
+		t.Error("expected tab button with 'settings_tab' action")
 	}
 
-	if !hasMarkdown {
-		t.Error("expected at least one markdown element in card")
-	}
-	if !hasButton {
-		t.Error("expected at least one button element in card")
-	}
-	if !hasSettingsAction {
-		t.Error("expected button value to contain 'settings_' action prefix")
-	}
 	if !settingsGetCalled {
 		t.Error("expected SettingsGet callback to be called")
+	}
+
+	// Ensure no V2-unsupported tags
+	if cardContainsTag(card, "note") {
+		t.Error("card should not contain 'note' tag (unsupported in V2)")
+	}
+	if cardContainsTag(card, "action") {
+		t.Error("card should not contain 'action' tag (unsupported in V2)")
 	}
 }
 
@@ -271,31 +312,26 @@ func TestBuildSettingsCard_ModelTab(t *testing.T) {
 		t.Fatal("expected non-nil card")
 	}
 
-	elements, ok := getCardElements(card)
-	if !ok {
-		t.Fatal("expected body.elements to be a []map[string]any")
-	}
-
-	// Verify current model info is in card
 	cardJSON, _ := json.Marshal(card)
 	cardStr := string(cardJSON)
 	if !strings.Contains(cardStr, "gpt-4") {
 		t.Error("expected card to contain current model 'gpt-4'")
 	}
 
-	// Verify model selection buttons contain settings_set_model action
-	actionDataList := collectActionDataFromCard(card)
-	hasSetModelAction := false
-	for _, ad := range actionDataList {
+	// Model tab should have a select_static for model selection
+	selects := collectSelectsFromCard(card)
+	hasSetModelSelect := false
+	for _, ad := range selects {
 		if strings.Contains(ad, "settings_set_model") {
-			hasSetModelAction = true
+			hasSetModelSelect = true
 		}
 	}
-	if !hasSetModelAction {
-		t.Error("expected model tab buttons to contain 'settings_set_model' action")
+	if !hasSetModelSelect {
+		t.Error("expected select_static with 'settings_set_model' action in model tab")
 	}
 
-	// Verify there are markdown elements for model display
+	// Verify markdown showing current model
+	elements, _ := getCardElements(card)
 	hasModelMarkdown := false
 	for _, elem := range elements {
 		if elem["tag"] == "markdown" {
@@ -307,6 +343,11 @@ func TestBuildSettingsCard_ModelTab(t *testing.T) {
 	}
 	if !hasModelMarkdown {
 		t.Error("expected markdown element showing current model")
+	}
+
+	// Must NOT contain 'note' tag
+	if cardContainsTag(card, "note") {
+		t.Error("model tab should not contain 'note' tag (unsupported in V2)")
 	}
 }
 
@@ -334,7 +375,6 @@ func TestHandleSettingsAction_TabSwitch(t *testing.T) {
 		t.Fatal("expected non-nil card")
 	}
 
-	// Verify the returned card is for the model tab (contains model info)
 	cardJSON, _ := json.Marshal(card)
 	cardStr := string(cardJSON)
 	if !strings.Contains(cardStr, "gpt-4") {
@@ -357,13 +397,13 @@ func TestHandleSettingsAction_SetValue(t *testing.T) {
 		},
 		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
 			return map[string]string{
-				"reply_style": "concise",
+				"context_mode": "phase1",
 			}, nil
 		},
 	})
 
 	actionData := map[string]any{
-		"action_data": `{"action":"settings_set","key":"reply_style","value":"detailed"}`,
+		"action_data": `{"action":"settings_set","key":"context_mode","value":"phase2"}`,
 	}
 
 	ctx := context.Background()
@@ -378,16 +418,86 @@ func TestHandleSettingsAction_SetValue(t *testing.T) {
 	if !settingsSetCalled {
 		t.Error("expected SettingsSet callback to be called")
 	}
-	if setKey != "reply_style" {
-		t.Errorf("expected key=reply_style, got %q", setKey)
+	if setKey != "context_mode" {
+		t.Errorf("expected key=context_mode, got %q", setKey)
 	}
-	if setValue != "detailed" {
-		t.Errorf("expected value=detailed, got %q", setValue)
+	if setValue != "phase2" {
+		t.Errorf("expected value=phase2, got %q", setValue)
 	}
 
-	// Verify returned card is valid (basic tab after set)
 	if card["schema"] != "2.0" {
 		t.Errorf("expected returned card schema=2.0, got %v", card["schema"])
+	}
+}
+
+func TestHandleSettingsAction_SetValueFromSelect(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	var setKey, setValue string
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		SettingsSet: func(channelName, senderID, key, value string) error {
+			setKey = key
+			setValue = value
+			return nil
+		},
+		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	})
+
+	// Simulate select_static callback: action_data has key but no value,
+	// selected_option is injected by onCardAction from action.Option
+	actionData := map[string]any{
+		"action_data":     `{"action":"settings_set","key":"context_mode"}`,
+		"selected_option": "phase2",
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("HandleSettingsAction returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+	if setKey != "context_mode" {
+		t.Errorf("expected key=context_mode, got %q", setKey)
+	}
+	if setValue != "phase2" {
+		t.Errorf("expected value=phase2 from selected_option, got %q", setValue)
+	}
+}
+
+func TestHandleSettingsAction_SetModelFromSelect(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	var setModel string
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		LLMSet: func(senderID, model string) error {
+			setModel = model
+			return nil
+		},
+		LLMList: func(senderID string) ([]string, string) {
+			return []string{"gpt-4", "claude-3"}, "gpt-4"
+		},
+	})
+
+	// Simulate select_static callback for model selection
+	actionData := map[string]any{
+		"action_data":     `{"action":"settings_set_model"}`,
+		"selected_option": "claude-3",
+	}
+
+	ctx := context.Background()
+	card, err := f.HandleSettingsAction(ctx, actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("HandleSettingsAction returned error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected non-nil card")
+	}
+	if setModel != "claude-3" {
+		t.Errorf("expected model=claude-3, got %q", setModel)
 	}
 }
 
@@ -541,6 +651,11 @@ func TestBuildSettingsCard_MarketTab(t *testing.T) {
 	if !strings.Contains(cardStr, "my-agent") {
 		t.Error("expected market tab to contain agent entry 'my-agent'")
 	}
+
+	// Must NOT contain 'note' tag
+	if cardContainsTag(card, "note") {
+		t.Error("market tab should not contain 'note' tag (unsupported in V2)")
+	}
 }
 
 func TestBuildSettingsCard_DefaultTab(t *testing.T) {
@@ -552,7 +667,6 @@ func TestBuildSettingsCard_DefaultTab(t *testing.T) {
 		},
 	})
 
-	// Pass empty tab — should default to "basic"
 	ctx := context.Background()
 	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "")
 	if err != nil {
@@ -562,17 +676,21 @@ func TestBuildSettingsCard_DefaultTab(t *testing.T) {
 		t.Fatal("expected non-nil card")
 	}
 
-	// Basic tab should have "设置面板" title
-	cardJSON, _ := json.Marshal(card)
-	cardStr := string(cardJSON)
-	if !strings.Contains(cardStr, "设置面板") {
-		t.Error("expected default tab card to contain '设置面板'")
+	header, ok := card["header"].(map[string]any)
+	if !ok {
+		t.Fatal("expected header to be a map")
+	}
+	titleMap, ok := header["title"].(map[string]any)
+	if !ok {
+		t.Fatal("expected header.title to be a map")
+	}
+	if titleMap["content"] != "⚙️ 设置" {
+		t.Errorf("expected header title '⚙️ 设置', got %v", titleMap["content"])
 	}
 }
 
 func TestBuildSettingsCard_NilCallbacks(t *testing.T) {
 	f := newTestFeishuChannel()
-	// No callbacks set — should not panic
 
 	ctx := context.Background()
 	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "basic")
@@ -584,5 +702,27 @@ func TestBuildSettingsCard_NilCallbacks(t *testing.T) {
 	}
 	if card["schema"] != "2.0" {
 		t.Errorf("expected schema=2.0, got %v", card["schema"])
+	}
+}
+
+func TestBuildSettingsCard_NoReplyStyle(t *testing.T) {
+	f := newTestFeishuChannel()
+
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		SettingsGet: func(channelName, senderID string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	})
+
+	ctx := context.Background()
+	card, err := f.BuildSettingsCard(ctx, "user1", "chat1", "basic")
+	if err != nil {
+		t.Fatalf("BuildSettingsCard returned error: %v", err)
+	}
+
+	cardJSON, _ := json.Marshal(card)
+	cardStr := string(cardJSON)
+	if strings.Contains(cardStr, "reply_style") || strings.Contains(cardStr, "回复风格") {
+		t.Error("card should not contain removed reply_style setting")
 	}
 }


### PR DESCRIPTION
- Changed setting key from "reply_style" to "context_mode" in tests and card building logic.
- Enhanced card interaction handling to support select options and ensure no deprecated tags are present.
- Improved button and select handling in the settings card to align with V2 structure.