### PR TITLE
fix: normalize senderID in settings card callbacks for single-user mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -812,7 +812,7 @@ func (a *Agent) Run(ctx context.Context) error {
 			return ctx.Err()
 		case msg := <-a.bus.Inbound:
 			// 单用户模式：在 bus 入口统一归一化 SenderID
-			msg.SenderID = a.normalizeSenderID(msg.SenderID)
+			msg.SenderID = a.NormalizeSenderID(msg.SenderID)
 
 			// /cancel 拦截：不进入 chatWorker 队列，直接发 cancel 信号
 			if strings.TrimSpace(strings.ToLower(msg.Content)) == "/cancel" {
@@ -849,9 +849,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 }
 
-// normalizeSenderID returns the effective sender ID for the message.
+// NormalizeSenderID returns the effective sender ID for the message.
 // In single-user mode, all sender IDs are mapped to "default".
-func (a *Agent) normalizeSenderID(senderID string) string {
+func (a *Agent) NormalizeSenderID(senderID string) string {
 	if a.singleUser {
 		return "default"
 	}
@@ -1605,7 +1605,7 @@ func (a *Agent) addReaction(msg bus.InboundMessage) {
 func (a *Agent) ProcessDirect(ctx context.Context, content string) (string, error) {
 	msg := bus.InboundMessage{
 		Channel:   "cli",
-		SenderID:  a.normalizeSenderID("user"),
+		SenderID:  a.NormalizeSenderID("user"),
 		ChatID:    "direct",
 		Content:   content,
 		Time:      time.Now(),

--- a/agent/single_user_test.go
+++ b/agent/single_user_test.go
@@ -16,7 +16,7 @@ func TestNormalizeSenderID_SingleUser(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := a.normalizeSenderID(tt.input)
+		got := a.NormalizeSenderID(tt.input)
 		if got != tt.want {
 			t.Errorf("normalizeSenderID(%q) = %q, want %q", tt.input, got, tt.want)
 		}
@@ -37,7 +37,7 @@ func TestNormalizeSenderID_MultiUser(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := a.normalizeSenderID(tt.input)
+		got := a.NormalizeSenderID(tt.input)
 		if got != tt.want {
 			t.Errorf("normalizeSenderID(%q) = %q, want %q", tt.input, got, tt.want)
 		}

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -47,6 +47,10 @@ type SettingsCallbacks struct {
 	ContextModeGet func() string
 	ContextModeSet func(mode string) error
 
+	// NormalizeSenderID normalizes sender ID for single-user mode.
+	// In single-user mode, all sender IDs are mapped to "default".
+	NormalizeSenderID func(senderID string) string
+
 	RegistryBrowse    func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error)
 	RegistryInstall   func(entryType string, id int64, senderID string) error
 	RegistryListMy    func(senderID, entryType string) (published []sqlite.SharedEntry, installed []string, err error)
@@ -1073,6 +1077,11 @@ func (f *FeishuChannel) onCardAction(ctx context.Context, event *callback.CardAc
 // handleSettingsCardAction handles settings card interactions (buttons & selects).
 // Returns the updated card directly in the callback response for instant UI refresh.
 func (f *FeishuChannel) handleSettingsCardAction(ctx context.Context, actionData map[string]any, chatID, senderID, messageID string) (*callback.CardActionTriggerResponse, error) {
+	// Normalize senderID for single-user mode
+	if f.settingsCallbacks.NormalizeSenderID != nil {
+		senderID = f.settingsCallbacks.NormalizeSenderID(senderID)
+	}
+
 	updatedCard, err := f.HandleSettingsAction(ctx, actionData, senderID, chatID, messageID)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{

--- a/main.go
+++ b/main.go
@@ -259,6 +259,9 @@ func main() {
 			ContextModeSet: func(mode string) error {
 				return agentLoop.SetContextMode(mode)
 			},
+			NormalizeSenderID: func(senderID string) string {
+				return agentLoop.NormalizeSenderID(senderID)
+			},
 			RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
 				return agentLoop.RegistryManager().Browse(entryType, limit, offset)
 			},


### PR DESCRIPTION
## 问题描述

在单用户模式 + none 沙箱环境下，使用 `/settings` 指令看不到用户的各种设置。

## 根本原因

1. 消息入队时，`msg.SenderID` 被归一化为 `"default"`
2. 但飞书卡片回调中的 `senderID` 是直接从飞书事件获取的真实 OpenID
3. 导致 `LLMGetConfig(realOpenID)` 找不到配置（配置存储在 `"default"` key 下）

## 修复方案

1. 在 `SettingsCallbacks` 中添加 `NormalizeSenderID` 回调
2. 将 `Agent.normalizeSenderID` 改为公开方法 `NormalizeSenderID`
3. 在 `handleSettingsCardAction` 中调用归一化回调
4. 在 `main.go` 中注册回调

## 测试

- ✅ 单元测试通过
- ✅ Settings 相关测试通过

## 变更文件

| 文件 | 变更 |
|------|------|
| `channel/feishu.go` | 添加 `NormalizeSenderID` 回调，在卡片回调处理中应用 |
| `agent/agent.go` | 重命名 `normalizeSenderID` → `NormalizeSenderID`（公开） |
| `main.go` | 注册 `NormalizeSenderID` 回调 |
| `agent/single_user_test.go` | 更新测试引用 |