### PR TITLE
feat: enhance Feishu settings with unpublish and delete functionality

### DIFF
--- a/agent/registry.go
+++ b/agent/registry.go
@@ -31,7 +31,17 @@ func NewRegistryManager(store *SkillStore, agentStore *AgentStore, sharedStore *
 }
 
 // Publish publishes a skill or agent to the shared registry.
+// Returns error if a public entry with the same type+name already exists from a different author.
 func (rm *RegistryManager) Publish(entryType, name, author string) error {
+	// Dedup: reject if same type+name already public by another author
+	existing, err := rm.sharedStore.GetByTypeAndName(entryType, name)
+	if err != nil {
+		return fmt.Errorf("dedup check: %w", err)
+	}
+	if existing != nil && existing.Author != author && existing.Sharing == "public" {
+		return fmt.Errorf("%s %q 已被 %s 发布，不能重名分享", entryType, name, existing.Author)
+	}
+
 	switch entryType {
 	case "skill":
 		return rm.publishSkill(name, author)
@@ -43,8 +53,7 @@ func (rm *RegistryManager) Publish(entryType, name, author string) error {
 }
 
 func (rm *RegistryManager) publishSkill(name, author string) error {
-	// Find skill directory (search global + user dirs)
-	skillDir := rm.findSkillDir(name)
+	skillDir := rm.findSkillDirForUser(name, author)
 	if skillDir == "" {
 		return fmt.Errorf("skill %q not found", name)
 	}
@@ -57,13 +66,18 @@ func (rm *RegistryManager) publishSkill(name, author string) error {
 		info.Author = author
 	}
 
+	cacheDir := rm.registryCacheDir("skill", info.Name)
+	if err := rm.snapshotToCache(skillDir, cacheDir); err != nil {
+		return fmt.Errorf("snapshot skill: %w", err)
+	}
+
 	entry := &sqlite.SharedEntry{
 		Type:        "skill",
 		Name:        info.Name,
 		Description: info.Description,
 		Author:      info.Author,
 		Tags:        info.Tags,
-		SourcePath:  skillDir,
+		SourcePath:  cacheDir,
 		Sharing:     "public",
 	}
 
@@ -71,25 +85,29 @@ func (rm *RegistryManager) publishSkill(name, author string) error {
 }
 
 func (rm *RegistryManager) publishAgent(name, author string) error {
-	// Find agent role file
-	agentDir := rm.findAgentDir(name)
+	agentDir := rm.findAgentDirForUser(name, author)
 	if agentDir == "" {
 		return fmt.Errorf("agent %q not found", name)
 	}
 
-	// Parse agent role file for description
 	roles, err := tools.LoadAgentRoles(agentDir)
 	if err != nil || len(roles) == 0 {
 		return fmt.Errorf("failed to load agent %q: %v", name, err)
 	}
 
 	role := roles[0]
+
+	cacheDir := rm.registryCacheDir("agent", role.Name)
+	if err := rm.snapshotToCache(agentDir, cacheDir); err != nil {
+		return fmt.Errorf("snapshot agent: %w", err)
+	}
+
 	entry := &sqlite.SharedEntry{
 		Type:        "agent",
 		Name:        role.Name,
 		Description: role.Description,
 		Author:      author,
-		SourcePath:  agentDir,
+		SourcePath:  cacheDir,
 		Sharing:     "public",
 	}
 
@@ -134,12 +152,14 @@ func (rm *RegistryManager) Install(entryType string, id int64, senderID string) 
 		return fmt.Errorf("unknown type %q", entryType)
 	}
 
-	// Don't overwrite existing
 	if _, err := os.Stat(destDir); err == nil {
 		return fmt.Errorf("%s %q already installed", entryType, entry.Name)
 	}
 
-	// Copy directory recursively
+	if _, err := os.Stat(entry.SourcePath); os.IsNotExist(err) {
+		return fmt.Errorf("%s %q 的源文件已不存在（可能已被删除或改名），请联系发布者重新发布", entryType, entry.Name)
+	}
+
 	if err := copyDir(entry.SourcePath, destDir); err != nil {
 		return fmt.Errorf("copy %s: %w", entryType, err)
 	}
@@ -203,15 +223,15 @@ func (rm *RegistryManager) Search(query, entryType string, limit int) ([]sqlite.
 	return rm.sharedStore.SearchShared(query, entryType, limit)
 }
 
-// ListMy lists the user's own published and installed entries.
-func (rm *RegistryManager) ListMy(senderID string, entryType string) (published []sqlite.SharedEntry, installed []string, err error) {
-	// Published
+// ListMy lists the user's own published entries and all locally available items
+// (global + user-private directories).
+func (rm *RegistryManager) ListMy(senderID string, entryType string) (published []sqlite.SharedEntry, local []string, err error) {
+	// Published by this user
 	published, err = rm.sharedStore.ListByAuthor(senderID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Filter by type if specified
 	if entryType != "" {
 		var filtered []sqlite.SharedEntry
 		for _, e := range published {
@@ -222,29 +242,63 @@ func (rm *RegistryManager) ListMy(senderID string, entryType string) (published 
 		published = filtered
 	}
 
-	// Installed: scan user's private directories
+	seen := make(map[string]bool)
+
+	// Skills: global dirs + user-private dir
 	if entryType == "" || entryType == "skill" {
-		skillsDir := tools.UserSkillsRoot(rm.workDir, senderID)
-		if entries, e := os.ReadDir(skillsDir); e == nil {
-			for _, ent := range entries {
-				if ent.IsDir() {
-					installed = append(installed, "skill:"+ent.Name())
-				}
-			}
+		for _, dir := range rm.store.globalDirs {
+			scanSkillDir(dir, &local, seen)
 		}
-	}
-	if entryType == "" || entryType == "agent" {
-		agentsDir := tools.UserAgentsRoot(rm.workDir, senderID)
-		if entries, e := os.ReadDir(agentsDir); e == nil {
-			for _, ent := range entries {
-				if ent.IsDir() {
-					installed = append(installed, "agent:"+ent.Name())
-				}
-			}
-		}
+		scanSkillDir(tools.UserSkillsRoot(rm.workDir, senderID), &local, seen)
 	}
 
-	return published, installed, nil
+	// Agents: global dir + user-private dir
+	if entryType == "" || entryType == "agent" {
+		if rm.agentStore != nil && rm.agentStore.globalDir != "" {
+			scanAgentDir(rm.agentStore.globalDir, &local, seen)
+		}
+		scanAgentDir(tools.UserAgentsRoot(rm.workDir, senderID), &local, seen)
+	}
+
+	return published, local, nil
+}
+
+func scanSkillDir(dir string, out *[]string, seen map[string]bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		key := "skill:" + ent.Name()
+		if seen[key] {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, ent.Name(), "SKILL.md")); err == nil {
+			seen[key] = true
+			*out = append(*out, key)
+		}
+	}
+}
+
+func scanAgentDir(dir string, out *[]string, seen map[string]bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		key := "agent:" + ent.Name()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		*out = append(*out, key)
+	}
 }
 
 // Browse lists public entries in the marketplace.
@@ -252,10 +306,24 @@ func (rm *RegistryManager) Browse(entryType string, limit, offset int) ([]sqlite
 	return rm.sharedStore.ListShared(entryType, limit, offset)
 }
 
+// --- registry cache ---
+
+// registryCacheDir returns the snapshot directory for a published entry.
+func (rm *RegistryManager) registryCacheDir(entryType, name string) string {
+	return filepath.Join(rm.workDir, ".xbot", "registry", entryType, name)
+}
+
+// snapshotToCache copies src directory into cacheDir, replacing any existing cache.
+func (rm *RegistryManager) snapshotToCache(src, cacheDir string) error {
+	if err := os.RemoveAll(cacheDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clean cache: %w", err)
+	}
+	return copyDir(src, cacheDir)
+}
+
 // --- helpers ---
 
 func (rm *RegistryManager) findSkillDir(name string) string {
-	// Search global dirs
 	for _, dir := range rm.store.globalDirs {
 		path := filepath.Join(dir, name)
 		if _, err := os.Stat(filepath.Join(path, "SKILL.md")); err == nil {
@@ -265,10 +333,37 @@ func (rm *RegistryManager) findSkillDir(name string) string {
 	return ""
 }
 
+// findSkillDirForUser searches global + user-private skill dirs.
+func (rm *RegistryManager) findSkillDirForUser(name, senderID string) string {
+	if dir := rm.findSkillDir(name); dir != "" {
+		return dir
+	}
+	if senderID != "" {
+		path := filepath.Join(tools.UserSkillsRoot(rm.workDir, senderID), name)
+		if _, err := os.Stat(filepath.Join(path, "SKILL.md")); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
 func (rm *RegistryManager) findAgentDir(name string) string {
-	// Search global agents dir
 	if rm.agentStore != nil && rm.agentStore.globalDir != "" {
 		path := filepath.Join(rm.agentStore.globalDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// findAgentDirForUser searches global + user-private agent dirs.
+func (rm *RegistryManager) findAgentDirForUser(name, senderID string) string {
+	if dir := rm.findAgentDir(name); dir != "" {
+		return dir
+	}
+	if senderID != "" {
+		path := filepath.Join(tools.UserAgentsRoot(rm.workDir, senderID), name)
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -47,10 +47,12 @@ type SettingsCallbacks struct {
 	ContextModeGet func() string
 	ContextModeSet func(mode string) error
 
-	RegistryBrowse  func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error)
-	RegistryInstall func(entryType string, id int64, senderID string) error
-	RegistryListMy  func(senderID, entryType string) (published []sqlite.SharedEntry, installed []string, err error)
-	RegistryPublish func(entryType, name, senderID string) error
+	RegistryBrowse    func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error)
+	RegistryInstall   func(entryType string, id int64, senderID string) error
+	RegistryListMy    func(senderID, entryType string) (published []sqlite.SharedEntry, installed []string, err error)
+	RegistryPublish   func(entryType, name, senderID string) error
+	RegistryUnpublish func(entryType, name, senderID string) error
+	RegistryDelete    func(entryType, name, senderID string) error
 }
 
 // FeishuChannel 飞书渠道实现

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -163,6 +163,32 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 		}
 		return f.BuildSettingsCard(ctx, senderID, chatID, "market")
 
+	case "settings_unpublish":
+		entryType := parsed["entry_type"]
+		name := parsed["name"]
+		if entryType == "" || name == "" {
+			return nil, fmt.Errorf("missing entry_type or name")
+		}
+		if f.settingsCallbacks.RegistryUnpublish != nil {
+			if err := f.settingsCallbacks.RegistryUnpublish(entryType, name, senderID); err != nil {
+				log.WithError(err).Warnf("HandleSettingsAction: failed to unpublish %s/%s", entryType, name)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "market")
+
+	case "settings_delete_item":
+		entryType := parsed["entry_type"]
+		name := parsed["name"]
+		if entryType == "" || name == "" {
+			return nil, fmt.Errorf("missing entry_type or name")
+		}
+		if f.settingsCallbacks.RegistryDelete != nil {
+			if err := f.settingsCallbacks.RegistryDelete(entryType, name, senderID); err != nil {
+				log.WithError(err).Warnf("HandleSettingsAction: failed to delete %s/%s", entryType, name)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "market")
+
 	default:
 		return nil, fmt.Errorf("unknown settings action: %s", action)
 	}
@@ -465,19 +491,20 @@ func (f *FeishuChannel) buildMyItemsSection(senderID, entryType, label string) [
 		"content": fmt.Sprintf("**📁 我的%s**", label),
 	})
 
-	published, installed, err := f.settingsCallbacks.RegistryListMy(senderID, entryType)
+	published, local, err := f.settingsCallbacks.RegistryListMy(senderID, entryType)
 	if err != nil {
 		log.WithError(err).Warnf("buildMyItemsSection: ListMy failed for %s", entryType)
 	}
 
-	// Build a set of published names for quick lookup
 	publishedNames := make(map[string]bool)
 	for _, e := range published {
-		publishedNames[e.Name] = true
+		if e.Sharing == "public" {
+			publishedNames[e.Name] = true
+		}
 	}
 
 	prefix := entryType + ":"
-	if len(installed) == 0 && len(published) == 0 {
+	if len(local) == 0 && len(published) == 0 {
 		elements = append(elements, map[string]any{
 			"tag":     "markdown",
 			"content": fmt.Sprintf("_暂无%s_", label),
@@ -485,56 +512,91 @@ func (f *FeishuChannel) buildMyItemsSection(senderID, entryType, label string) [
 		return elements
 	}
 
-	// Show local items with share/published status
-	for _, item := range installed {
+	for _, item := range local {
 		name := strings.TrimPrefix(item, prefix)
 		if publishedNames[name] {
-			elements = append(elements, map[string]any{
-				"tag":     "markdown",
-				"content": fmt.Sprintf("• %s　✅ 已分享", name),
-			})
+			// Already shared: show unpublish + delete
+			elements = append(elements, buildItemRow(name, "✅ 已分享",
+				actionBtn("📤 下架", "settings_unpublish", entryType, name),
+				actionBtn("🗑️", "settings_delete_item", entryType, name),
+			))
 		} else {
-			elements = append(elements, buildSettingRow(
-				"• "+name,
-				"",
-				map[string]any{
-					"tag": "button",
-					"text": map[string]any{
-						"tag":     "plain_text",
-						"content": "📤 分享",
-					},
-					"type": "default",
-					"size": "small",
-					"value": map[string]string{
-						"action_data": mustMapToJSON(map[string]string{
-							"action":     "settings_publish",
-							"entry_type": entryType,
-							"name":       name,
-						}),
-					},
-				},
+			// Not shared: show share + delete
+			elements = append(elements, buildItemRow(name, "",
+				actionBtn("📤 分享", "settings_publish", entryType, name),
+				actionBtn("🗑️", "settings_delete_item", entryType, name),
 			))
 		}
 	}
 
-	// Show published items that aren't in local (edge case)
+	// Published items that are no longer local (edge case: deleted locally but still in registry)
 	for _, e := range published {
 		found := false
-		for _, item := range installed {
+		for _, item := range local {
 			if strings.TrimPrefix(item, prefix) == e.Name {
 				found = true
 				break
 			}
 		}
-		if !found {
-			elements = append(elements, map[string]any{
-				"tag":     "markdown",
-				"content": fmt.Sprintf("• %s　✅ 已分享", e.Name),
-			})
+		if !found && e.Sharing == "public" {
+			elements = append(elements, buildItemRow(e.Name, "✅ 已分享（本地已删除）",
+				actionBtn("📤 下架", "settings_unpublish", entryType, e.Name),
+			))
 		}
 	}
 
 	return elements
+}
+
+func actionBtn(text, action, entryType, name string) map[string]any {
+	return map[string]any{
+		"tag":  "button",
+		"text": map[string]any{"tag": "plain_text", "content": text},
+		"type": "default",
+		"size": "small",
+		"value": map[string]string{
+			"action_data": mustMapToJSON(map[string]string{
+				"action":     action,
+				"entry_type": entryType,
+				"name":       name,
+			}),
+		},
+	}
+}
+
+func buildItemRow(name, status string, buttons ...map[string]any) map[string]any {
+	leftText := "• " + name
+	if status != "" {
+		leftText += "　" + status
+	}
+	return map[string]any{
+		"tag":                "column_set",
+		"flex_mode":          "none",
+		"horizontal_spacing": "default",
+		"columns": []map[string]any{
+			{
+				"tag":            "column",
+				"width":          "weighted",
+				"weight":         2,
+				"vertical_align": "center",
+				"elements": []map[string]any{
+					{"tag": "markdown", "content": leftText},
+				},
+			},
+			{
+				"tag":            "column",
+				"width":          "weighted",
+				"weight":         1,
+				"vertical_align": "center",
+				"elements": []map[string]any{
+					{
+						"tag":      "interactive_container",
+						"elements": buttons,
+					},
+				},
+			},
+		},
+	}
 }
 
 func (f *FeishuChannel) buildMarketSection(entryType, title string) []map[string]any {

--- a/channel/feishu_settings_test.go
+++ b/channel/feishu_settings_test.go
@@ -465,6 +465,9 @@ func TestBuildSettingsCard_MarketTab(t *testing.T) {
 			if entryType == "skill" {
 				return nil, []string{"skill:my-local-skill"}, nil
 			}
+			if entryType == "agent" {
+				return nil, []string{"agent:my-agent"}, nil
+			}
 			return nil, nil, nil
 		},
 	})
@@ -484,8 +487,14 @@ func TestBuildSettingsCard_MarketTab(t *testing.T) {
 	if !strings.Contains(s, "my-local-skill") {
 		t.Error("should contain user's local skill")
 	}
+	if !strings.Contains(s, "my-agent") {
+		t.Error("should contain user's local agent")
+	}
 	if !strings.Contains(s, "分享") {
 		t.Error("should have share button for unpublished local items")
+	}
+	if !strings.Contains(s, "settings_delete_item") {
+		t.Error("should have delete button for local items")
 	}
 }
 
@@ -497,7 +506,7 @@ func TestBuildSettingsCard_MarketTab_PublishedItem(t *testing.T) {
 		},
 		RegistryListMy: func(senderID, entryType string) ([]sqlite.SharedEntry, []string, error) {
 			if entryType == "skill" {
-				return []sqlite.SharedEntry{{Name: "shared-skill"}}, []string{"skill:shared-skill"}, nil
+				return []sqlite.SharedEntry{{Name: "shared-skill", Sharing: "public"}}, []string{"skill:shared-skill"}, nil
 			}
 			return nil, nil, nil
 		},
@@ -511,6 +520,9 @@ func TestBuildSettingsCard_MarketTab_PublishedItem(t *testing.T) {
 	s := cardJSON(card)
 	if !strings.Contains(s, "已分享") {
 		t.Error("should show '已分享' for published items")
+	}
+	if !strings.Contains(s, "settings_unpublish") {
+		t.Error("published items should have unpublish button")
 	}
 }
 
@@ -576,6 +588,70 @@ func TestHandleSettingsAction_Publish(t *testing.T) {
 	}
 	if pubType != "skill" || pubName != "my-skill" {
 		t.Errorf("expected skill/my-skill, got %s/%s", pubType, pubName)
+	}
+}
+
+func TestHandleSettingsAction_Unpublish(t *testing.T) {
+	f := newTestFeishuChannel()
+	var unpubType, unpubName string
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		RegistryUnpublish: func(entryType, name, senderID string) error {
+			unpubType = entryType
+			unpubName = name
+			return nil
+		},
+		RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
+			return nil, nil
+		},
+		RegistryListMy: func(senderID, entryType string) ([]sqlite.SharedEntry, []string, error) {
+			return nil, nil, nil
+		},
+	})
+
+	actionData := map[string]any{
+		"action_data": `{"action":"settings_unpublish","entry_type":"skill","name":"my-skill"}`,
+	}
+	card, err := f.HandleSettingsAction(context.Background(), actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected card")
+	}
+	if unpubType != "skill" || unpubName != "my-skill" {
+		t.Errorf("expected skill/my-skill, got %s/%s", unpubType, unpubName)
+	}
+}
+
+func TestHandleSettingsAction_DeleteItem(t *testing.T) {
+	f := newTestFeishuChannel()
+	var delType, delName string
+	f.SetSettingsCallbacks(SettingsCallbacks{
+		RegistryDelete: func(entryType, name, senderID string) error {
+			delType = entryType
+			delName = name
+			return nil
+		},
+		RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
+			return nil, nil
+		},
+		RegistryListMy: func(senderID, entryType string) ([]sqlite.SharedEntry, []string, error) {
+			return nil, nil, nil
+		},
+	})
+
+	actionData := map[string]any{
+		"action_data": `{"action":"settings_delete_item","entry_type":"agent","name":"old-agent"}`,
+	}
+	card, err := f.HandleSettingsAction(context.Background(), actionData, "user1", "chat1", "msg1")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if card == nil {
+		t.Fatal("expected card")
+	}
+	if delType != "agent" || delName != "old-agent" {
+		t.Errorf("expected agent/old-agent, got %s/%s", delType, delName)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -271,6 +271,12 @@ func main() {
 			RegistryPublish: func(entryType, name, senderID string) error {
 				return agentLoop.RegistryManager().Publish(entryType, name, senderID)
 			},
+			RegistryUnpublish: func(entryType, name, senderID string) error {
+				return agentLoop.RegistryManager().Unpublish(entryType, name, senderID)
+			},
+			RegistryDelete: func(entryType, name, senderID string) error {
+				return agentLoop.RegistryManager().Uninstall(entryType, name, senderID)
+			},
 		})
 
 		// 注入飞书渠道特化 prompt 提供者


### PR DESCRIPTION
- Added RegistryUnpublish and RegistryDelete callbacks to manage unpublishing and deleting skills and agents.
- Updated the Feishu settings card to include buttons for unpublishing and deleting local items.
- Enhanced the RegistryManager to handle deduplication and caching for published entries.
- Improved tests to cover new unpublish and delete actions, ensuring proper functionality and user feedback.