### PR TITLE
feat: OS user-based permission control for tool execution

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1854,6 +1854,7 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 	mc.SetExtra(ExtraKeySkillsCatalog, a.skills.GetSkillsCatalog(ctx, msg.SenderID))
 	mc.SetExtra(ExtraKeyAgentsCatalog, a.agents.GetAgentsCatalog(ctx, msg.SenderID))
 	mc.SetExtra(ExtraKeyMemoryProvider, tenantSession.Memory())
+	mc.SetExtra(ExtraKeyPermUsers, a.settingsSvc.GetPermUsers(msg.Channel, msg.SenderID))
 
 	mc.SetExtra(ExtraKeyTenantID, tenantSession.TenantID())
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1855,7 +1855,9 @@ func (a *Agent) buildPrompt(ctx context.Context, msg bus.InboundMessage, tenantS
 	mc.SetExtra(ExtraKeySkillsCatalog, a.skills.GetSkillsCatalog(ctx, msg.SenderID))
 	mc.SetExtra(ExtraKeyAgentsCatalog, a.agents.GetAgentsCatalog(ctx, msg.SenderID))
 	mc.SetExtra(ExtraKeyMemoryProvider, tenantSession.Memory())
-	mc.SetExtra(ExtraKeyPermUsers, a.settingsSvc.GetPermUsers(msg.Channel, msg.SenderID))
+	permUsers := a.settingsSvc.GetPermUsers(msg.Channel, msg.SenderID)
+	mc.SetExtra(ExtraKeyPermUsers, permUsers)
+	mc.Ctx = withPermControlEnabled(mc.Ctx, IsPermControlEnabled(permUsers))
 
 	mc.SetExtra(ExtraKeyTenantID, tenantSession.TenantID())
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -754,6 +754,7 @@ func New(cfg Config) *Agent {
 		hookChain: tools.NewHookChain(
 			tools.NewLoggingHook(),
 			tools.NewTimingHook(),
+			tools.NewApprovalHook(nil), // handler set later by channel when available
 		),
 		bgTaskMgr: tools.NewBackgroundTaskManager(),
 	}

--- a/agent/context.go
+++ b/agent/context.go
@@ -175,6 +175,7 @@ func (a *Agent) initPipelines(memoryProvider string) {
 		NewSystemPromptMiddleware(a.promptLoader, memoryProvider),
 		NewSkillsCatalogMiddleware(),
 		NewAgentsCatalogMiddleware(),
+		NewPermissionControlMiddleware(),
 		NewMemoryMiddleware(),
 		NewSenderInfoMiddleware(),
 		NewLanguageMiddleware(a.settingsSvc),

--- a/agent/context_handler.go
+++ b/agent/context_handler.go
@@ -39,7 +39,7 @@ func (a *Agent) handleContextInfo(ctx context.Context, msg bus.InboundMessage, t
 
 	// 获取工具定义并计算 token
 	sessionKey := msg.Channel + ":" + msg.ChatID
-	toolDefs := a.tools.AsDefinitionsForSession(sessionKey)
+	toolDefs := visibleToolDefs(a.tools.AsDefinitionsForSession(sessionKey), a.settingsSvc, msg.Channel, msg.SenderID)
 	toolDefsTokens, _ := llm.CountToolsTokens(toolDefs, model)
 
 	// Prefer API-returned prompt_tokens (authoritative) over local estimation.

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -139,6 +139,9 @@ type RunConfig struct {
 	// HookChain tool execution hook chain (nil = no hooks).
 	HookChain *tools.HookChain
 
+	// SettingsSvc provides access to user settings (nil = settings not available).
+	SettingsSvc *SettingsService
+
 	// OffloadStore Layer 1 offload store（nil = 不启用）
 	OffloadStore *OffloadStore
 
@@ -392,9 +395,16 @@ func defaultToolExecutor(cfg *RunConfig) func(ctx context.Context, tc llm.ToolCa
 
 		toolCtx := buildToolContext(ctx, cfg)
 
-		// Run pre-tool hooks
+		// Run pre-tool hooks (inject perm users into context for ApprovalHook)
 		if cfg.HookChain != nil {
-			if err := cfg.HookChain.RunPre(ctx, tc.Name, tc.Arguments); err != nil {
+			hookCtx := ctx
+			if cfg.SettingsSvc != nil {
+				permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
+				if permUsers != nil {
+					hookCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
+				}
+			}
+			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
 				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
 			}
 		}

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -393,17 +393,18 @@ func defaultToolExecutor(cfg *RunConfig) func(ctx context.Context, tc llm.ToolCa
 			return nil, fmt.Errorf("unknown tool: %s", tc.Name)
 		}
 
-		toolCtx := buildToolContext(ctx, cfg)
+		toolExecCtx := ctx
+		if cfg.SettingsSvc != nil {
+			permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
+			if permUsers != nil {
+				toolExecCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
+			}
+		}
+		toolCtx := buildToolContext(toolExecCtx, cfg)
 
 		// Run pre-tool hooks (inject perm users into context for ApprovalHook)
 		if cfg.HookChain != nil {
-			hookCtx := ctx
-			if cfg.SettingsSvc != nil {
-				permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
-				if permUsers != nil {
-					hookCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
-				}
-			}
+			hookCtx := toolExecCtx
 			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
 				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
 			}

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -393,11 +393,11 @@ func defaultToolExecutor(cfg *RunConfig) func(ctx context.Context, tc llm.ToolCa
 			return nil, fmt.Errorf("unknown tool: %s", tc.Name)
 		}
 
-		toolExecCtx := ctx
+		toolExecCtx := withApprovalTarget(ctx, cfg.ChatID, cfg.OriginUserID)
 		if cfg.SettingsSvc != nil {
 			permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
 			if permUsers != nil {
-				toolExecCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
+				toolExecCtx = tools.WithPermUsers(toolExecCtx, permUsers.DefaultUser, permUsers.PrivilegedUser)
 			}
 		}
 		toolCtx := buildToolContext(toolExecCtx, cfg)

--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -380,7 +380,7 @@ func (s *runState) assertSystemMessages(ctx context.Context) *RunOutput {
 // callLLM invokes the LLM with the current messages, handling per-tenant
 // concurrency semaphore and input-too-long errors with forced compression.
 func (s *runState) callLLM(ctx context.Context, retryNotifyCtx context.Context) (*llm.LLMResponse, error) {
-	toolDefs := s.cfg.Tools.AsDefinitionsForSession(s.sessionKey)
+	toolDefs := visibleToolDefs(s.cfg.Tools.AsDefinitionsForSession(s.sessionKey), s.cfg.SettingsSvc, s.cfg.Channel, s.cfg.OriginUserID)
 
 	var releaseLLMSem func()
 	if s.cfg.LLMSemAcquire != nil {

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -131,6 +131,9 @@ func (a *Agent) buildBaseRunConfig(
 		// HookChain — inherit from Agent
 		HookChain: a.hookChain,
 
+		// SettingsSvc — inherit from Agent
+		SettingsSvc: a.settingsSvc,
+
 		// LLM 并发限流回调（per-tenant）
 		LLMSemAcquire:             llmSemAcquire,
 		EnableConcurrentSubAgents: true,
@@ -700,6 +703,7 @@ func (a *Agent) buildSubAgentRunConfig(
 	}
 	// HookChain — SubAgent inherits parent Agent's hook chain
 	cfg.HookChain = a.hookChain
+	cfg.SettingsSvc = a.settingsSvc
 
 	// Interactive 回调独立注入，不依赖 SpawnAgent
 	cfg.InteractiveCallbacks = &InteractiveCallbacks{
@@ -774,6 +778,7 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 
 	// Inherit hook chain from Agent.
 	cfg.HookChain = a.hookChain
+	cfg.SettingsSvc = a.settingsSvc
 
 	return func(ctx context.Context, tc llm.ToolCall) (*tools.ToolResult, error) {
 		// Lazy-inject session so buildToolContext can persist CWD across tool calls.
@@ -821,9 +826,16 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 			}
 		}
 
-		// 5. Run pre-tool hooks
+		// 5. Run pre-tool hooks (inject perm users into context for ApprovalHook)
 		if cfg.HookChain != nil {
-			if err := cfg.HookChain.RunPre(ctx, tc.Name, tc.Arguments); err != nil {
+			hookCtx := ctx
+			if cfg.SettingsSvc != nil {
+				permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
+				if permUsers != nil {
+					hookCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
+				}
+			}
+			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
 				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
 			}
 		}

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -826,11 +826,11 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 			}
 		}
 
-		toolExecCtx := ctx
+		toolExecCtx := withApprovalTarget(ctx, cfg.ChatID, cfg.OriginUserID)
 		if cfg.SettingsSvc != nil {
 			permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
 			if permUsers != nil {
-				toolExecCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
+				toolExecCtx = tools.WithPermUsers(toolExecCtx, permUsers.DefaultUser, permUsers.PrivilegedUser)
 			}
 		}
 

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -826,22 +826,24 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 			}
 		}
 
+		toolExecCtx := ctx
+		if cfg.SettingsSvc != nil {
+			permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
+			if permUsers != nil {
+				toolExecCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
+			}
+		}
+
 		// 5. Run pre-tool hooks (inject perm users into context for ApprovalHook)
 		if cfg.HookChain != nil {
-			hookCtx := ctx
-			if cfg.SettingsSvc != nil {
-				permUsers := cfg.SettingsSvc.GetPermUsers(cfg.Channel, cfg.OriginUserID)
-				if permUsers != nil {
-					hookCtx = tools.WithPermUsers(ctx, permUsers.DefaultUser, permUsers.PrivilegedUser)
-				}
-			}
+			hookCtx := toolExecCtx
 			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
 				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
 			}
 		}
 
 		// 6. 构建 ToolContext（统一路径，只有 ctx 变化）
-		toolCtx := buildToolContext(ctx, cfg)
+		toolCtx := buildToolContext(toolExecCtx, cfg)
 
 		// 7. Execute tool with timing
 		start := time.Now()

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -65,6 +65,7 @@ const (
 	ExtraKeyMemoryProvider = "memory_provider"
 	ExtraKeyTenantID       = "tenant_id"
 	ExtraKeyUserLanguage   = "user_language"
+	ExtraKeyPermUsers      = "perm_users" // permission control user config
 )
 
 // GetExtra 从 Extra 中获取指定类型的值

--- a/agent/middleware_builtin.go
+++ b/agent/middleware_builtin.go
@@ -122,7 +122,7 @@ func (m *PermissionControlMiddleware) Process(mc *MessageContext) error {
 		fmt.Fprintf(&sb, "- Use `run_as: %q` for routine operations\n", config.DefaultUser)
 	}
 	if config.PrivilegedUser != "" {
-		sb.WriteString(fmt.Sprintf("- Use `run_as: %q` ONLY when the task genuinely requires elevated privileges\n", config.PrivilegedUser))
+		fmt.Fprintf(&sb, "- Use `run_as: %q` ONLY when the task genuinely requires elevated privileges\n", config.PrivilegedUser)
 		sb.WriteString("- Always explain WHY you need the privileged user when requesting it\n")
 	}
 

--- a/agent/middleware_builtin.go
+++ b/agent/middleware_builtin.go
@@ -82,6 +82,11 @@ type PermUsersConfig struct {
 	PrivilegedUser string `json:"privileged_user"`
 }
 
+// IsPermControlEnabled reports whether permission control is active for the current user/channel.
+func IsPermControlEnabled(config *PermUsersConfig) bool {
+	return config != nil && (config.DefaultUser != "" || config.PrivilegedUser != "")
+}
+
 // PermissionControlMiddleware injects the permission control system prompt
 // when the feature is enabled (at least one user is configured).
 type PermissionControlMiddleware struct{}
@@ -95,10 +100,7 @@ func (m *PermissionControlMiddleware) Priority() int { return 115 }
 
 func (m *PermissionControlMiddleware) Process(mc *MessageContext) error {
 	config, ok := GetExtraTyped[*PermUsersConfig](mc, ExtraKeyPermUsers)
-	if !ok || config == nil {
-		return nil
-	}
-	if config.DefaultUser == "" && config.PrivilegedUser == "" {
+	if !ok || !IsPermControlEnabled(config) {
 		return nil // feature disabled
 	}
 

--- a/agent/middleware_builtin.go
+++ b/agent/middleware_builtin.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"xbot/memory"
@@ -72,6 +73,60 @@ func (m *AgentsCatalogMiddleware) Process(mc *MessageContext) error {
 	if catalog != "" {
 		mc.SystemParts["15_agents"] = catalog
 	}
+	return nil
+}
+
+// PermUsersConfig holds the permission control user configuration.
+type PermUsersConfig struct {
+	DefaultUser    string `json:"default_user"`
+	PrivilegedUser string `json:"privileged_user"`
+}
+
+// PermissionControlMiddleware injects the permission control system prompt
+// when the feature is enabled (at least one user is configured).
+type PermissionControlMiddleware struct{}
+
+func NewPermissionControlMiddleware() *PermissionControlMiddleware {
+	return &PermissionControlMiddleware{}
+}
+
+func (m *PermissionControlMiddleware) Name() string  { return "permission_control" }
+func (m *PermissionControlMiddleware) Priority() int { return 115 }
+
+func (m *PermissionControlMiddleware) Process(mc *MessageContext) error {
+	config, ok := GetExtraTyped[*PermUsersConfig](mc, ExtraKeyPermUsers)
+	if !ok || config == nil {
+		return nil
+	}
+	if config.DefaultUser == "" && config.PrivilegedUser == "" {
+		return nil // feature disabled
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Execution User Control\n\n")
+	sb.WriteString("You can execute tools as a different OS user by passing the `run_as` parameter.\n")
+	sb.WriteString("Available users are configured by the system administrator.\n\n")
+	sb.WriteString("### Available Users\n")
+	sb.WriteString("| User | Approval Required | Description |\n")
+	sb.WriteString("|------|-------------------|-------------|\n")
+	sb.WriteString("| (omit run_as) | None | Current process user |\n")
+	if config.DefaultUser != "" {
+		sb.WriteString(fmt.Sprintf("| %s | None | Default execution user |\n", config.DefaultUser))
+	}
+	if config.PrivilegedUser != "" {
+		sb.WriteString(fmt.Sprintf("| %s | **Yes** | Privileged user — user must approve each use |\n", config.PrivilegedUser))
+	}
+	sb.WriteString("\n### Rules\n")
+	sb.WriteString("- Omit `run_as` to execute as the current process user\n")
+	if config.DefaultUser != "" {
+		sb.WriteString(fmt.Sprintf("- Use `run_as: %q` for routine operations\n", config.DefaultUser))
+	}
+	if config.PrivilegedUser != "" {
+		sb.WriteString(fmt.Sprintf("- Use `run_as: %q` ONLY when the task genuinely requires elevated privileges\n", config.PrivilegedUser))
+		sb.WriteString("- Always explain WHY you need the privileged user when requesting it\n")
+	}
+
+	mc.SystemParts["14_perm_control"] = sb.String()
 	return nil
 }
 

--- a/agent/middleware_builtin.go
+++ b/agent/middleware_builtin.go
@@ -111,15 +111,15 @@ func (m *PermissionControlMiddleware) Process(mc *MessageContext) error {
 	sb.WriteString("|------|-------------------|-------------|\n")
 	sb.WriteString("| (omit run_as) | None | Current process user |\n")
 	if config.DefaultUser != "" {
-		sb.WriteString(fmt.Sprintf("| %s | None | Default execution user |\n", config.DefaultUser))
+		fmt.Fprintf(&sb, "| %s | None | Default execution user |\n", config.DefaultUser)
 	}
 	if config.PrivilegedUser != "" {
-		sb.WriteString(fmt.Sprintf("| %s | **Yes** | Privileged user — user must approve each use |\n", config.PrivilegedUser))
+		fmt.Fprintf(&sb, "| %s | **Yes** | Privileged user — user must approve each use |\n", config.PrivilegedUser)
 	}
 	sb.WriteString("\n### Rules\n")
 	sb.WriteString("- Omit `run_as` to execute as the current process user\n")
 	if config.DefaultUser != "" {
-		sb.WriteString(fmt.Sprintf("- Use `run_as: %q` for routine operations\n", config.DefaultUser))
+		fmt.Fprintf(&sb, "- Use `run_as: %q` for routine operations\n", config.DefaultUser)
 	}
 	if config.PrivilegedUser != "" {
 		sb.WriteString(fmt.Sprintf("- Use `run_as: %q` ONLY when the task genuinely requires elevated privileges\n", config.PrivilegedUser))

--- a/agent/perm_control_helpers.go
+++ b/agent/perm_control_helpers.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"context"
+	"xbot/internal/ctxkeys"
+	"xbot/llm"
+)
+
+func withPermControlEnabled(ctx context.Context, enabled bool) context.Context {
+	return ctxkeys.WithPermControlEnabled(ctx, enabled)
+}
+
+func withApprovalTarget(ctx context.Context, chatID, senderID string) context.Context {
+	return ctxkeys.WithApprovalTarget(ctx, chatID, senderID)
+}
+
+// toolDefFilter wraps a tool definition and can hide selected params without
+// mutating the global registry copy.
+type toolDefFilter struct {
+	base       llm.ToolDefinition
+	hiddenArgs map[string]bool
+}
+
+func (t *toolDefFilter) Name() string        { return t.base.Name() }
+func (t *toolDefFilter) Description() string { return t.base.Description() }
+func (t *toolDefFilter) Parameters() []llm.ToolParam {
+	params := t.base.Parameters()
+	if len(t.hiddenArgs) == 0 {
+		return params
+	}
+	out := make([]llm.ToolParam, 0, len(params))
+	for _, p := range params {
+		if t.hiddenArgs[p.Name] {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func isPermControlEnabledFor(settingsSvc *SettingsService, channel, senderID string) bool {
+	if settingsSvc == nil {
+		return false
+	}
+	return IsPermControlEnabled(settingsSvc.GetPermUsers(channel, senderID))
+}
+
+func visibleToolDefs(defs []llm.ToolDefinition, settingsSvc *SettingsService, channel, senderID string) []llm.ToolDefinition {
+	if isPermControlEnabledFor(settingsSvc, channel, senderID) {
+		return defs
+	}
+	out := make([]llm.ToolDefinition, 0, len(defs))
+	for _, d := range defs {
+		switch d.Name() {
+		case "Shell", "FileCreate", "FileReplace":
+			out = append(out, &toolDefFilter{base: d, hiddenArgs: map[string]bool{"run_as": true, "reason": true}})
+		default:
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/agent/prompt_handler.go
+++ b/agent/prompt_handler.go
@@ -32,7 +32,7 @@ func (a *Agent) handlePromptQuery(ctx context.Context, msg bus.InboundMessage, t
 
 	// 获取工具定义
 	sessionKey := msg.Channel + ":" + msg.ChatID
-	toolDefs := a.tools.AsDefinitionsForSession(sessionKey)
+	toolDefs := visibleToolDefs(a.tools.AsDefinitionsForSession(sessionKey), a.settingsSvc, msg.Channel, msg.SenderID)
 
 	// 格式化输出
 	var buf strings.Builder

--- a/agent/settings.go
+++ b/agent/settings.go
@@ -33,6 +33,26 @@ func (s *SettingsService) GetSettings(channelName, senderID string) (map[string]
 	return s.store.Get(channelName, senderID)
 }
 
+// GetPermUsers retrieves the permission control user configuration for a user.
+// Returns a PermUsersConfig with DefaultUser and PrivilegedUser from user settings.
+func (s *SettingsService) GetPermUsers(channelName, senderID string) *PermUsersConfig {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	settings, err := s.store.Get(channelName, senderID)
+	if err != nil {
+		return nil
+	}
+	config := &PermUsersConfig{
+		DefaultUser:    settings["default_user"],
+		PrivilegedUser: settings["privileged_user"],
+	}
+	if config.DefaultUser == "" && config.PrivilegedUser == "" {
+		return nil // feature disabled
+	}
+	return config
+}
+
 // SetSetting sets a single setting value.
 func (s *SettingsService) SetSetting(channelName, senderID, key, value string) error {
 	if s == nil || s.store == nil {

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -135,6 +135,11 @@ func (c *CLIChannel) Start() error {
 	)
 	c.programMu.Unlock()
 
+	// Wire CLIApprovalHandler into the ApprovalHook now that the program exists
+	if c.approvalHook != nil {
+		c.approvalHook.SetHandler(NewCLIApprovalHandler(c.program))
+	}
+
 	// Ctrl+Z 紧急退出：双保险
 	// 1) Key event handler (cli_update.go): raw mode 下终端可能直接传 0x1A 字节
 	// 2) SIGTSTP 信号兜底: 某些终端 emulator 在 raw mode 下仍发信号
@@ -233,6 +238,12 @@ func (c *CLIChannel) SendProgress(chatID string, payload *CLIProgressPayload) {
 		return
 	}
 	c.program.Send(cliProgressMsg{payload: payload})
+}
+
+// SetApprovalHook stores the ApprovalHook reference so that Start() can wire
+// the CLIApprovalHandler after the tea.Program is created.
+func (c *CLIChannel) SetApprovalHook(hook *tools.ApprovalHook) {
+	c.approvalHook = hook
 }
 
 // SetBgTaskManager configures the background task manager for status display.

--- a/channel/cli_approval.go
+++ b/channel/cli_approval.go
@@ -3,8 +3,10 @@ package channel
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"xbot/tools"
 )
@@ -23,7 +25,7 @@ func NewCLIApprovalHandler(program *tea.Program) *CLIApprovalHandler {
 // RequestApproval sends an approval request to the TUI and blocks until the user responds.
 func (h *CLIApprovalHandler) RequestApproval(ctx context.Context, req tools.ApprovalRequest) (tools.ApprovalResult, error) {
 	// Create a channel to receive the user's response
-	resultCh := make(chan bool, 1)
+	resultCh := make(chan tools.ApprovalResult, 1)
 
 	// Send approval request to the TUI
 	if h.program != nil {
@@ -35,18 +37,174 @@ func (h *CLIApprovalHandler) RequestApproval(ctx context.Context, req tools.Appr
 
 	// Wait for user response or context cancellation
 	select {
-	case approved := <-resultCh:
-		if approved {
-			return tools.ApprovalApproved, nil
-		}
-		return tools.ApprovalDenied, nil
+	case result := <-resultCh:
+		return result, nil
 	case <-ctx.Done():
-		return tools.ApprovalDenied, fmt.Errorf("approval request timed out")
+		return tools.ApprovalResult{Approved: false}, fmt.Errorf("approval request timed out")
 	}
 }
 
 // approvalRequestMsg is a Tea message that triggers the approval dialog.
 type approvalRequestMsg struct {
 	request  tools.ApprovalRequest
-	resultCh chan<- bool
+	resultCh chan<- tools.ApprovalResult
+}
+
+// --- Panel: Update (key handling) ---
+
+// updateApprovalPanel handles key events for the approval dialog.
+func (m *cliModel) updateApprovalPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
+	if m.approvalEnteringDeny {
+		var cmd tea.Cmd
+		m.approvalDenyInput, cmd = m.approvalDenyInput.Update(msg)
+		m.renderCacheValid = false
+		switch msg.Code {
+		case tea.KeyEnter:
+			m.resolveApproval(false, strings.TrimSpace(m.approvalDenyInput.Value()))
+			return true, m, nil
+		case tea.KeyEscape:
+			m.approvalEnteringDeny = false
+			m.approvalDenyInput.Blur()
+			return true, m, nil
+		}
+		return true, m, cmd
+	}
+
+	switch msg.Code {
+	case tea.KeyLeft, tea.KeyUp:
+		m.approvalCursor = 0 // Approve
+		m.renderCacheValid = false
+		return true, m, nil
+	case tea.KeyRight, tea.KeyDown:
+		m.approvalCursor = 1 // Deny
+		m.renderCacheValid = false
+		return true, m, nil
+	case tea.KeyTab:
+		m.approvalCursor = (m.approvalCursor + 1) % 2
+		m.renderCacheValid = false
+		return true, m, nil
+	case tea.KeyEnter:
+		if m.approvalCursor == 0 {
+			m.resolveApproval(true, "")
+		} else {
+			m.approvalEnteringDeny = true
+			m.approvalDenyInput.Focus()
+		}
+		return true, m, nil
+	case tea.KeyEscape:
+		m.resolveApproval(false, "") // Esc = deny without reason
+		return true, m, nil
+	}
+
+	if msg.Code == 0 {
+		switch msg.String() {
+		case "y", "Y":
+			m.resolveApproval(true, "")
+			return true, m, nil
+		case "n", "N":
+			m.approvalEnteringDeny = true
+			m.approvalDenyInput.Focus()
+			m.renderCacheValid = false
+			return true, m, nil
+		}
+	}
+
+	return true, m, nil // swallow all keys in approval mode
+}
+
+// resolveApproval sends the result and closes the approval panel.
+func (m *cliModel) resolveApproval(approved bool, denyReason string) {
+	if m.approvalResultCh != nil {
+		m.approvalResultCh <- tools.ApprovalResult{Approved: approved, DenyReason: denyReason}
+		m.approvalResultCh = nil
+	}
+	m.approvalRequest = nil
+	m.approvalCursor = 0
+	m.approvalEnteringDeny = false
+	m.panelMode = ""
+	m.renderCacheValid = false
+}
+
+// --- Panel: View (rendering) ---
+
+// viewApprovalPanel renders the approval dialog content.
+func (m *cliModel) viewApprovalPanel() string {
+	if m.approvalRequest == nil {
+		return ""
+	}
+
+	s := m.styles
+	req := m.approvalRequest
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString(s.PanelHeader.Render("⚠ Permission Required"))
+	sb.WriteString("\n")
+	sb.WriteString(s.SettingsDivider.Render("┈" + strings.Repeat("┈", 30)))
+	sb.WriteString("\n\n")
+
+	// Details
+	warnSt := lipgloss.NewStyle().Foreground(s.PanelHeader.GetForeground()).Bold(true)
+	labelSt := lipgloss.NewStyle().Foreground(s.PanelDesc.GetForeground())
+	valueSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#ffffff"))
+
+	sb.WriteString(warnSt.Render(fmt.Sprintf("  LLM wants to execute as %q", req.RunAs)))
+	sb.WriteString("\n\n")
+
+	sb.WriteString(labelSt.Render("  Tool:    "))
+	sb.WriteString(valueSt.Render(req.ToolName))
+	sb.WriteString("\n")
+
+	if req.Command != "" {
+		sb.WriteString(labelSt.Render("  Command: "))
+		sb.WriteString(valueSt.Render(req.Command))
+		sb.WriteString("\n")
+	}
+	if req.FilePath != "" {
+		sb.WriteString(labelSt.Render("  File:    "))
+		sb.WriteString(valueSt.Render(req.FilePath))
+		sb.WriteString("\n")
+	}
+	if req.ArgsSummary != "" && req.ArgsSummary != req.Command && req.ArgsSummary != req.FilePath {
+		sb.WriteString(labelSt.Render("  Args:    "))
+		sb.WriteString(valueSt.Render(req.ArgsSummary))
+		sb.WriteString("\n")
+	}
+	if req.Reason != "" {
+		sb.WriteString(labelSt.Render("  Reason:  "))
+		sb.WriteString(valueSt.Render(req.Reason))
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+	if m.approvalEnteringDeny {
+		sb.WriteString(labelSt.Render("  Deny note: "))
+		sb.WriteString("\n")
+		sb.WriteString("  " + m.approvalDenyInput.View())
+		sb.WriteString("\n")
+		sb.WriteString(labelSt.Render("  Enter submit deny, Esc back"))
+		sb.WriteString("\n\n")
+	}
+
+	// Buttons
+	approveLabel := "  Approve (y)  "
+	denyLabel := "  Deny (n)  "
+
+	activeSt := lipgloss.NewStyle().Background(lipgloss.Color("#22c55e")).Foreground(lipgloss.Color("#000000")).Bold(true)
+	activeRedSt := lipgloss.NewStyle().Background(lipgloss.Color("#ef4444")).Foreground(lipgloss.Color("#ffffff")).Bold(true)
+	inactiveSt := lipgloss.NewStyle().Foreground(s.PanelDesc.GetForeground()).Faint(true)
+
+	var approve, deny string
+	if m.approvalCursor == 0 {
+		approve = activeSt.Render(approveLabel)
+		deny = inactiveSt.Render(denyLabel)
+	} else {
+		approve = inactiveSt.Render(approveLabel)
+		deny = activeRedSt.Render(denyLabel)
+	}
+
+	sb.WriteString("  " + approve + "    " + deny)
+	sb.WriteString("\n")
+
+	return sb.String()
 }

--- a/channel/cli_approval.go
+++ b/channel/cli_approval.go
@@ -3,7 +3,6 @@ package channel
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -13,18 +12,12 @@ import (
 // CLIApprovalHandler implements tools.ApprovalHandler for the CLI channel.
 // It uses the Bubble Tea TUI to present approval dialogs.
 type CLIApprovalHandler struct {
-	mu      sync.Mutex
 	program *tea.Program
 }
 
 // NewCLIApprovalHandler creates a new CLIApprovalHandler.
 func NewCLIApprovalHandler(program *tea.Program) *CLIApprovalHandler {
 	return &CLIApprovalHandler{program: program}
-}
-
-// approvalResultMsg carries the user's approval decision back to the waiting goroutine.
-type approvalResultMsg struct {
-	approved bool
 }
 
 // RequestApproval sends an approval request to the TUI and blocks until the user responds.

--- a/channel/cli_approval.go
+++ b/channel/cli_approval.go
@@ -1,0 +1,59 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	tea "charm.land/bubbletea/v2"
+
+	"xbot/tools"
+)
+
+// CLIApprovalHandler implements tools.ApprovalHandler for the CLI channel.
+// It uses the Bubble Tea TUI to present approval dialogs.
+type CLIApprovalHandler struct {
+	mu      sync.Mutex
+	program *tea.Program
+}
+
+// NewCLIApprovalHandler creates a new CLIApprovalHandler.
+func NewCLIApprovalHandler(program *tea.Program) *CLIApprovalHandler {
+	return &CLIApprovalHandler{program: program}
+}
+
+// approvalResultMsg carries the user's approval decision back to the waiting goroutine.
+type approvalResultMsg struct {
+	approved bool
+}
+
+// RequestApproval sends an approval request to the TUI and blocks until the user responds.
+func (h *CLIApprovalHandler) RequestApproval(ctx context.Context, req tools.ApprovalRequest) (tools.ApprovalResult, error) {
+	// Create a channel to receive the user's response
+	resultCh := make(chan bool, 1)
+
+	// Send approval request to the TUI
+	if h.program != nil {
+		h.program.Send(approvalRequestMsg{
+			request:  req,
+			resultCh: resultCh,
+		})
+	}
+
+	// Wait for user response or context cancellation
+	select {
+	case approved := <-resultCh:
+		if approved {
+			return tools.ApprovalApproved, nil
+		}
+		return tools.ApprovalDenied, nil
+	case <-ctx.Done():
+		return tools.ApprovalDenied, fmt.Errorf("approval request timed out")
+	}
+}
+
+// approvalRequestMsg is a Tea message that triggers the approval dialog.
+type approvalRequestMsg struct {
+	request  tools.ApprovalRequest
+	resultCh chan<- bool
+}

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -274,17 +274,23 @@ type cliModel struct {
 	panelCombo    bool           // settings panel: combo dropdown open
 	panelComboIdx int            // settings panel: combo selected option index
 	// --- AskUser panel ---
-	panelItems     []askItem                       // askuser panel: question items
-	panelTab       int                             // askuser panel: current tab (question index)
-	panelOptSel    map[int]map[int]bool            // askuser panel: selected option indices per question
-	panelOptCursor map[int]int                     // askuser panel: highlighted option index per question
-	panelAnswerTA  textarea.Model                  // askuser panel: free-input editor (no-options mode)
-	panelOtherTI   textinput.Model                 // askuser panel: single-line Other input
-	panelSchema    []SettingDefinition             // settings panel: schema copy
-	panelValues    map[string]string               // settings panel: current values
-	panelOnSubmit  func(values map[string]string)  // callback on settings submit
-	panelOnAnswer  func(answers map[string]string) // callback on askuser answers (key=index, value=answer)
-	panelOnCancel  func()                          // callback on cancel
+	panelItems     []askItem            // askuser panel: question items
+	panelTab       int                  // askuser panel: current tab (question index)
+	panelOptSel    map[int]map[int]bool // askuser panel: selected option indices per question
+	panelOptCursor map[int]int          // askuser panel: highlighted option index per question
+	panelAnswerTA  textarea.Model       // askuser panel: free-input editor (no-options mode)
+	panelOtherTI   textinput.Model      // askuser panel: single-line Other input
+	panelSchema    []SettingDefinition  // settings panel: schema copy
+	// --- Approval panel ---
+	approvalRequest      *tools.ApprovalRequest // pending approval request
+	approvalResultCh     chan<- tools.ApprovalResult
+	approvalCursor       int                             // 0=approve, 1=deny
+	approvalDenyInput    textinput.Model                 // deny reason input
+	approvalEnteringDeny bool                            // true when editing deny reason
+	panelValues          map[string]string               // settings panel: current values
+	panelOnSubmit        func(values map[string]string)  // callback on settings submit
+	panelOnAnswer        func(answers map[string]string) // callback on askuser answers (key=index, value=answer)
+	panelOnCancel        func()                          // callback on cancel
 
 	// --- Bg Tasks Panel ---
 	panelBgTasks    []*tools.BackgroundTask // cached task list

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -486,6 +486,8 @@ func (m *cliModel) updatePanel(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 			return m.updateDangerPanel(msg)
 		case "runner":
 			return m.updateRunnerPanel(msg)
+		case "approval":
+			return m.updateApprovalPanel(msg)
 		}
 		return false, m, nil
 	}()
@@ -1053,6 +1055,8 @@ func (m *cliModel) viewPanel() string {
 		raw = m.viewDangerPanel()
 	case "runner":
 		raw = m.viewRunnerPanel()
+	case "approval":
+		raw = m.viewApprovalPanel()
 	default:
 		return ""
 	}

--- a/channel/cli_progress_test.go
+++ b/channel/cli_progress_test.go
@@ -310,9 +310,14 @@ func TestBgTaskInjectedUserMessage_StartsSpinner(t *testing.T) {
 		t.Error("should not be typing initially")
 	}
 
-	model.Update(cliInjectedUserMsg{content: "bg task done"})
+	_, cmd := model.Update(cliInjectedUserMsg{content: "bg task done"})
 
-	// After injection, should be typing
+	// After injection, should be typing and re-arm fast tick chain.
+	// This prevents spinner/elapsed timers from freezing when a bg task
+	// completion arrives while the UI was idle.
+	if cmd == nil {
+		t.Fatal("expected injected bg-task message to schedule follow-up commands (tick/toast)")
+	}
 	if !model.typing {
 		t.Error("should be typing after bg injection")
 	}

--- a/channel/cli_prompt.go
+++ b/channel/cli_prompt.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"xbot/internal/ctxkeys"
 	"xbot/prompt"
 )
 
@@ -11,8 +12,12 @@ type CliPromptProvider struct{}
 
 func (p *CliPromptProvider) ChannelPromptName() string { return "cli" }
 
-func (p *CliPromptProvider) ChannelSystemParts(_ context.Context, _, _ string) map[string]string {
-	return map[string]string{
+func (p *CliPromptProvider) ChannelSystemParts(ctx context.Context, _, _ string) map[string]string {
+	parts := map[string]string{
 		"05_channel_cli": prompt.CLIChannel,
 	}
+	if ctxkeys.PermControlEnabledFromContext(ctx) {
+		parts["06_channel_cli_perm"] = "\n## CLI Permission Control\n\n- Never write raw `sudo` in commands.\n- When privilege switching is needed, use `run_as` and `reason` together.\n- Use the default execution user for routine work.\n- Use the privileged user only when genuinely necessary.\n- If approval is denied and the user provides feedback, respect that feedback and adjust your plan.\n"
+	}
+	return parts
 }

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -472,6 +472,9 @@ type CLIChannel struct {
 
 	runnerAutoConnect *runnerAutoConnectConfig // auto-connect as runner after TUI init
 
+	// Permission control
+	approvalHook *tools.ApprovalHook // injected to wire CLIApprovalHandler after program creation
+
 }
 
 // SettingsService is the interface needed by CLIChannel for settings panel.

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"fmt"
@@ -323,6 +324,20 @@ func (m *cliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, matrixTickCmd())
 		}
 		return m, tea.Batch(cmds...)
+
+	case approvalRequestMsg:
+		// Permission control: show approval dialog
+		m.approvalRequest = &msg.request
+		m.approvalResultCh = msg.resultCh
+		m.approvalCursor = 0 // default to Approve
+		m.approvalEnteringDeny = false
+		m.approvalDenyInput = textinput.New()
+		m.approvalDenyInput.Placeholder = "Optional deny reason for LLM"
+		m.approvalDenyInput.CharLimit = 200
+		m.approvalDenyInput.SetWidth(60)
+		m.panelMode = "approval"
+		m.renderCacheValid = false
+		return m, nil
 	}
 
 	// Kick off tick chain when processing just started

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -518,6 +518,16 @@ func (m *cliModel) handleInjectedUserMsg(msg cliInjectedUserMsg) []tea.Cmd {
 		m.bgTaskCount = m.bgTaskCountFn()
 	}
 	m.renderCacheValid = false
+	// IMPORTANT: re-arm the fast tick chain *here* when an injected user message
+	// flips the UI from idle -> typing (common case: bg task completion arrives
+	// while the agent is otherwise idle). Do NOT rely solely on the generic
+	// `if m.typing && !wasTyping { tickCmd() }` logic at the bottom of Update():
+	// that transition can be bypassed by future early-return branches, which has
+	// repeatedly caused the whole TUI (spinner / elapsed timers / queue flush)
+	// to stop updating. The message that starts typing must enqueue its own tick.
+	//
+	// Keep this invariant local to the state transition source to prevent another
+	// recurrence of the “UI froze after bg task completion” class of bugs.
 	// §16 触发 toast 通知（后台任务完成提示）
 	// 提取首行作为 toast 文本，避免内容过长
 	firstLine := msg.content
@@ -535,7 +545,7 @@ func (m *cliModel) handleInjectedUserMsg(msg cliInjectedUserMsg) []tea.Cmd {
 	} else if strings.Contains(lower, "error") || strings.Contains(lower, "failed") {
 		icon = "✗"
 	}
-	return []tea.Cmd{m.enqueueToast(firstLine, icon)}
+	return []tea.Cmd{tickCmd(), m.enqueueToast(firstLine, icon)}
 }
 
 // handleUpdateCheck processes update check results.

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -583,6 +583,8 @@ func (m *cliModel) renderFooter() string {
 			} else {
 				hints = append(hints, m.keyHint("↑↓", m.locale.FooterNavigate), m.keyHint("Enter", m.locale.FooterLog), m.keyHint("Del", m.locale.FooterKill), m.keyHint("Esc", m.locale.FooterClose))
 			}
+		case "approval":
+			hints = append(hints, m.keyHint("←→", m.locale.FooterNavigate), m.keyHint("y/n", "Quick"), m.keyHint("Enter", m.locale.FooterSelect), m.keyHint("Esc", "Deny"))
 		default:
 			hints = append(hints, m.keyHint("↑↓", m.locale.FooterNavigate), m.keyHint("Enter", m.locale.FooterSelect), m.keyHint("Esc", m.locale.FooterClose))
 		}

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"xbot/bus"
+	"xbot/internal/ctxkeys"
 	log "xbot/logger"
 	"xbot/prompt"
 	"xbot/storage/sqlite"
@@ -148,6 +149,23 @@ type FeishuChannel struct {
 
 	// Settings card callbacks (injected from Agent via main.go)
 	settingsCallbacks SettingsCallbacks
+
+	// Permission control
+	approvalHook *tools.ApprovalHook
+	approvalsMu  sync.Mutex
+	approvals    map[string]*feishuPendingApproval
+}
+
+type feishuPendingApproval struct {
+	Request          tools.ApprovalRequest
+	ChatID           string
+	SenderID         string
+	MessageID        string
+	ResultCh         chan tools.ApprovalResult
+	CreatedAt        time.Time
+	ApproveAction    string
+	DenyAction       string
+	DenySubmitAction string
 }
 
 // NewFeishuChannel 创建飞书渠道
@@ -158,6 +176,7 @@ func NewFeishuChannel(cfg FeishuConfig, msgBus *bus.MessageBus) *FeishuChannel {
 		processedIDs:  make(map[string]struct{}),
 		maxProcessed:  1000,
 		userNameCache: make(map[string]string),
+		approvals:     make(map[string]*feishuPendingApproval),
 	}
 }
 
@@ -174,6 +193,11 @@ func (f *FeishuChannel) ChannelSystemParts(ctx context.Context, chatID, senderID
 // SetCardBuilder sets the CardBuilder for card callback handling.
 func (f *FeishuChannel) SetCardBuilder(builder *tools.CardBuilder) {
 	f.cardBuilder = builder
+}
+
+// SetApprovalHook stores the ApprovalHook reference so Start() can wire a Feishu approval handler.
+func (f *FeishuChannel) SetApprovalHook(hook *tools.ApprovalHook) {
+	f.approvalHook = hook
 }
 
 // SetSettingsCallbacks injects settings card callbacks from Agent.
@@ -207,6 +231,10 @@ func (f *FeishuChannel) Start() error {
 	// 初始化机器人自身 open_id（用于群聊 @ 识别）
 	if err := f.refreshBotOpenID(context.Background()); err != nil {
 		log.WithError(err).Warn("Feishu: failed to initialize bot open_id from bot/v3/info")
+	}
+
+	if f.approvalHook != nil {
+		f.approvalHook.SetHandler(NewFeishuApprovalHandler(f))
 	}
 
 	// 创建事件处理器
@@ -1172,6 +1200,11 @@ func (f *FeishuChannel) onCardAction(ctx context.Context, event *callback.CardAc
 		messageID = event.Event.Context.OpenMessageID
 	}
 
+	// Intercept permission approval actions before other card routing.
+	if resp, ok := f.handleApprovalCardAction(actionData, action, senderID); ok {
+		return resp, nil
+	}
+
 	// 拦截 settings 卡片交互（按钮点击、下拉选择、表单提交，在 CardBuilder 路由之前）
 	if parsed := parseActionDataFromMap(actionData); parsed != nil {
 		if actionName := parsed["action"]; strings.HasPrefix(actionName, settingsCardActionPrefix) {
@@ -1262,6 +1295,314 @@ func (f *FeishuChannel) buildKeepCardResponse(cardID string) *callback.CardActio
 		}
 	}
 	return resp
+}
+
+// FeishuApprovalHandler implements tools.ApprovalHandler for the Feishu channel.
+type FeishuApprovalHandler struct {
+	channel *FeishuChannel
+}
+
+// NewFeishuApprovalHandler creates a new FeishuApprovalHandler.
+func NewFeishuApprovalHandler(channel *FeishuChannel) *FeishuApprovalHandler {
+	return &FeishuApprovalHandler{channel: channel}
+}
+
+// RequestApproval sends an approval card and waits for the user's response.
+func (h *FeishuApprovalHandler) RequestApproval(ctx context.Context, req tools.ApprovalRequest) (tools.ApprovalResult, error) {
+	if h == nil || h.channel == nil {
+		return tools.ApprovalResult{Approved: false}, fmt.Errorf("feishu approval handler is not initialized")
+	}
+	return h.channel.requestApproval(ctx, req)
+}
+
+func (f *FeishuChannel) requestApproval(ctx context.Context, req tools.ApprovalRequest) (tools.ApprovalResult, error) {
+	chatID, senderID := ctxkeys.ApprovalTargetFromContext(ctx)
+	if chatID == "" || senderID == "" {
+		log.WithFields(log.Fields{"chat_id": chatID, "sender_id": senderID, "tool": req.ToolName, "run_as": req.RunAs}).Warn("Feishu approval missing target context")
+		return tools.ApprovalResult{Approved: false}, fmt.Errorf("feishu approval requires chat and sender in context")
+	}
+
+	pending := &feishuPendingApproval{
+		Request:          req,
+		ChatID:           chatID,
+		SenderID:         senderID,
+		ResultCh:         make(chan tools.ApprovalResult, 1),
+		CreatedAt:        time.Now(),
+		ApproveAction:    fmt.Sprintf("perm_approve_%d", time.Now().UnixNano()),
+		DenyAction:       fmt.Sprintf("perm_deny_%d", time.Now().UnixNano()),
+		DenySubmitAction: fmt.Sprintf("perm_deny_submit_%d", time.Now().UnixNano()),
+	}
+
+	card := f.buildApprovalCard(pending)
+	cardJSON, err := json.Marshal(card)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"chat_id": chatID, "sender_id": senderID, "tool": req.ToolName, "run_as": req.RunAs}).Error("Feishu approval card marshal failed")
+		return tools.ApprovalResult{Approved: false}, fmt.Errorf("marshal approval card: %w", err)
+	}
+
+	log.WithFields(log.Fields{"chat_id": chatID, "sender_id": senderID, "tool": req.ToolName, "run_as": req.RunAs}).Info("Sending Feishu approval card")
+	messageID, err := f.sendNormalMessage(chatID, cardJSON)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"chat_id": chatID, "sender_id": senderID, "tool": req.ToolName, "run_as": req.RunAs, "card": string(cardJSON)}).Error("Feishu approval card send failed")
+		return tools.ApprovalResult{Approved: false}, fmt.Errorf("send approval card: %w", err)
+	}
+	pending.MessageID = messageID
+	log.WithFields(log.Fields{"message_id": messageID, "chat_id": chatID, "sender_id": senderID, "tool": req.ToolName, "run_as": req.RunAs}).Info("Feishu approval card sent")
+
+	f.approvalsMu.Lock()
+	f.approvals[pending.ApproveAction] = pending
+	f.approvals[pending.DenyAction] = pending
+	f.approvals[pending.DenySubmitAction] = pending
+	f.approvalsMu.Unlock()
+
+	select {
+	case result := <-pending.ResultCh:
+		log.WithFields(log.Fields{"message_id": pending.MessageID, "tool": req.ToolName, "run_as": req.RunAs, "approved": result.Approved}).Info("Feishu approval resolved")
+		return result, nil
+	case <-ctx.Done():
+		result := tools.ApprovalResult{Approved: false, DenyReason: "approval request timed out"}
+		f.finishPendingApproval(pending, result)
+		f.closeApprovalCardOnTimeout(pending)
+		log.WithFields(log.Fields{"message_id": pending.MessageID, "tool": req.ToolName, "run_as": req.RunAs}).Warn("Feishu approval timed out")
+		return tools.ApprovalResult{Approved: false}, fmt.Errorf("approval request timed out")
+	}
+}
+
+func (f *FeishuChannel) buildApprovalCard(p *feishuPendingApproval) map[string]any {
+	req := p.Request
+	elements := []map[string]any{
+		{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**Permission approval required**\n\nLLM wants to execute as `%s`.", req.RunAs),
+		},
+		{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**Tool:** %s\n**Reason:** %s", req.ToolName, escapeFeishuMarkdown(req.Reason)),
+		},
+	}
+	if req.Command != "" {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**Command:** `%s`", escapeFeishuMarkdown(req.Command)),
+		})
+	}
+	if req.FilePath != "" {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**File:** `%s`", escapeFeishuMarkdown(req.FilePath)),
+		})
+		if req.ArgsSummary != "" && req.ArgsSummary != req.FilePath {
+			elements = append(elements, map[string]any{
+				"tag":     "markdown",
+				"content": fmt.Sprintf("**Args:** `%s`", escapeFeishuMarkdown(req.ArgsSummary)),
+			})
+		}
+	} else if req.ArgsSummary != "" && req.ArgsSummary != req.Command {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**Args:** `%s`", escapeFeishuMarkdown(req.ArgsSummary)),
+		})
+	}
+	elements = append(elements,
+		wrapButtonsInColumns([]map[string]any{
+			{
+				"tag":   "button",
+				"text":  map[string]any{"tag": "plain_text", "content": "Approve"},
+				"type":  "primary",
+				"value": map[string]any{"action": p.ApproveAction},
+			},
+			{
+				"tag":   "button",
+				"text":  map[string]any{"tag": "plain_text", "content": "Deny"},
+				"type":  "danger",
+				"value": map[string]any{"action": p.DenyAction},
+			},
+		}),
+	)
+
+	return map[string]any{
+		"schema": "2.0",
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": "Permission Approval"},
+			"template": "orange",
+		},
+		"body":   map[string]any{"elements": elements},
+		"config": map[string]any{"wide_screen_mode": true},
+	}
+}
+
+func escapeFeishuMarkdown(s string) string {
+	s = strings.ReplaceAll(s, "`", "'")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}
+
+func (f *FeishuChannel) findPendingApproval(action string) *feishuPendingApproval {
+	f.approvalsMu.Lock()
+	defer f.approvalsMu.Unlock()
+	return f.approvals[action]
+}
+
+func (f *FeishuChannel) removePendingApproval(p *feishuPendingApproval) {
+	f.approvalsMu.Lock()
+	defer f.approvalsMu.Unlock()
+	delete(f.approvals, p.ApproveAction)
+	delete(f.approvals, p.DenyAction)
+	delete(f.approvals, p.DenySubmitAction)
+}
+
+func (f *FeishuChannel) finishPendingApproval(p *feishuPendingApproval, result tools.ApprovalResult) {
+	if p == nil {
+		return
+	}
+	f.removePendingApproval(p)
+	select {
+	case p.ResultCh <- result:
+	default:
+	}
+}
+
+func (f *FeishuChannel) handleApprovalCardAction(actionData map[string]any, action *callback.CallBackAction, senderID string) (*callback.CardActionTriggerResponse, bool) {
+	if actionData == nil {
+		return nil, false
+	}
+	actionName, _ := actionData["action"].(string)
+	pending := f.findPendingApproval(actionName)
+	if pending == nil {
+		return nil, false
+	}
+	if senderID == "" || senderID != pending.SenderID {
+		return &callback.CardActionTriggerResponse{
+			Toast: &callback.Toast{Type: "error", Content: "Only the requesting user can approve this action."},
+		}, true
+	}
+
+	switch actionName {
+	case pending.ApproveAction:
+		result := tools.ApprovalResult{Approved: true}
+		f.finishPendingApproval(pending, result)
+		return &callback.CardActionTriggerResponse{
+			Card:  &callback.Card{Type: "raw", Data: f.buildApprovalResultCard(pending, result)},
+			Toast: &callback.Toast{Type: "success", Content: approvalToastContent(result)},
+		}, true
+	case pending.DenyAction:
+		return &callback.CardActionTriggerResponse{
+			Card:  &callback.Card{Type: "raw", Data: f.buildApprovalDenyReasonCard(pending)},
+			Toast: &callback.Toast{Type: "info", Content: "Add an optional deny reason, then submit."},
+		}, true
+	case pending.DenySubmitAction:
+		denyReason := strings.TrimSpace(formStr(action.FormValue, "deny_reason"))
+		result := tools.ApprovalResult{Approved: false, DenyReason: denyReason}
+		f.finishPendingApproval(pending, result)
+		return &callback.CardActionTriggerResponse{
+			Card:  &callback.Card{Type: "raw", Data: f.buildApprovalResultCard(pending, result)},
+			Toast: &callback.Toast{Type: "success", Content: approvalToastContent(result)},
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func approvalToastContent(result tools.ApprovalResult) string {
+	if result.Approved {
+		return "Approved"
+	}
+	if strings.Contains(strings.ToLower(strings.TrimSpace(result.DenyReason)), "timed out") {
+		return "Timed out"
+	}
+	return "Denied"
+}
+
+func (f *FeishuChannel) buildApprovalDenyReasonCard(p *feishuPendingApproval) map[string]any {
+	elements := []map[string]any{
+		{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**Deny execution as `%s`**\n\nTool: %s", escapeFeishuMarkdown(p.Request.RunAs), p.Request.ToolName),
+		},
+	}
+	if p.Request.Command != "" {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("**Command:** `%s`", escapeFeishuMarkdown(p.Request.Command)),
+		})
+	}
+	elements = append(elements, map[string]any{
+		"tag":  "form",
+		"name": "perm_deny_reason_form",
+		"elements": []map[string]any{
+			{
+				"tag":         "input",
+				"name":        "deny_reason",
+				"label":       map[string]any{"tag": "plain_text", "content": "Deny reason (optional)"},
+				"placeholder": map[string]any{"tag": "plain_text", "content": "Why deny this request?"},
+			},
+			{
+				"tag":   "button",
+				"name":  "submit_deny_reason",
+				"text":  map[string]any{"tag": "plain_text", "content": "Submit Deny"},
+				"type":  "danger",
+				"value": map[string]any{"action": p.DenySubmitAction},
+			},
+		},
+	})
+	return map[string]any{
+		"schema": "2.0",
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": "Permission Approval - Deny"},
+			"template": "red",
+		},
+		"body":   map[string]any{"elements": elements},
+		"config": map[string]any{"wide_screen_mode": true},
+	}
+}
+
+func (f *FeishuChannel) closeApprovalCardOnTimeout(p *feishuPendingApproval) {
+	if f == nil || p == nil || p.MessageID == "" {
+		return
+	}
+	cardJSON, err := json.Marshal(f.buildApprovalResultCard(p, tools.ApprovalResult{Approved: false, DenyReason: "approval request timed out"}))
+	if err != nil {
+		log.WithError(err).WithField("message_id", p.MessageID).Warn("Feishu: failed to marshal timeout approval card")
+		return
+	}
+	if err := f.patchMessage(p.MessageID, cardJSON); err != nil {
+		log.WithError(err).WithField("message_id", p.MessageID).Warn("Feishu: failed to patch timed-out approval card")
+		return
+	}
+	log.WithField("message_id", p.MessageID).Info("Feishu approval card closed after timeout")
+}
+
+func (f *FeishuChannel) buildApprovalResultCard(p *feishuPendingApproval, result tools.ApprovalResult) map[string]any {
+	status := "Denied"
+	template := "red"
+	summary := "Execution denied."
+	if result.Approved {
+		status = "Approved"
+		template = "green"
+		summary = "Execution approved."
+	} else if strings.Contains(strings.ToLower(strings.TrimSpace(result.DenyReason)), "timed out") {
+		status = "Timed Out"
+		template = "grey"
+		summary = "Approval request timed out. This card is now closed."
+	} else if strings.TrimSpace(result.DenyReason) != "" {
+		summary = fmt.Sprintf("Execution denied: %s", escapeFeishuMarkdown(result.DenyReason))
+	}
+	content := fmt.Sprintf("**Status:** %s\n**Tool:** %s\n**Run as:** `%s`\n%s", status, p.Request.ToolName, escapeFeishuMarkdown(p.Request.RunAs), summary)
+	if p.Request.Command != "" {
+		content += fmt.Sprintf("\n**Command:** `%s`", escapeFeishuMarkdown(p.Request.Command))
+	}
+	if p.Request.FilePath != "" {
+		content += fmt.Sprintf("\n**File:** `%s`", escapeFeishuMarkdown(p.Request.FilePath))
+	}
+	return map[string]any{
+		"schema": "2.0",
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": "Permission Approval - " + status},
+			"template": template,
+		},
+		"body": map[string]any{"elements": []map[string]any{{"tag": "markdown", "content": content}}},
+	}
 }
 
 // handleCardBuilderAction handles card actions from Card Builder MCP cards.
@@ -2225,15 +2566,16 @@ func limitMarkdownTables(content string, maxTables int) string {
 
 // feishuSettingsSchema returns the settings definitions for Feishu channel.
 func feishuSettingsSchema() []SettingDefinition {
-	return []SettingDefinition{
-		{
-			Key:         "sandbox_cleanup",
-			Label:       "沙箱持久化",
-			Description: "将当前沙箱文件系统变更保存为镜像（export+import）。执行期间会阻塞你的所有请求。",
-			Type:        SettingTypeToggle,
-			Category:    "沙箱",
-		},
-	}
+	loc := GetLocale(currentLocaleLang)
+	base := append([]SettingDefinition(nil), loc.SettingsSchema...)
+	base = append(base, SettingDefinition{
+		Key:         "sandbox_cleanup",
+		Label:       "沙箱持久化",
+		Description: "将当前沙箱文件系统变更保存为镜像（export+import）。执行期间会阻塞你的所有请求。",
+		Type:        SettingTypeToggle,
+		Category:    "沙箱",
+	})
+	return base
 }
 
 // SettingsSchema returns the settings definitions for Feishu channel.

--- a/channel/feishu_settings_test.go
+++ b/channel/feishu_settings_test.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"xbot/bus"
 	"xbot/storage/sqlite"
+	"xbot/tools"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 )
 
 func newTestFeishuChannel() *FeishuChannel {
@@ -189,6 +193,145 @@ func TestBuildSettingsCard_DefaultsToGeneral(t *testing.T) {
 		if !strings.Contains(cardJSON(card), "远程 Runner") {
 			t.Errorf("tab=%q should default to general tab", tab)
 		}
+	}
+}
+
+func TestBuildApprovalCard_ContainsApproveDenyControls(t *testing.T) {
+	f := newTestFeishuChannel()
+	pending := &feishuPendingApproval{
+		Request: tools.ApprovalRequest{
+			ToolName: "Shell",
+			RunAs:    "root",
+			Reason:   "install package",
+			Command:  "apt install nginx",
+		},
+		ApproveAction:    "perm_approve_test",
+		DenyAction:       "perm_deny_test",
+		DenySubmitAction: "perm_deny_submit_test",
+	}
+
+	card := f.buildApprovalCard(pending)
+	s := cardJSON(card)
+	if !strings.Contains(s, "Permission Approval") {
+		t.Fatalf("expected approval card header, got %s", s)
+	}
+	if !strings.Contains(s, "perm_approve_test") || !strings.Contains(s, "perm_deny_test") {
+		t.Fatalf("expected approve/deny action ids in card: %s", s)
+	}
+	if strings.Contains(s, "deny_reason") {
+		t.Fatalf("did not expect deny_reason field in initial approval card: %s", s)
+	}
+	if !strings.Contains(s, "Deny") {
+		t.Fatalf("expected deny button in card: %s", s)
+	}
+	if strings.Contains(s, "perm_deny_submit_test") {
+		t.Fatalf("did not expect deny submit action in initial approval card: %s", s)
+	}
+}
+
+func TestHandleApprovalCardAction_DenyReasonPropagates(t *testing.T) {
+	f := newTestFeishuChannel()
+	pending := &feishuPendingApproval{
+		Request:          tools.ApprovalRequest{ToolName: "Shell", RunAs: "root", Command: "rm -rf /tmp/x"},
+		SenderID:         "user_open_id",
+		ResultCh:         make(chan tools.ApprovalResult, 1),
+		CreatedAt:        time.Now(),
+		ApproveAction:    "perm_approve_test",
+		DenyAction:       "perm_deny_test",
+		DenySubmitAction: "perm_deny_submit_test",
+	}
+	f.approvals[pending.ApproveAction] = pending
+	f.approvals[pending.DenyAction] = pending
+	f.approvals[pending.DenySubmitAction] = pending
+
+	resp, handled := f.handleApprovalCardAction(
+		map[string]any{"action": pending.DenyAction},
+		&callback.CallBackAction{},
+		"user_open_id",
+	)
+	if !handled {
+		t.Fatal("expected action to be handled")
+	}
+	if resp == nil || resp.Toast == nil || resp.Card == nil {
+		t.Fatal("expected toast and updated card response")
+	}
+	if got := <-func() chan string {
+		ch := make(chan string, 1)
+		select {
+		case result := <-pending.ResultCh:
+			ch <- result.DenyReason
+		default:
+			ch <- "__pending__"
+		}
+		return ch
+	}(); got != "__pending__" {
+		t.Fatalf("deny button should open deny-reason card first, got immediate result %q", got)
+	}
+
+	resp, handled = f.handleApprovalCardAction(
+		map[string]any{"action": pending.DenySubmitAction},
+		&callback.CallBackAction{FormValue: map[string]any{"deny_reason": "unsafe"}},
+		"user_open_id",
+	)
+	if !handled {
+		t.Fatal("expected deny submit action to be handled")
+	}
+	if resp == nil || resp.Toast == nil || resp.Card == nil {
+		t.Fatal("expected toast and updated card response after deny submit")
+	}
+	select {
+	case result := <-pending.ResultCh:
+		if result.Approved {
+			t.Fatal("expected denied result")
+		}
+		if result.DenyReason != "unsafe" {
+			t.Fatalf("expected deny reason propagation, got %q", result.DenyReason)
+		}
+	default:
+		t.Fatal("expected approval result to be delivered after deny submit")
+	}
+}
+
+func TestBuildApprovalResultCard_TimeoutClosedMessage(t *testing.T) {
+	f := newTestFeishuChannel()
+	pending := &feishuPendingApproval{
+		Request:   tools.ApprovalRequest{ToolName: "Shell", RunAs: "root", Command: "ls -la /root"},
+		MessageID: "msg_timeout_test",
+	}
+	card := f.buildApprovalResultCard(pending, tools.ApprovalResult{Approved: false, DenyReason: "approval request timed out"})
+	s := cardJSON(card)
+	if !strings.Contains(s, "Timed Out") {
+		t.Fatalf("expected timeout status in card: %s", s)
+	}
+	if !strings.Contains(s, "This card is now closed") {
+		t.Fatalf("expected closed-card message in timeout card: %s", s)
+	}
+}
+
+func TestHandleApprovalCardAction_RejectsWrongUser(t *testing.T) {
+	f := newTestFeishuChannel()
+	pending := &feishuPendingApproval{
+		Request:       tools.ApprovalRequest{ToolName: "Shell", RunAs: "root"},
+		SenderID:      "owner_user",
+		ResultCh:      make(chan tools.ApprovalResult, 1),
+		CreatedAt:     time.Now(),
+		ApproveAction: "perm_approve_test2",
+		DenyAction:    "perm_deny_test2",
+	}
+	f.approvals[pending.ApproveAction] = pending
+	f.approvals[pending.DenyAction] = pending
+
+	resp, handled := f.handleApprovalCardAction(map[string]any{"action": pending.ApproveAction}, &callback.CallBackAction{}, "other_user")
+	if !handled {
+		t.Fatal("expected action to be handled")
+	}
+	if resp == nil || resp.Toast == nil || resp.Toast.Type != "error" {
+		t.Fatal("expected error toast for wrong user")
+	}
+	select {
+	case <-pending.ResultCh:
+		t.Fatal("should not resolve pending approval for wrong user")
+	default:
 	}
 }
 

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -547,8 +547,8 @@ func localeZH() *UILocale {
 				},
 			},
 			// Permission control
-			{Key: "default_user", Label: "默认执行用户", Description: "工具执行的默认 OS 用户（需要配置 NOPASSWD sudoers）", Type: SettingTypeText, Category: "权限"},
-			{Key: "privileged_user", Label: "特权用户", Description: "需要审批才能使用的特权 OS 用户（需要配置 NOPASSWD sudoers）", Type: SettingTypeText, Category: "权限"},
+			{Key: "default_user", Label: "默认执行用户", Description: "LLM 可以免审批以此用户执行工具。留空则只能以当前进程用户执行（最安全）。需配置 NOPASSWD sudoers", Type: SettingTypeText, Category: "权限"},
+			{Key: "privileged_user", Label: "特权用户", Description: "LLM 以此用户执行时需要人工审批。留空则禁止提权。需配置 NOPASSWD sudoers", Type: SettingTypeText, Category: "权限"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner 管理", Type: SettingTypeText, Category: "Runner"},
 			// Danger zone entry (display-only, triggers panel switch)
@@ -918,8 +918,8 @@ func localeEN() *UILocale {
 				},
 			},
 			// Permission control
-			{Key: "default_user", Label: "Default User", Description: "Default OS user for tool execution (requires NOPASSWD sudoers)", Type: SettingTypeText, Category: "Permissions"},
-			{Key: "privileged_user", Label: "Privileged User", Description: "Privileged OS user requiring approval (requires NOPASSWD sudoers)", Type: SettingTypeText, Category: "Permissions"},
+			{Key: "default_user", Label: "Default User", Description: "OS user for LLM tool execution without approval. Leave empty to restrict to current process user (safest). Requires NOPASSWD sudoers", Type: SettingTypeText, Category: "Permissions"},
+			{Key: "privileged_user", Label: "Privileged User", Description: "OS user that requires human approval when used by LLM. Leave empty to block privilege escalation. Requires NOPASSWD sudoers", Type: SettingTypeText, Category: "Permissions"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner Manager", Type: SettingTypeText, Category: "Runner"},
 			// Danger zone entry (display-only, triggers panel switch)
@@ -1289,8 +1289,8 @@ func localeJA() *UILocale {
 				},
 			},
 			// Permission control
-			{Key: "default_user", Label: "デフォルトユーザー", Description: "ツール実行用のデフォルト OS ユーザー（NOPASSWD sudoers 設定が必要）", Type: SettingTypeText, Category: "権限"},
-			{Key: "privileged_user", Label: "特権ユーザー", Description: "承認が必要な特権 OS ユーザー（NOPASSWD sudoers 設定が必要）", Type: SettingTypeText, Category: "権限"},
+			{Key: "default_user", Label: "デフォルトユーザー", Description: "LLMが承認なしでツールを実行できるOSユーザー。空の場合は現在のプロセスユーザーに制限（最も安全）。NOPASSWD sudoersが必要", Type: SettingTypeText, Category: "権限"},
+			{Key: "privileged_user", Label: "特権ユーザー", Description: "LLMが使用時に人間の承認が必要なOSユーザー。空の場合は権限昇格を禁止。NOPASSWD sudoersが必要", Type: SettingTypeText, Category: "権限"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner 管理", Type: SettingTypeText, Category: "Runner"},
 			// Danger zone entry (display-only, triggers panel switch)

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -546,6 +546,9 @@ func localeZH() *UILocale {
 					{Label: "catppuccin:摩卡", Value: "catppuccin"},
 				},
 			},
+			// Permission control
+			{Key: "default_user", Label: "默认执行用户", Description: "工具执行的默认 OS 用户（需要配置 NOPASSWD sudoers）", Type: SettingTypeText, Category: "权限"},
+			{Key: "privileged_user", Label: "特权用户", Description: "需要审批才能使用的特权 OS 用户（需要配置 NOPASSWD sudoers）", Type: SettingTypeText, Category: "权限"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner 管理", Type: SettingTypeText, Category: "Runner"},
 			// Danger zone entry (display-only, triggers panel switch)
@@ -914,6 +917,9 @@ func localeEN() *UILocale {
 					{Label: "catppuccin:Mocha", Value: "catppuccin"},
 				},
 			},
+			// Permission control
+			{Key: "default_user", Label: "Default User", Description: "Default OS user for tool execution (requires NOPASSWD sudoers)", Type: SettingTypeText, Category: "Permissions"},
+			{Key: "privileged_user", Label: "Privileged User", Description: "Privileged OS user requiring approval (requires NOPASSWD sudoers)", Type: SettingTypeText, Category: "Permissions"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner Manager", Type: SettingTypeText, Category: "Runner"},
 			// Danger zone entry (display-only, triggers panel switch)
@@ -1282,6 +1288,9 @@ func localeJA() *UILocale {
 					{Label: "catppuccin:モカ", Value: "catppuccin"},
 				},
 			},
+			// Permission control
+			{Key: "default_user", Label: "デフォルトユーザー", Description: "ツール実行用のデフォルト OS ユーザー（NOPASSWD sudoers 設定が必要）", Type: SettingTypeText, Category: "権限"},
+			{Key: "privileged_user", Label: "特権ユーザー", Description: "承認が必要な特権 OS ユーザー（NOPASSWD sudoers 設定が必要）", Type: SettingTypeText, Category: "権限"},
 			// Runner panel entry (display-only, triggers panel switch)
 			{Key: "runner_panel", Label: "🔧 Runner 管理", Type: SettingTypeText, Category: "Runner"},
 			// Danger zone entry (display-only, triggers panel switch)

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -598,6 +598,12 @@ func main() {
 		// Inject BgTaskManager for background task display
 		bgSessionKey := "cli:" + cliCfg.ChatID
 		cliCh.SetBgTaskManager(app.agentLoop.BgTaskManager(), bgSessionKey)
+		// Inject ApprovalHook for permission control approval dialog
+		if hook := app.agentLoop.ToolHookChain().Get("approval"); hook != nil {
+			if ah, ok := hook.(*tools.ApprovalHook); ok {
+				cliCh.SetApprovalHook(ah)
+			}
+		}
 		// Inject TrimHistoryFn for Ctrl+K session truncation
 		if cliTenantID != 0 && cliSessionSvc != nil {
 			cliCh.SetTrimHistoryFn(func(keepCount int) error {

--- a/docs/design/runner-permission-control.md
+++ b/docs/design/runner-permission-control.md
@@ -1,0 +1,722 @@
+# OS User-Based Permission Control Design
+
+> 2026-04-08
+
+## 1. Problem Statement
+
+Agent permission control is a hard problem. Command-level matching (Claude Code style) is fragile — regex patterns don't cover all edge cases, and the permission boundary lives at the wrong abstraction level.
+
+**Our approach**: leverage Linux's mature OS user identity model as the permission boundary. Built-in tools (Shell, FileReplace, FileCreate, etc.) can optionally execute as a different OS user. The user configures two profiles:
+
+- **Default user** — no approval needed, used for routine operations (optional)
+- **Privileged user** — requires pre-hook approval before each execution (optional)
+
+Both are optional. If neither is configured, the feature is **disabled** — tools execute as the xbot process user (current behavior, zero change).
+
+This is simpler, more robust, and more Unix-idiomatic than command matching. The OS kernel enforces file permissions, PATH restrictions, and capability boundaries — no need to reinvent any of that.
+
+## 2. Scope
+
+- **Opt-in feature**: disabled by default, must be explicitly enabled
+- **Priority**: none sandbox mode first (CLI single-user scenario)
+- **Tools**: Shell, FileReplace, FileCreate (the core side-effect tools)
+- **Approval**: channel-agnostic interface; CLI implementation via AskUser first
+- **Future**: docker sandbox, remote sandbox, Web channel
+
+### 2.1 Default Behavior (Feature Disabled)
+
+When `default_user` and `privileged_user` are both unset (the default):
+- All tools execute as the xbot process user — **zero behavioral change from current code**
+- The `run_as` parameter is still present in tool schemas but is ignored (treated as empty string)
+- No ApprovalHook is registered in HookChain
+- No system prompt section about user control
+- No sudo wrapping, no approval dialogs, no performance overhead
+
+### 2.2 Activation
+
+User explicitly sets `default_user` and/or `privileged_user` in settings. On first enable, the system generates a sudoers setup script and reminds the user to restart.
+
+## 3. Core Concepts
+
+### 3.1 Two User Profiles
+
+| Profile | Approval | Use Case |
+|---------|----------|----------|
+| **default_user** | None | Daily development: read files, edit code, run builds |
+| **privileged_user** | Pre-hook approval required | System changes: install packages, modify system files, restart services |
+
+Both are optional. If neither is configured, tools execute as the xbot process user (current behavior).
+
+The LLM chooses which user to execute as by passing a `run_as` parameter in tool calls:
+
+```json
+{"name": "Shell", "arguments": {"command": "apt install nginx", "run_as": "privileged"}}
+```
+
+If `run_as` is omitted, the tool executes as the xbot process user (no change from current behavior). If `run_as` matches `default_user`, it executes directly. If `run_as` matches `privileged_user`, the approval hook fires.
+
+### 3.2 Why OS Users?
+
+1. **Kernel-enforced isolation** — file permissions, capabilities, cgroups, seccomp all work out of the box
+2. **PATH/bin restrictions** — each user can only execute binaries accessible to them
+3. **Audit trail** — `auditd`, `syslog`, and `last` log who ran what
+4. **No reinvention** — decades of Unix security engineering vs. homegrown regex matching
+5. **Simple mental model** — "run as alice" vs. "run as root" is something every developer understands
+
+### 3.3 Pre-Hook Approval
+
+When a tool call targets the privileged user:
+1. `ApprovalHook` (a `ToolHook`) intercepts in `PreToolUse`
+2. Sends `ApprovalRequest` to the channel via a channel-agnostic interface
+3. Channel renders approval UI (CLI: AskUser dialog; Web: future)
+4. User approves → execution continues; denies → returns "user denied" error
+
+## 4. Current Architecture (Baseline)
+
+### 4.1 None Sandbox Execution Paths
+
+**Shell tool** (`tools/shell.go:56`):
+```
+ShellTool.Execute() → buildSpec() → sandbox.Exec(spec)
+  → SandboxRouter → NoneSandbox.Exec() → buildCmdFromSpec()
+  → exec.Command("/bin/sh", "-c", command)
+```
+
+**FileReplace / FileCreate** (`tools/edit.go:152,47`):
+```
+FileReplaceTool.Execute() → shouldUseSandbox(ctx)
+  → false (none sandbox) → executeLocal()
+  → os.ReadFile() / os.WriteFile()  ← direct OS calls, no exec.Command
+```
+
+### 4.2 Key Integration Points
+
+| What | Location | Current Behavior |
+|------|----------|-----------------|
+| `ExecSpec` | `tools/sandbox.go:20-35` | No `RunAsUser` field |
+| `buildCmdFromSpec()` | `tools/none_sandbox.go:431-456` | Creates `exec.Cmd` with no user switch |
+| `NoneSandbox` struct | `tools/none_sandbox.go:21` | Empty struct, stateless |
+| `FileReplace.executeLocal()` | `tools/edit.go:203-224` | Direct `os.ReadFile/WriteFile` |
+| `FileCreate.executeLocal()` | `tools/edit.go:71-96` | Direct `os.MkdirAll/WriteFile` |
+| `ToolContext` | `tools/interface.go:19-70` | No `RunAsUser` field |
+| `user_settings` table | `storage/sqlite/schema.go:151-160` | Generic KV `(channel, sender_id, key, value)` |
+| `ToolHook` interface | `tools/hook.go:17-27` | `PreToolUse` can block execution |
+| `HookChain` | `tools/hook.go:29-110` | Runs all hooks in order |
+| `checkDangerousCommand` | `tools/shell.go:600-629` | Blocks bare `sudo` — must coexist with injected `sudo -u` |
+
+### 4.3 Existing Settings Pattern
+
+`user_settings` is a generic KV store per `(channel, sender_id)`. Already used for `active_runner`:
+```sql
+SELECT value FROM user_settings WHERE channel = 'web' AND sender_id = ? AND key = 'active_runner'
+```
+We'll add keys `default_user` and `privileged_user` using the same pattern.
+
+## 5. Design
+
+### 5.1 User Configuration
+
+Stored in `user_settings` table:
+
+| Key | Example Value | Meaning |
+|-----|---------------|---------|
+| `default_user` | `"alice"` | Execute as this user without approval |
+| `privileged_user` | `"root"` | Execute as this user, requires approval |
+
+Channel-agnostic storage: the settings work for CLI, Web, Feishu, etc. The `channel` column can be `"*"` for cross-channel settings, or channel-specific.
+
+### 5.2 Tool Parameter Extension
+
+Core side-effect tools gain an optional `run_as` parameter. **This is a tool schema change** — it modifies the `Parameters()` return value, which flows through to the LLM's function calling schema via `toOpenAITools()` (`llm/openai.go:352`).
+
+**Schema change audit** (every modification point in the tool→LLM pipeline):
+
+| # | File | Method | Change |
+|---|------|--------|--------|
+| S1 | `tools/shell.go:48` | `ShellTool.Parameters()` | Add `{Name: "run_as", Type: "string", Required: false}` |
+| S2 | `tools/edit.go:35` | `FileCreateTool.Parameters()` | Add `{Name: "run_as", Type: "string", Required: false}` |
+| S3 | `tools/edit.go:130` | `FileReplaceTool.Parameters()` | Add `{Name: "run_as", Type: "string", Required: false}` |
+| S4 | `llm/openai.go:352` | `toOpenAITools()` | **No change needed** — reads `Parameters()` dynamically, new param flows through automatically |
+| S5 | `tools/shell.go:57` | `ShellTool.Execute()` params struct | Add `RunAs string \`json:"run_as"\`` |
+| S6 | `tools/edit.go:42` | `FileCreateParams` struct | Add `RunAs string \`json:"run_as"\`` |
+| S7 | `tools/edit.go:142` | `FileReplaceParams` struct | Add `RunAs string \`json:"run_as"\`` |
+
+**Backward compatibility**: `run_as` is `Required: false`. When omitted or empty, behavior is identical to current code — no sudo wrapping, no approval check. The LLM sees the parameter in the schema but won't use it unless the system prompt tells it to (which only happens when the feature is enabled).
+
+**Risk mitigation**:
+- The param struct field uses `json:"run_as"` with a string zero value (`""`) — no nil pointer risk
+- The `Execute()` method checks `params.RunAs == ""` early and short-circuits to existing path
+- No existing test asserts on the full `Parameters()` return — tests use functionally, not schema inspection
+- If an older LLM ignores the new param, everything still works (defaults to current user)
+
+```go
+// tools/shell.go — ShellParams (struct used in Execute)
+type ShellParams struct {
+    Command    string  `json:"command"`
+    Timeout    float64 `json:"timeout"`
+    Background bool    `json:"background"`
+    RunAs      string  `json:"run_as,omitempty"`  // NEW: optional, empty = current user
+}
+
+// tools/shell.go — Parameters() (schema for LLM)
+func (t *ShellTool) Parameters() []llm.ToolParam {
+    return []llm.ToolParam{
+        {Name: "command", Type: "string", Description: "The command to execute", Required: true},
+        {Name: "timeout", Type: "number", Description: "Timeout in seconds (default: 120, max: 600)", Required: false},
+        {Name: "background", Type: "boolean", Description: "Run command in background...", Required: false},
+        {Name: "run_as", Type: "string", Description: "OS username to execute as (requires permission control to be enabled)", Required: false},  // NEW
+    }
+}
+```
+
+The `run_as` value must match either `default_user` or `privileged_user` from user settings. Any other value is rejected. When the feature is disabled (both settings empty), any non-empty `run_as` value is rejected with a clear error.
+
+### 5.3 Execution Path — Shell
+
+In none sandbox mode, `buildCmdFromSpec()` (`tools/none_sandbox.go:431`) is the single chokepoint for all `exec.Cmd` creation. User switching happens here:
+
+```
+buildCmdFromSpec(ctx, spec, managedCtx):
+  if spec.RunAsUser != "":
+      // sudo -n -u <user> -- /bin/sh -c "<command>"
+      // Requires: xbot user has NOPASSWD sudoers entry for target user
+      cmd = exec.CommandContext(ctx, "sudo", "-n", "-H", "-u", spec.RunAsUser,
+          "--", "/bin/sh", "-l", "-c", spec.Command)
+  else:
+      cmd = exec.CommandContext(ctx, "/bin/sh", "-c", spec.Command)  // existing
+```
+
+**Why `sudo -n -u` instead of `SysProcAttr.Credential`?**
+- `SysProcAttr.Credential` requires xbot to run as root — unrealistic for most deployments
+- `sudo -n` (non-interactive) won't prompt for password — fails fast if not configured
+- `sudoers` can be configured per-user: `xbot_user ALL=(target_user) NOPASSWD: ALL`
+- Process group management (`Setpgid`, SIGKILL) still works through sudo
+
+**Why `--` separator?**
+- Prevents command injection via malicious tool arguments being interpreted as sudo flags
+- The target command is passed as a single argument to `/bin/sh -c`
+
+**Why `-H` flag?**
+- Sets `$HOME` to the target user's home directory instead of the calling user's
+- Ensures the login shell (`-l`) sources the correct profile
+
+**Existing `checkDangerousCommand` interaction**:
+- The LLM-generated command does NOT contain `sudo` — it's injected by the sandbox layer below
+- The safety check at `shell.go:600-629` sees the original command (before sudo wrapping), so no conflict
+- If the LLM itself tries to use `sudo`, the existing check blocks it — correct behavior
+
+### 5.4 Execution Path — FileReplace / FileCreate
+
+These tools use direct `os.ReadFile/WriteFile` in none mode, bypassing `exec.Command`. We add a helper that writes via subprocess:
+
+```go
+// tools/edit.go — new helper
+func writeFileAsUser(runAsUser, path, content string, perm os.FileMode) error {
+    // Use sudo to write as the target user
+    cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser,
+        "--", "/bin/sh", "-c", fmt.Sprintf("cat > '%s' && chmod %o '%s'",
+            shellescape(path), perm, shellescape(path)))
+    cmd.Stdin = strings.NewReader(content)
+    return cmd.Run()
+}
+```
+
+In `executeLocal()`, the path branches:
+```go
+if params.RunAs != "" && isPrivilegedUser(params.RunAs) {
+    return writeFileAsUser(params.RunAs, filePath, newContent, 0644)
+}
+// existing: os.WriteFile(filePath, []byte(newContent), 0644)
+```
+
+Files created this way are owned by the target OS user — correct behavior.
+
+### 5.5 Approval System
+
+#### 5.5.1 Channel-Agnostic Interface
+
+```go
+// tools/approval.go (new file)
+
+// ApprovalRequest represents a pending user approval for a tool execution.
+type ApprovalRequest struct {
+    ToolName string // e.g., "Shell"
+    ToolArgs string // JSON arguments (for display)
+    RunAs    string // Target OS user
+    Reason   string // Human-readable description
+    // Extracted details for display
+    Command  string // Parsed command (for Shell)
+    FilePath string // Target file (for FileReplace/FileCreate)
+}
+
+// ApprovalResult is the user's decision.
+type ApprovalResult int
+
+const (
+    ApprovalDenied   ApprovalResult = 0
+    ApprovalApproved ApprovalResult = 1
+)
+
+// ApprovalHandler is the channel-agnostic interface for user approval.
+type ApprovalHandler interface {
+    RequestApproval(ctx context.Context, req ApprovalRequest) (ApprovalResult, error)
+}
+```
+
+#### 5.5.2 ApprovalHook
+
+```go
+// tools/approval.go
+
+type ApprovalHook struct {
+    handler        ApprovalHandler
+    defaultUser    string // from user settings
+    privilegedUser string // from user settings
+}
+
+func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args string) error {
+    runAs := extractRunAs(args) // parse "run_as" from JSON args
+
+    if runAs == "" || runAs == h.defaultUser {
+        return nil // no approval needed
+    }
+    if runAs != h.privilegedUser {
+        return fmt.Errorf("unknown run_as user %q: must be %q or %q",
+            runAs, h.defaultUser, h.privilegedUser)
+    }
+
+    // Privileged user — request approval
+    req := ApprovalRequest{
+        ToolName: toolName,
+        ToolArgs: args,
+        RunAs:    runAs,
+        // ... extract Command/FilePath for display ...
+    }
+    result, err := h.handler.RequestApproval(ctx, req)
+    if err != nil {
+        return fmt.Errorf("approval request failed: %w", err)
+    }
+    if result != ApprovalApproved {
+        return fmt.Errorf("user denied execution as %q", runAs)
+    }
+    return nil
+}
+```
+
+The `ApprovalHook` is registered in `HookChain` and only activates for tool calls that target the privileged user. Normal operations (no `run_as` or `default_user`) pass through with zero overhead.
+
+#### 5.5.3 CLI Implementation
+
+```go
+// channel/cli_approval.go (new file)
+
+type CLIApprovalHandler struct {
+    program *tea.Program
+}
+
+func (h *CLIApprovalHandler) RequestApproval(ctx context.Context, req ApprovalRequest) (ApprovalResult, error) {
+    // Use program.Send() to push approval dialog to TUI
+    // Block until user responds via a channel
+    // Return ApprovalApproved or ApprovalDenied
+}
+```
+
+CLI rendering:
+```
+┌─ ⚠ Approval Required ─────────────────────────────┐
+│ Tool:     Shell                                     │
+│ Run as:   root (privileged)                         │
+│ Command:  apt install nginx                         │
+│                                                     │
+│ Allow this operation? [Y/n]                         │
+└─────────────────────────────────────────────────────┘
+```
+
+### 5.6 System Prompt Integration
+
+**This section is only included when the feature is enabled** (at least one of `default_user`/`privileged_user` is set). When disabled, the LLM sees the `run_as` parameter in tool schemas but has no context about it — it simply won't use it.
+
+Dynamic system prompt section tells the LLM about available users:
+
+```markdown
+## Execution User Control
+
+You can execute tools as a different OS user by passing the `run_as` parameter.
+Available users are configured by the system administrator.
+
+### Available Users
+| User | Approval | Description |
+|------|----------|-------------|
+| (default) | None | Current process user |
+| alice | None | Default execution user |
+| root | **Required** | Privileged user — user must approve each use |
+
+### Rules
+- Omit `run_as` to execute as the current process user
+- Use `run_as: "alice"` for routine operations
+- Use `run_as: "root"` ONLY when the task genuinely requires elevated privileges
+- Always explain WHY you need the privileged user when requesting it
+```
+
+### 5.7 ExecSpec Extension
+
+```go
+// tools/sandbox.go — ExecSpec
+type ExecSpec struct {
+    // ... existing fields ...
+    RunAsUser string // NEW: execute as this OS user (none sandbox only)
+}
+```
+
+Threaded from tool params → ExecSpec → buildCmdFromSpec:
+```
+ShellParams.RunAs → ShellTool.Execute() → buildSpec() → spec.RunAsUser
+  → NoneSandbox.Exec() → buildCmdFromSpec() → sudo -n -H -u <user> -- ...
+```
+
+### 5.8 Runner Support (Shared Command Builder)
+
+The runner binary (`cmd/runner/`) and TUI-as-runner mode both use `internal/runnerclient/` which has **completely independent** execution code from `tools/none_sandbox.go`. Currently zero code is shared:
+
+| Aspect | Server (`tools/`) | Runner (`runnerclient/`) |
+|--------|-------------------|--------------------------|
+| ExecSpec | `tools.ExecSpec` — has `Workspace`, `UserID`, `KeepAlive` | `runnerclient.ExecSpec` — simpler, no user fields |
+| Command builder | `buildCmdFromSpec()` shared helper | Inline in `NativeExecutor.Exec()` at `native.go:35` |
+| File writes | `os.WriteFile()` directly | `os.WriteFile()` directly at `native.go:100` |
+
+To avoid duplicating the `sudo -u` logic, we extract a shared command builder into a new internal package:
+
+#### 5.8.1 Shared Command Builder
+
+```go
+// internal/cmdbuilder/cmdbuilder.go (new package)
+
+package cmdbuilder
+
+// Build creates an *exec.Cmd with optional OS user switching.
+// This is the single source of truth for command construction,
+// used by both NoneSandbox (server) and NativeExecutor (runner).
+func Build(ctx context.Context, shell bool, command string, args []string,
+    dir string, env []string, stdin string, runAsUser string) *exec.Cmd {
+    // ... unified command building with sudo -n -H -u wrapping ...
+}
+```
+
+Both `tools/none_sandbox.go` and `internal/runnerclient/native.go` call `cmdbuilder.Build()` instead of building commands inline.
+
+#### 5.8.2 Runner ExecSpec Extension
+
+```go
+// internal/runnerclient/executor.go — ExecSpec
+type ExecSpec struct {
+    // ... existing fields ...
+    RunAsUser string `json:"run_as_user,omitempty"` // NEW: execute as this OS user
+}
+```
+
+#### 5.8.3 Runner Protocol Extension
+
+```go
+// internal/runnerproto/runner_proto.go — ExecRequest
+type ExecRequest struct {
+    // ... existing fields ...
+    RunAsUser string `json:"run_as_user,omitempty"` // NEW: target OS user
+}
+```
+
+#### 5.8.4 Runner Handler
+
+```go
+// internal/runnerclient/handler.go — handleExec()
+spec := ExecSpec{
+    // ... existing fields ...
+    RunAsUser: req.RunAsUser, // NEW: pass through from protocol
+}
+```
+
+#### 5.8.5 Runner CLI Flags
+
+```bash
+xbot-runner --default-user alice --privileged-user root ...
+```
+
+Runner stores these locally (no DB needed — runner is single-user by nature). When the server sends `run_as_user` in an exec request, the runner validates it against its local configuration before executing.
+
+#### 5.8.6 Runner WriteFileAsUser
+
+Same `writeFileAsUser` logic, extracted to the shared `cmdbuilder` package:
+
+```go
+// internal/cmdbuilder/file.go
+func WriteFileAsUser(runAsUser, path string, data []byte, perm os.FileMode) error {
+    cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser,
+        "--", "/bin/sh", "-c", fmt.Sprintf("cat > '%s' && chmod %o '%s'",
+            shellescape(path), perm, shellescape(path)))
+    cmd.Stdin = strings.NewReader(data)
+    return cmd.Run()
+}
+```
+
+Used by both `tools/edit.go` (server-side none sandbox) and `internal/runnerclient/native.go` (runner-side).
+
+## 6. Data Flow
+
+### 6.1 Normal Execution (No run_as)
+
+```
+LLM: {name: "Shell", arguments: {command: "go test ./..."}}
+  → ShellTool.Execute()
+  → buildSpec(): spec.RunAsUser = "" (no run_as param)
+  → NoneSandbox.Exec(spec)
+  → buildCmdFromSpec(): exec.Command("/bin/sh", "-c", "go test ./...")
+  → [unchanged from current behavior]
+```
+
+### 6.2 Default User Execution (No Approval)
+
+```
+LLM: {name: "Shell", arguments: {command: "go build ./...", run_as: "alice"}}
+  → ShellTool.Execute(): params.RunAs = "alice"
+  → ApprovalHook.PreToolUse(): runAs == defaultUser → return nil
+  → buildSpec(): spec.RunAsUser = "alice"
+  → NoneSandbox.Exec(spec)
+  → buildCmdFromSpec(): exec.Command("sudo", "-n", "-H", "-u", "alice", "--", "/bin/sh", "-l", "-c", "go build ./...")
+```
+
+### 6.3 Privileged User Execution (With Approval)
+
+```
+LLM: {name: "Shell", arguments: {command: "apt install nginx", run_as: "root"}}
+  → ShellTool.Execute(): params.RunAs = "root"
+  → ApprovalHook.PreToolUse(): runAs == privilegedUser
+    → CLIApprovalHandler.RequestApproval()
+    → CLI shows approval dialog
+    → User presses Y → ApprovalApproved
+  → buildSpec(): spec.RunAsUser = "root"
+  → NoneSandbox.Exec(spec)
+  → buildCmdFromSpec(): exec.Command("sudo", "-n", "-H", "-u", "root", "--", "/bin/sh", "-l", "-c", "apt install nginx")
+```
+
+### 6.4 Privileged User Denied
+
+```
+LLM: {name: "Shell", arguments: {command: "apt install nginx", run_as: "root"}}
+  → ApprovalHook.PreToolUse(): runAs == privilegedUser
+    → CLI shows approval dialog
+    → User presses N → ApprovalDenied
+  → return error: "user denied execution as root"
+  → ToolResult{Summary: "Execution denied by user", IsError: true}
+  → LLM learns to respect user's decision
+```
+
+### 6.5 Invalid User
+
+```
+LLM: {name: "Shell", arguments: {command: "ls", run_as: "hacker"}}
+  → ApprovalHook.PreToolUse(): runAs not in {defaultUser, privilegedUser}
+  → return error: `unknown run_as user "hacker": must be "alice" or "root"`
+```
+
+### 6.6 Runner Execution (Remote Sandbox Path)
+
+When the agent uses a remote runner, the flow extends through the WebSocket protocol:
+
+```
+LLM: {name: "Shell", arguments: {command: "npm install", run_as: "alice"}}
+  → ShellTool.Execute(): params.RunAs = "alice"
+  → ApprovalHook.PreToolUse(): runAs == defaultUser → return nil
+  → shouldUseSandbox(ctx) = true (remote runner connected)
+  → buildSpec(): spec.RunAsUser = "alice"
+  → RemoteSandbox.Exec(spec)
+    → WebSocket: {"type": "exec", "body": {"command": "npm install", "shell": true, "run_as_user": "alice"}}
+  → Runner handler.handleExec()
+    → spec.RunAsUser = req.RunAsUser = "alice"
+    → NativeExecutor.Exec(ctx, spec)
+      → cmdbuilder.Build(ctx, ..., runAsUser: "alice")
+      → exec.Command("sudo", "-n", "-H", "-u", "alice", "--", "sh", "-c", "npm install")
+  → Result flows back through WebSocket
+```
+
+The approval happens on the **agent side** (server), before the request reaches the runner. The runner itself just executes — it trusts the server's approval decision. The runner validates `run_as_user` against its local `--default-user`/`--privileged-user` config as a safety net.
+
+## 7. Configuration
+
+### 7.1 Feature Activation Flow
+
+```
+1. User opens CLI settings panel → "Permission Control" section
+2. User sets default_user and/or privileged_user
+3. System detects first-time enable (sudoers not yet configured)
+4. System generates sudoers setup script and shows it to user
+5. User runs the script (requires sudo password once)
+6. System reminds: "Restart xbot-cli for changes to take effect"
+7. On restart: ApprovalHook registered, system prompt updated
+```
+
+### 7.2 sudoers Setup Script Generation
+
+When the user first enables permission control, the system generates a setup script:
+
+```bash
+#!/bin/bash
+# xbot permission control setup script
+# Run this script with sudo: sudo bash /path/to/setup-xbot-sudoers.sh
+
+CURRENT_USER="$(whoami)"
+XBOT_USER="${CURRENT_USER}"  # xbot process runs as this user
+
+sudoers_file="/etc/sudoers.d/xbot"
+
+echo "Setting up sudoers for xbot permission control..."
+echo ""
+echo "This will allow user '${XBOT_USER}' to run commands as:"
+echo "  - alice (default, no approval needed)"
+echo "  - root (privileged, requires approval)"
+
+cat > /tmp/xbot-sudoers.$$ << 'EOF'
+# xbot permission control — auto-generated
+# Allows xbot process user to execute as configured users without password
+xbot_user ALL=(alice) NOPASSWD: ALL
+xbot_user ALL=(root) NOPASSWD: ALL
+EOF
+
+# Replace placeholder with actual username
+sed -i "s/xbot_user/${XBOT_USER}/g" /tmp/xbot-sudoers.$$
+
+# Validate and install (visudo checks syntax)
+visudo -c -f /tmp/xbot-sudoers.$$ && \
+    install -m 0440 /tmp/xbot-sudoers.$$ "${sudoers_file}" && \
+    rm /tmp/xbot-sudoers.$$ && \
+    echo "✓ sudoers configured at ${sudoers_file}" && \
+    echo "⚠ Please restart xbot-cli for changes to take effect" || {
+    rm -f /tmp/xbot-sudoers.$$
+    echo "✗ Failed to configure sudoers"
+    exit 1
+}
+```
+
+The script:
+- Uses `visudo -c` to validate syntax before installing (prevents locking yourself out)
+- Installs with `0440` permissions (required by sudoers)
+- Replaces the placeholder username with the actual xbot process user
+- Reminds user to restart xbot-cli
+
+### 7.3 Detection: Is sudoers Configured?
+
+Before enabling the feature, check if sudoers is already set up:
+
+```go
+func isSudoersConfigured() bool {
+    currentUser := os.Getenv("USER")
+    // Test: sudo -n -u <default_user> true
+    cmd := exec.Command("sudo", "-n", "-u", currentUser, "--", "true")
+    return cmd.Run() == nil
+}
+```
+
+If not configured, show the setup script. If already configured, skip the reminder.
+
+### 7.4 User Settings (Runtime)
+
+Via CLI settings panel or API:
+```
+default_user = "alice"
+privileged_user = "root"
+```
+
+If `default_user` is not set, the `run_as` parameter is the only way to switch users.
+If `privileged_user` is not set, all `run_as` values that aren't `default_user` are rejected.
+If **both** are unset, the feature is disabled — all `run_as` values are rejected.
+
+## 8. Implementation Plan
+
+### Phase 1: Shared Command Builder + Shell Support
+
+Extract the shared command builder first — both server and runner depend on it.
+
+| # | Task | File | Description |
+|---|------|------|-------------|
+| 1.1 | Shared `cmdbuilder` package | `internal/cmdbuilder/cmdbuilder.go` (new) | `Build()` with `sudo -n -H -u` wrapping, `WriteFileAsUser()` helper |
+| 1.2 | Server `ExecSpec.RunAsUser` | `tools/sandbox.go` | Add field to ExecSpec struct |
+| 1.3 | Server `buildCmdFromSpec` refactor | `tools/none_sandbox.go:431` | Delegate to `cmdbuilder.Build()` instead of inline cmd construction |
+| 1.4 | Server async path | `tools/none_sandbox.go:368` | `noneSandboxExecAsync` inherits via refactored buildCmdFromSpec |
+| 1.5 | **Shell schema change** | `tools/shell.go:48` | Add `run_as` to `Parameters()` — **protocol change, audit S1** |
+| 1.6 | **Shell params struct** | `tools/shell.go:57` | Add `RunAs string` to Execute params — **audit S5** |
+| 1.7 | Settings read helper | `tools/` | Read `default_user`/`privileged_user` from user_settings |
+| 1.8 | **Opt-in guard** | `tools/shell.go` | When both settings empty: reject non-empty `run_as` with clear error |
+| 1.9 | Validation | `tools/shell.go` | When enabled: validate `run_as` against configured users |
+| 1.10 | **Runner `ExecSpec.RunAsUser`** | `internal/runnerclient/executor.go` | Add field to runner ExecSpec |
+| 1.11 | **Runner `NativeExecutor` refactor** | `internal/runnerclient/native.go:35` | Delegate to `cmdbuilder.Build()` instead of inline cmd construction |
+| 1.12 | **Runner protocol extension** | `internal/runnerproto/runner_proto.go` | Add `RunAsUser` to `ExecRequest` |
+| 1.13 | **Runner handler threading** | `internal/runnerclient/handler.go:209` | Pass `req.RunAsUser` to ExecSpec |
+| 1.14 | **Runner CLI flags** | `cmd/runner/main.go` | `--default-user`, `--privileged-user` flags |
+| 1.15 | **Runner local validation** | `internal/runnerclient/handler.go` | Validate `run_as_user` against local config |
+
+### Phase 2: File Tools + Approval System
+
+| # | Task | File | Description |
+|---|------|------|-------------|
+| 2.1 | **FileCreate schema change** | `tools/edit.go:35` | Add `run_as` to `Parameters()` — **protocol change, audit S2** |
+| 2.2 | **FileCreate params struct** | `tools/edit.go:42` | Add `RunAs string` to FileCreateParams — **audit S6** |
+| 2.3 | **FileReplace schema change** | `tools/edit.go:130` | Add `run_as` to `Parameters()` — **protocol change, audit S3** |
+| 2.4 | **FileReplace params struct** | `tools/edit.go:142` | Add `RunAs string` to FileReplaceParams — **audit S7** |
+| 2.5 | Server `writeFileAsUser` | `tools/edit.go` | Use `cmdbuilder.WriteFileAsUser()` in executeLocal |
+| 2.6 | **Runner `write_file` with user** | `internal/runnerclient/handler.go` | Thread `RunAsUser` to WriteFile path |
+| 2.7 | Approval interface | `tools/approval.go` (new) | `ApprovalRequest/Result/Handler` |
+| 2.8 | ApprovalHook | `tools/approval.go` | ToolHook implementation — only registered when feature is enabled |
+| 2.9 | CLI handler | `channel/cli_approval.go` (new) | AskUser-based approval dialog |
+| 2.10 | **Conditional hook registration** | `agent/engine_wire.go` | Register ApprovalHook only when privileged_user is set |
+
+### Phase 3: Integration & Polish
+
+| # | Task | File | Description |
+|---|------|------|-------------|
+| 3.1 | **Conditional system prompt** | `agent/` | User info section only included when feature is enabled |
+| 3.2 | Settings UI | `channel/cli_panel.go` | Add default_user/privileged_user to settings panel |
+| 3.3 | **sudoers setup script** | `tools/` or new file | Generate script, detect if sudoers already configured |
+| 3.4 | **Restart reminder** | `channel/cli_panel.go` | Show "restart xbot-cli" message after sudoers setup |
+| 3.5 | Error messages | Various | Clear errors for misconfiguration, sudo failures, feature disabled |
+| 3.6 | Tests | `internal/cmdbuilder/cmdbuilder_test.go` | Unit tests for sudo wrapping + writeFileAsUser |
+| 3.7 | Tests | `tools/approval_test.go` | Unit tests for hook allow/deny logic |
+| 3.8 | Tests | Schema backward compat | Verify `run_as` omitted → identical behavior |
+| 3.9 | Documentation | `docs/ARCHITECTURE.md` | Update with permission control section |
+
+## 9. Edge Cases & Considerations
+
+### 9.1 sudo Not Configured
+If `sudo -n -u <user>` fails (sudoers not set up), `buildCmdFromSpec` returns a clear error:
+```
+failed to execute as user "alice": sudo requires a password (configure NOPASSWD in /etc/sudoers.d/)
+```
+
+### 9.2 Process Group Kill with sudo
+`killProcessGroup` sends SIGKILL to `-pid` (negative PID = process group). With `sudo`, the process tree is:
+```
+xbot → sudo -u alice → /bin/sh -l -c "command" → command subprocesses
+```
+`Setpgid=true` on the sudo process means the entire tree is in the same process group. SIGKILL to `-pid` kills the whole tree. ✓
+
+### 9.3 Background Tasks with sudo
+`noneSandboxExecAsync` also uses `buildCmdFromSpec`, so `RunAsUser` is automatically supported. The KeepAlive process management works the same way.
+
+### 9.4 File Ownership
+Files created via `writeFileAsUser` are owned by the target user (since the write process runs as that user). This is correct behavior — files created by "alice" belong to alice.
+
+### 9.5 Approval Timeout
+If the user doesn't respond within a configurable timeout (default 60s), auto-deny. Prevents indefinite blocking of the agent loop.
+
+### 9.6 SubAgent Inheritance
+SubAgents inherit the parent's user settings. The ApprovalHook reads from `ToolContext.OriginUserID`, so it automatically picks up the right configuration. SubAgents cannot escalate beyond what the parent's settings allow.
+
+### 9.7 None Sandbox + NativeExecutor (v1)
+The `RunAsUser` field is processed by `NoneSandbox` (server-side) and `NativeExecutor` (runner-side). DockerSandbox and DockerExecutor ignore it in v1. Future: docker could use `--user` flag; the shared `cmdbuilder` makes this straightforward to add.
+
+## 10. Open Questions
+
+1. **Should read-only tools (Read, Grep, Glob) support `run_as`?** Probably not needed in v1 — the OS user mainly affects write operations. Can add later if needed (e.g., reading files owned by another user).
+
+2. **Per-tool user override in config?** E.g., "FileReplace always uses alice, Shell can use either." Useful but adds complexity. Defer to v2.
+
+3. **Approval caching / "always allow for this session"?** Common UX pattern. Defer to v2 — start with per-request approval.
+
+4. **Audit logging?** Log all privileged user executions (approved or denied) for compliance. Should be added in Phase 2.

--- a/internal/cmdbuilder/cmdbuilder.go
+++ b/internal/cmdbuilder/cmdbuilder.go
@@ -126,8 +126,9 @@ func ReadFileAsUser(runAsUser, path string) ([]byte, error) {
 		return os.ReadFile(path)
 	}
 
-	escaped := shellEscape(path)
-	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "cat", escaped)
+	// Pass the raw path as an argv element. Do NOT shell-escape here because
+	// exec.Command does not invoke a shell; quoting would become part of the filename.
+	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "cat", path)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/cmdbuilder/cmdbuilder.go
+++ b/internal/cmdbuilder/cmdbuilder.go
@@ -1,0 +1,228 @@
+// Package cmdbuilder provides shared command construction logic
+// for both server-side NoneSandbox and runner-side NativeExecutor.
+// It centralizes exec.Cmd creation with optional OS user switching via sudo.
+package cmdbuilder
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Config controls command construction behavior.
+type Config struct {
+	// RunAsUser is the OS username to execute the command as.
+	// When set, the command is wrapped with: sudo -n -H -u <user> --
+	// Requires NOPASSWD sudoers entry for the target user.
+	// Empty string means execute as the current process user (no wrapping).
+	RunAsUser string
+}
+
+// Build creates an *exec.Cmd with optional OS user switching.
+//
+// When cfg.RunAsUser is set, the command is wrapped with sudo:
+//
+//	sudo -n -H -u <user> -- /bin/sh -c "<command>"
+//
+// When cfg.RunAsUser is empty, the command is constructed directly:
+//
+//	/bin/sh -c "<command>"
+//
+// Parameters:
+//   - ctx: context for cancellation (nil → no context)
+//   - shell: true → use "sh -c <command>"; false → use args directly
+//   - command: the command string (used when shell=true)
+//   - args: the arg list (used when shell=false, must be non-empty)
+//   - dir: working directory
+//   - env: additional environment variables (appended to os.Environ())
+//   - cfg: configuration including RunAsUser
+func Build(ctx context.Context, shell bool, command string, args []string,
+	dir string, env []string, cfg Config) (*exec.Cmd, error) {
+
+	var cmd *exec.Cmd
+
+	if cfg.RunAsUser != "" {
+		// Wrap with sudo -n -H -u <user> --
+		if shell {
+			sudoArgs := []string{"-n", "-H", "-u", cfg.RunAsUser, "--", "/bin/sh", "-c", command}
+			if ctx != nil {
+				cmd = exec.CommandContext(ctx, "sudo", sudoArgs...)
+			} else {
+				cmd = exec.Command("sudo", sudoArgs...)
+			}
+		} else {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("non-shell exec requires args to be set")
+			}
+			sudoArgs := append([]string{"-n", "-H", "-u", cfg.RunAsUser, "--"}, args...)
+			if ctx != nil {
+				cmd = exec.CommandContext(ctx, "sudo", sudoArgs...)
+			} else {
+				cmd = exec.Command("sudo", sudoArgs...)
+			}
+		}
+	} else {
+		// No user switching — direct execution
+		if shell {
+			if ctx != nil {
+				cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command)
+			} else {
+				cmd = exec.Command("/bin/sh", "-c", command)
+			}
+		} else {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("non-shell exec requires args to be set")
+			}
+			if ctx != nil {
+				cmd = exec.CommandContext(ctx, args[0], args[1:]...)
+			} else {
+				cmd = exec.Command(args[0], args[1:]...)
+			}
+		}
+	}
+
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	return cmd, nil
+}
+
+// WriteFileAsUser writes data to a file as the specified OS user via sudo.
+// If runAsUser is empty, falls back to os.WriteFile directly.
+func WriteFileAsUser(runAsUser, path string, data []byte, perm os.FileMode) error {
+	if runAsUser == "" {
+		return os.WriteFile(path, data, perm)
+	}
+
+	// Use sudo to write as the target user:
+	// sudo -n -H -u <user> -- /bin/sh -c "cat > '<escaped_path>' && chmod <perm> '<escaped_path>'"
+	escaped := shellEscape(path)
+	permStr := fmt.Sprintf("%o", perm)
+	shellCmd := fmt.Sprintf("cat > %s && chmod %s %s", escaped, permStr, escaped)
+
+	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "/bin/sh", "-c", shellCmd)
+	cmd.Stdin = bytes.NewReader(data)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("write file as user %q failed: %w: %s", runAsUser, err, stderr.String())
+	}
+	return nil
+}
+
+// ReadFileAsUser reads a file as the specified OS user via sudo.
+// If runAsUser is empty, falls back to os.ReadFile directly.
+func ReadFileAsUser(runAsUser, path string) ([]byte, error) {
+	if runAsUser == "" {
+		return os.ReadFile(path)
+	}
+
+	escaped := shellEscape(path)
+	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "cat", escaped)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("read file as user %q failed: %w: %s", runAsUser, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+// MkdirAllAsUser creates directories as the specified OS user via sudo.
+// If runAsUser is empty, falls back to os.MkdirAll directly.
+func MkdirAllAsUser(runAsUser, path string, perm os.FileMode) error {
+	if runAsUser == "" {
+		return os.MkdirAll(path, perm)
+	}
+
+	escaped := shellEscape(path)
+	permStr := fmt.Sprintf("%o", perm)
+	shellCmd := fmt.Sprintf("mkdir -p %s && chmod %s %s", escaped, permStr, escaped)
+
+	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "/bin/sh", "-c", shellCmd)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("mkdir as user %q failed: %w: %s", runAsUser, err, stderr.String())
+	}
+	return nil
+}
+
+// shellEscape wraps a path in single quotes, escaping any embedded single quotes.
+func shellEscape(s string) string {
+	// Replace ' with '\'' (end quote, escaped quote, start quote)
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// CheckSudoers tests whether sudo -n -u <user> -- true works (NOPASSWD configured).
+// Returns nil if sudoers is properly configured for the given user.
+func CheckSudoers(user string) error {
+	cmd := exec.Command("sudo", "-n", "-H", "-u", user, "--", "true")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("sudoers not configured for user %q: %s", user, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// GenerateSudoersScript generates a bash script that sets up /etc/sudoers.d/xbot.
+// The script validates syntax with visudo -c before installing.
+func GenerateSudoersScript(defaultUser, privilegedUser string) string {
+	currentUser := os.Getenv("USER")
+	if currentUser == "" {
+		currentUser = "$(whoami)"
+	}
+
+	var entries []string
+	if defaultUser != "" {
+		entries = append(entries, fmt.Sprintf("%s ALL=(%s) NOPASSWD: ALL", currentUser, defaultUser))
+	}
+	if privilegedUser != "" {
+		entries = append(entries, fmt.Sprintf("%s ALL=(%s) NOPASSWD: ALL", currentUser, privilegedUser))
+	}
+
+	entriesStr := ""
+	for _, e := range entries {
+		entriesStr += e + "\n"
+	}
+
+	return fmt.Sprintf(`#!/bin/bash
+# xbot permission control setup script
+# Run with: sudo bash %s
+
+set -e
+
+SUDOERS_FILE="/etc/sudoers.d/xbot"
+
+echo "Setting up sudoers for xbot permission control..."
+echo ""
+
+cat > /tmp/xbot-sudoers.$$ << 'EOF'
+%s
+EOF
+
+# Validate syntax before installing
+if visudo -c -f /tmp/xbot-sudoers.$$ >/dev/null 2>&1; then
+    install -m 0440 /tmp/xbot-sudoers.$$ "$SUDOERS_FILE"
+    rm -f /tmp/xbot-sudoers.$$
+    echo "✓ sudoers configured at $SUDOERS_FILE"
+else
+    cat /tmp/xbot-sudoers.$$
+    rm -f /tmp/xbot-sudoers.$$
+    echo "✗ sudoers syntax check failed. Please fix manually."
+    exit 1
+fi
+`, "<generated-script>", entriesStr)
+}

--- a/internal/cmdbuilder/cmdbuilder_test.go
+++ b/internal/cmdbuilder/cmdbuilder_test.go
@@ -1,0 +1,120 @@
+package cmdbuilder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShellEscape(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/tmp/file.txt", "'/tmp/file.txt'"},
+		{"file with spaces", "'file with spaces'"},
+		{"file'with'quotes", "'file'\\''with'\\''quotes'"},
+		{"", "''"},
+	}
+
+	for _, tt := range tests {
+		got := shellEscape(tt.input)
+		if got != tt.expected {
+			t.Errorf("shellEscape(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestBuild_NoRunAs(t *testing.T) {
+	// Without RunAsUser, should produce a direct command
+	cmd, err := Build(nil, true, "echo hello", nil, "", nil, Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Path != "/bin/sh" {
+		t.Errorf("expected /bin/sh, got %s", cmd.Path)
+	}
+}
+
+func TestBuild_WithRunAs(t *testing.T) {
+	// With RunAsUser, should produce a sudo-wrapped command
+	cmd, err := Build(nil, true, "echo hello", nil, "", nil, Config{RunAsUser: "alice"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cmd.Path resolves to the full path (e.g., /usr/bin/sudo)
+	if filepath.Base(cmd.Path) != "sudo" {
+		t.Errorf("expected sudo, got %s", cmd.Path)
+	}
+}
+
+func TestBuild_NonShellRequiresArgs(t *testing.T) {
+	_, err := Build(nil, false, "", nil, "", nil, Config{})
+	if err == nil {
+		t.Error("expected error for non-shell with empty args")
+	}
+}
+
+func TestWriteFileAsUser_NoRunAs(t *testing.T) {
+	// Without RunAsUser, should fall back to os.WriteFile
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	err := WriteFileAsUser("", path, []byte("hello"), 0644)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error reading file: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("expected 'hello', got %q", string(data))
+	}
+}
+
+func TestWriteFileAsUser_WithRunAs(t *testing.T) {
+	// This test requires sudo to be configured.
+	// We test the error path — if sudo is not configured, we should get a clear error.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	err := WriteFileAsUser("nonexistent_user_for_test", path, []byte("hello"), 0644)
+	if err == nil {
+		// If it succeeds, that means sudo is configured for this test user — verify content
+		data, _ := os.ReadFile(path)
+		if string(data) != "hello" {
+			t.Errorf("expected 'hello', got %q", string(data))
+		}
+	}
+	// Error is expected in most environments — no assertion on error
+}
+
+func TestReadFileAsUser_NoRunAs(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	os.WriteFile(path, []byte("hello"), 0644)
+
+	data, err := ReadFileAsUser("", path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("expected 'hello', got %q", string(data))
+	}
+}
+
+func TestMkdirAllAsUser_NoRunAs(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "sub", "dir")
+	err := MkdirAllAsUser("", path, 0755)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("unexpected error stating dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected directory")
+	}
+}

--- a/internal/cmdbuilder/cmdbuilder_test.go
+++ b/internal/cmdbuilder/cmdbuilder_test.go
@@ -1,6 +1,7 @@
 package cmdbuilder
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +28,7 @@ func TestShellEscape(t *testing.T) {
 
 func TestBuild_NoRunAs(t *testing.T) {
 	// Without RunAsUser, should produce a direct command
-	cmd, err := Build(nil, true, "echo hello", nil, "", nil, Config{})
+	cmd, err := Build(context.TODO(), true, "echo hello", nil, "", nil, Config{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,7 +39,7 @@ func TestBuild_NoRunAs(t *testing.T) {
 
 func TestBuild_WithRunAs(t *testing.T) {
 	// With RunAsUser, should produce a sudo-wrapped command
-	cmd, err := Build(nil, true, "echo hello", nil, "", nil, Config{RunAsUser: "alice"})
+	cmd, err := Build(context.TODO(), true, "echo hello", nil, "", nil, Config{RunAsUser: "alice"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestBuild_WithRunAs(t *testing.T) {
 }
 
 func TestBuild_NonShellRequiresArgs(t *testing.T) {
-	_, err := Build(nil, false, "", nil, "", nil, Config{})
+	_, err := Build(context.TODO(), false, "", nil, "", nil, Config{})
 	if err == nil {
 		t.Error("expected error for non-shell with empty args")
 	}

--- a/internal/ctxkeys/ctxkeys.go
+++ b/internal/ctxkeys/ctxkeys.go
@@ -1,0 +1,46 @@
+package ctxkeys
+
+import "context"
+
+type key string
+
+const (
+	permControlEnabledKey key = "perm_control_enabled"
+	chatIDKey             key = "chat_id"
+	senderIDKey           key = "sender_id"
+)
+
+func WithPermControlEnabled(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, permControlEnabledKey, enabled)
+}
+
+func PermControlEnabledFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(permControlEnabledKey).(bool)
+	return enabled
+}
+
+func WithApprovalTarget(ctx context.Context, chatID, senderID string) context.Context {
+	ctx = context.WithValue(ctx, chatIDKey, chatID)
+	ctx = context.WithValue(ctx, senderIDKey, senderID)
+	return ctx
+}
+
+func ApprovalTargetFromContext(ctx context.Context) (chatID, senderID string) {
+	if ctx == nil {
+		return "", ""
+	}
+	if v := ctx.Value(chatIDKey); v != nil {
+		if s, ok := v.(string); ok {
+			chatID = s
+		}
+	}
+	if v := ctx.Value(senderIDKey); v != nil {
+		if s, ok := v.(string); ok {
+			senderID = s
+		}
+	}
+	return chatID, senderID
+}

--- a/internal/runnerclient/executor.go
+++ b/internal/runnerclient/executor.go
@@ -36,6 +36,11 @@ type ExecSpec struct {
 	Env     []string
 	Stdin   string
 	Timeout time.Duration
+
+	// RunAsUser is the OS username to execute the command as.
+	// When set, the command is wrapped with: sudo -n -H -u <user> --
+	// Requires NOPASSWD sudoers entry for the target user.
+	RunAsUser string
 }
 
 // ExecResult 是命令执行结果。

--- a/internal/runnerclient/handler.go
+++ b/internal/runnerclient/handler.go
@@ -220,13 +220,14 @@ func (h *Handler) handleExec(msg runnerproto.RunnerMessage) *runnerproto.RunnerM
 	defer cancel()
 
 	spec := ExecSpec{
-		Command: req.Command,
-		Args:    req.Args,
-		Shell:   req.Shell,
-		Dir:     req.Dir,
-		Env:     req.Env,
-		Stdin:   req.Stdin,
-		Timeout: timeout,
+		Command:   req.Command,
+		Args:      req.Args,
+		Shell:     req.Shell,
+		Dir:       req.Dir,
+		Env:       req.Env,
+		Stdin:     req.Stdin,
+		Timeout:   timeout,
+		RunAsUser: req.RunAsUser,
 	}
 
 	// pathguard 检查工作目录

--- a/internal/runnerclient/native.go
+++ b/internal/runnerclient/native.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"xbot/internal/cmdbuilder"
 )
 
 // maxDownloadSize 是下载操作的最大文件大小（100MB）。
@@ -33,15 +35,10 @@ func NewNativeExecutor(workspace string) *NativeExecutor {
 func (e *NativeExecutor) Close() error { return nil }
 
 func (e *NativeExecutor) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, error) {
-	var cmd *exec.Cmd
-	if spec.Shell {
-		cmd = exec.CommandContext(ctx, "sh", "-c", spec.Command)
-	} else {
-		args := spec.Args
-		if len(args) == 0 {
-			return nil, fmt.Errorf("non-shell exec requires Args to be set explicitly")
-		}
-		cmd = exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd, err := cmdbuilder.Build(ctx, spec.Shell, spec.Command, spec.Args,
+		"", spec.Env, cmdbuilder.Config{RunAsUser: spec.RunAsUser})
+	if err != nil {
+		return nil, err
 	}
 
 	// 创建新进程组，超时时可以 kill 所有子进程
@@ -50,9 +47,6 @@ func (e *NativeExecutor) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, 
 		cmd.Dir = filepath.Clean(spec.Dir)
 	} else {
 		cmd.Dir = e.Workspace
-	}
-	if len(spec.Env) > 0 {
-		cmd.Env = append(os.Environ(), spec.Env...)
 	}
 	if spec.Stdin != "" {
 		cmd.Stdin = strings.NewReader(spec.Stdin)
@@ -63,7 +57,7 @@ func (e *NativeExecutor) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, 
 	cmd.Stderr = &stderr
 
 	start := time.Now()
-	err := cmd.Run()
+	err = cmd.Run()
 	_ = time.Since(start)
 
 	exitCode := 0

--- a/internal/runnerproto/runner_proto.go
+++ b/internal/runnerproto/runner_proto.go
@@ -93,6 +93,10 @@ type ExecRequest struct {
 	Env     []string `json:"env,omitempty"`
 	Stdin   string   `json:"stdin,omitempty"`
 	Timeout int      `json:"timeout"` // seconds
+
+	// RunAsUser is the OS username to execute as.
+	// When set, the runner wraps the command with sudo -n -H -u <user> --
+	RunAsUser string `json:"run_as_user,omitempty"`
 }
 
 // ExecResultResponse is the response for command execution.

--- a/main.go
+++ b/main.go
@@ -624,6 +624,11 @@ func main() {
 	// 设置飞书渠道的 CardBuilder（用于卡片回调处理）
 	if feishuCh != nil {
 		feishuCh.SetCardBuilder(agentLoop.GetCardBuilder())
+		if hook := agentLoop.ToolHookChain().Get("approval"); hook != nil {
+			if ah, ok := hook.(*tools.ApprovalHook); ok {
+				feishuCh.SetApprovalHook(ah)
+			}
+		}
 
 		// 传递 admin chatID 和 web DB（用于 admin 命令如 !webadd）
 		if adminChatID != "" {

--- a/scripts/setup-perm-control.sh
+++ b/scripts/setup-perm-control.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -euo pipefail
+
+# xbot permission-control setup script
+# Configures NOPASSWD sudoers + xbot settings for default_user / privileged_user
+#
+# Usage: sudo ./setup-perm-control.sh [XBOT_WORK_DIR]
+#   XBOT_WORK_DIR: xbot working directory (default: detect from cwd or ~/src/xbot)
+#
+# After running, xbot's LLM can:
+#   - Run shell commands as "user" without approval (default_user)
+#   - Request to run as "root" with user approval (privileged_user)
+
+DEFAULT_USER="${DEFAULT_USER:-user}"
+PRIVILEGED_USER="${PRIVILEGED_USER:-root}"
+
+# --- Detect xbot process user (the user that runs xbot, NOT the target users) ---
+if [[ $EUID -eq 0 ]]; then
+    # Running as root — find the real xbot user (first non-root UID 1000+ user)
+    XBOT_PROCESS_USER=$(awk -F: '$3 >= 1000 && $3 != 65534 && $1 != "root" {print $1; exit}' /etc/passwd)
+    if [[ -z "$XBOT_PROCESS_USER" ]]; then
+        echo "ERROR: Cannot determine xbot process user (running as root, no regular user found)"
+        exit 1
+    fi
+    echo "Running as root, xbot process user detected: $XBOT_PROCESS_USER"
+else
+    XBOT_PROCESS_USER="$(whoami)"
+    echo "xbot process user: $XBOT_PROCESS_USER"
+fi
+
+echo "Default user (no approval needed): $DEFAULT_USER"
+echo "Privileged user (approval required): $PRIVILEGED_USER"
+echo ""
+
+# --- 1. Configure sudoers ---
+SUDOERS_FILE="/etc/sudoers.d/xbot-perm-control"
+SUDOERS_ENTRY="$XBOT_PROCESS_USER ALL=($DEFAULT_USER,$PRIVILEGED_USER) NOPASSWD: ALL"
+
+echo "=== Step 1: Configure sudoers ==="
+echo "Will write: $SUDOERS_ENTRY"
+echo "Target: $SUDOERS_FILE"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Need root to write sudoers. Re-executing with sudo..."
+    # Pass all args through, re-exec as root
+    exec sudo bash "$0" "$@"
+fi
+
+# Validate sudoers syntax before writing
+echo "$SUDOERS_ENTRY" | visudo -cf - > /dev/null 2>&1 || {
+    echo "ERROR: sudoers entry failed validation"
+    exit 1
+}
+
+cat > "$SUDOERS_FILE" <<EOF
+# xbot permission control — allow xbot process to switch to default/privileged users
+# Installed by setup-perm-control.sh on $(date -Iseconds)
+$SUDOERS_ENTRY
+EOF
+
+chmod 440 "$SUDOERS_FILE"
+echo "✓ sudoers configured: $SUDOERS_FILE"
+
+# Verify
+if sudo -n -u "$DEFAULT_USER" whoami > /dev/null 2>&1; then
+    echo "✓ sudo -n -u $DEFAULT_USER: OK ($(sudo -n -u "$DEFAULT_USER" whoami))"
+else
+    echo "✗ sudo -n -u $DEFAULT_USER: FAILED (user may not exist)"
+fi
+
+if sudo -n -u "$PRIVILEGED_USER" whoami > /dev/null 2>&1; then
+    echo "✓ sudo -n -u $PRIVILEGED_USER: OK ($(sudo -n -u "$PRIVILEGED_USER" whoami))"
+else
+    echo "✗ sudo -n -u $PRIVILEGED_USER: FAILED"
+fi
+
+echo ""
+
+# --- 2. Configure xbot settings in SQLite ---
+echo "=== Step 2: Configure xbot settings ==="
+
+# Detect xbot DB path
+# Priority: ~/.xbot/xbot.db (CLI default) > workdir/.xbot/xbot.db
+REAL_HOME=$(eval echo "~$XBOT_PROCESS_USER")
+DB_PATH=""
+
+# Check ~/.xbot/xbot.db first (standard CLI location)
+if [[ -f "$REAL_HOME/.xbot/xbot.db" ]]; then
+    DB_PATH="$REAL_HOME/.xbot/xbot.db"
+else
+    # Fallback: try workdir argument or common locations
+    WORK_DIR="${1:-}"
+    if [[ -z "$WORK_DIR" ]]; then
+        for candidate in "$PWD" "$REAL_HOME/src/xbot" "$REAL_HOME/xbot"; do
+            if [[ -f "$candidate/.xbot/xbot.db" ]]; then
+                DB_PATH="$candidate/.xbot/xbot.db"
+                break
+            fi
+        done
+    elif [[ -f "$WORK_DIR/.xbot/xbot.db" ]]; then
+        DB_PATH="$WORK_DIR/.xbot/xbot.db"
+    fi
+fi
+
+if [[ -z "$DB_PATH" ]]; then
+    echo "ERROR: Cannot find xbot.db. Searched:"
+    echo "  $REAL_HOME/.xbot/xbot.db"
+    echo "  \$PWD/.xbot/xbot.db"
+    echo ""
+    echo "Pass xbot work directory as argument: sudo $0 /path/to/workdir"
+    echo "Or set it up manually in xbot TUI: /settings → default_user, privileged_user"
+    exit 1
+fi
+echo "Database: $DB_PATH"
+
+NOW=$(date +%s)
+
+# Insert or update settings (channel=cli, sender_id=cli_user)
+sqlite3 "$DB_PATH" <<EOF
+INSERT INTO user_settings (channel, sender_id, key, value, updated_at)
+    VALUES ('cli', 'cli_user', 'default_user', '$DEFAULT_USER', $NOW)
+    ON CONFLICT(channel, sender_id, key)
+    DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at;
+
+INSERT INTO user_settings (channel, sender_id, key, value, updated_at)
+    VALUES ('cli', 'cli_user', 'privileged_user', '$PRIVILEGED_USER', $NOW)
+    ON CONFLICT(channel, sender_id, key)
+    DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at;
+EOF
+
+echo "✓ Settings written:"
+echo "  default_user    = $DEFAULT_USER"
+echo "  privileged_user = $PRIVILEGED_USER"
+echo ""
+
+# Verify
+echo "=== Verification ==="
+sqlite3 -header -column "$DB_PATH" \
+    "SELECT channel, sender_id, key, value FROM user_settings WHERE key IN ('default_user', 'privileged_user') AND channel = 'cli';"
+
+echo ""
+echo "=== Done! ==="
+echo "Restart xbot to pick up the new settings."

--- a/tools/approval.go
+++ b/tools/approval.go
@@ -7,6 +7,34 @@ import (
 	"time"
 )
 
+// contextKey is an unexported type for context keys defined in this package.
+type contextKey string
+
+const permUsersKey contextKey = "perm_users"
+
+// PermUsersFromContext retrieves the permission control user config from context.
+func PermUsersFromContext(ctx context.Context) (defaultUser, privilegedUser string) {
+	config, ok := ctx.Value(permUsersKey).(*PermUsersPair)
+	if !ok || config == nil {
+		return "", ""
+	}
+	return config.DefaultUser, config.PrivilegedUser
+}
+
+// PermUsersPair holds the permission control user pair for context injection.
+type PermUsersPair struct {
+	DefaultUser    string
+	PrivilegedUser string
+}
+
+// WithPermUsers injects the permission control user config into the context.
+func WithPermUsers(ctx context.Context, defaultUser, privilegedUser string) context.Context {
+	return context.WithValue(ctx, permUsersKey, &PermUsersPair{
+		DefaultUser:    defaultUser,
+		PrivilegedUser: privilegedUser,
+	})
+}
+
 // ApprovalRequest represents a pending user approval for a tool execution.
 type ApprovalRequest struct {
 	ToolName string `json:"tool_name"` // e.g., "Shell"
@@ -35,22 +63,19 @@ type ApprovalHandler interface {
 }
 
 // ApprovalHook is a ToolHook that intercepts tool calls targeting privileged users.
-// It only activates when the tool call includes a run_as parameter matching the
-// configured privileged user.
+// It reads the user configuration from context (injected per-request by the engine),
+// so settings changes take effect immediately without restart.
 type ApprovalHook struct {
-	handler        ApprovalHandler
-	defaultUser    string // from user settings (empty = feature disabled)
-	privilegedUser string // from user settings (empty = no privileged user)
-	timeout        time.Duration
+	handler ApprovalHandler
+	timeout time.Duration
 }
 
-// NewApprovalHook creates an ApprovalHook with the given handler and user configuration.
-func NewApprovalHook(handler ApprovalHandler, defaultUser, privilegedUser string) *ApprovalHook {
+// NewApprovalHook creates an ApprovalHook with the given handler.
+// User configuration (defaultUser, privilegedUser) is read from context per-request.
+func NewApprovalHook(handler ApprovalHandler) *ApprovalHook {
 	return &ApprovalHook{
-		handler:        handler,
-		defaultUser:    defaultUser,
-		privilegedUser: privilegedUser,
-		timeout:        60 * time.Second,
+		handler: handler,
+		timeout: 60 * time.Second,
 	}
 }
 
@@ -64,31 +89,39 @@ func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args str
 		return nil
 	}
 
+	// Read user configuration from context (per-request, from user_settings)
+	defaultUser, privilegedUser := PermUsersFromContext(ctx)
+
 	// Feature not configured — reject any run_as value
-	if h.defaultUser == "" && h.privilegedUser == "" {
+	if defaultUser == "" && privilegedUser == "" {
 		return fmt.Errorf("permission control is not enabled: cannot use run_as %q (configure default_user or privileged_user in settings)", runAs)
 	}
 
 	// Validate run_as against configured users
-	if runAs == h.defaultUser {
+	if runAs == defaultUser {
 		// Default user — no approval needed
 		return nil
 	}
 
-	if runAs != h.privilegedUser {
+	if runAs != privilegedUser {
 		// Unknown user
-		users := h.defaultUser
-		if h.privilegedUser != "" {
+		users := defaultUser
+		if privilegedUser != "" {
 			if users != "" {
-				users += " or " + h.privilegedUser
+				users += " or " + privilegedUser
 			} else {
-				users = h.privilegedUser
+				users = privilegedUser
 			}
 		}
 		return fmt.Errorf("unknown run_as user %q: must be %q", runAs, users)
 	}
 
 	// Privileged user — request approval with timeout
+	if h.handler == nil {
+		// No approval handler registered — block execution
+		return fmt.Errorf("execution as %q requires approval but no approval handler is available (running in non-interactive channel?)", runAs)
+	}
+
 	approvalCtx, cancel := context.WithTimeout(ctx, h.timeout)
 	defer cancel()
 

--- a/tools/approval.go
+++ b/tools/approval.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -43,17 +44,16 @@ type ApprovalRequest struct {
 	Reason   string `json:"reason"`    // Human-readable description
 
 	// Extracted details for display (populated by ApprovalHook)
-	Command  string `json:"command,omitempty"`   // Parsed command (for Shell)
-	FilePath string `json:"file_path,omitempty"` // Target file (for FileReplace/FileCreate)
+	Command     string `json:"command,omitempty"`      // Parsed command (possibly truncated for display)
+	FilePath    string `json:"file_path,omitempty"`    // Target file (possibly truncated for display)
+	ArgsSummary string `json:"args_summary,omitempty"` // Extra argument summary for approval UI
 }
 
 // ApprovalResult is the user's decision.
-type ApprovalResult int
-
-const (
-	ApprovalDenied   ApprovalResult = 0
-	ApprovalApproved ApprovalResult = 1
-)
+type ApprovalResult struct {
+	Approved   bool   `json:"approved"`
+	DenyReason string `json:"deny_reason,omitempty"`
+}
 
 // ApprovalHandler is the channel-agnostic interface for user approval.
 // Each channel (CLI, Web) provides its own implementation.
@@ -80,6 +80,12 @@ func NewApprovalHook(handler ApprovalHandler) *ApprovalHook {
 }
 
 func (h *ApprovalHook) Name() string { return "approval" }
+
+// SetHandler replaces the approval handler at runtime.
+// Called by channels (CLI, Web) after they have a UI program ready.
+func (h *ApprovalHook) SetHandler(handler ApprovalHandler) {
+	h.handler = handler
+}
 
 func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args string) error {
 	runAs := extractRunAs(args)
@@ -138,7 +144,10 @@ func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args str
 	if err != nil {
 		return fmt.Errorf("approval request failed: %w", err)
 	}
-	if result != ApprovalApproved {
+	if !result.Approved {
+		if strings.TrimSpace(result.DenyReason) != "" {
+			return fmt.Errorf("user denied execution as %q: %s", runAs, strings.TrimSpace(result.DenyReason))
+		}
 		return fmt.Errorf("user denied execution as %q", runAs)
 	}
 
@@ -161,32 +170,66 @@ func extractRunAs(args string) string {
 	return raw.RunAs
 }
 
+func truncateApprovalText(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}
+
 // populateApprovalDetails extracts human-readable details for the approval dialog.
 func populateApprovalDetails(req *ApprovalRequest, toolName, args string) {
+	const maxDisplayLen = 160
+
 	switch toolName {
 	case "Shell":
 		var p struct {
 			Command string `json:"command"`
+			Reason  string `json:"reason"`
 		}
 		if json.Unmarshal([]byte(args), &p) == nil {
-			req.Command = p.Command
-			req.Reason = fmt.Sprintf("Execute command as %q: %s", req.RunAs, p.Command)
+			req.Command = truncateApprovalText(p.Command, maxDisplayLen)
+			req.ArgsSummary = req.Command
+			if strings.TrimSpace(p.Reason) != "" {
+				req.Reason = truncateApprovalText(p.Reason, maxDisplayLen)
+			} else {
+				req.Reason = fmt.Sprintf("Execute command as %q", req.RunAs)
+			}
 		}
 	case "FileCreate":
 		var p struct {
-			Path string `json:"path"`
+			Path   string `json:"path"`
+			RunAs  string `json:"run_as"`
+			Reason string `json:"reason"`
 		}
 		if json.Unmarshal([]byte(args), &p) == nil {
-			req.FilePath = p.Path
-			req.Reason = fmt.Sprintf("Create file as %q: %s", req.RunAs, p.Path)
+			req.FilePath = truncateApprovalText(p.Path, maxDisplayLen)
+			req.ArgsSummary = req.FilePath
+			if strings.TrimSpace(p.Reason) != "" {
+				req.Reason = truncateApprovalText(p.Reason, maxDisplayLen)
+			} else {
+				req.Reason = fmt.Sprintf("Create file as %q", req.RunAs)
+			}
 		}
 	case "FileReplace":
 		var p struct {
-			Path string `json:"path"`
+			Path      string `json:"path"`
+			OldString string `json:"old_string"`
+			NewString string `json:"new_string"`
+			Reason    string `json:"reason"`
 		}
 		if json.Unmarshal([]byte(args), &p) == nil {
-			req.FilePath = p.Path
-			req.Reason = fmt.Sprintf("Modify file as %q: %s", req.RunAs, p.Path)
+			req.FilePath = truncateApprovalText(p.Path, maxDisplayLen)
+			req.ArgsSummary = fmt.Sprintf("old=%q new=%q", truncateApprovalText(p.OldString, 40), truncateApprovalText(p.NewString, 40))
+			if strings.TrimSpace(p.Reason) != "" {
+				req.Reason = truncateApprovalText(p.Reason, maxDisplayLen)
+			} else {
+				req.Reason = fmt.Sprintf("Modify file as %q", req.RunAs)
+			}
 		}
 	}
 	if req.Reason == "" {

--- a/tools/approval.go
+++ b/tools/approval.go
@@ -1,0 +1,162 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ApprovalRequest represents a pending user approval for a tool execution.
+type ApprovalRequest struct {
+	ToolName string `json:"tool_name"` // e.g., "Shell"
+	ToolArgs string `json:"tool_args"` // JSON arguments (for display)
+	RunAs    string `json:"run_as"`    // Target OS user
+	Reason   string `json:"reason"`    // Human-readable description
+
+	// Extracted details for display (populated by ApprovalHook)
+	Command  string `json:"command,omitempty"`   // Parsed command (for Shell)
+	FilePath string `json:"file_path,omitempty"` // Target file (for FileReplace/FileCreate)
+}
+
+// ApprovalResult is the user's decision.
+type ApprovalResult int
+
+const (
+	ApprovalDenied   ApprovalResult = 0
+	ApprovalApproved ApprovalResult = 1
+)
+
+// ApprovalHandler is the channel-agnostic interface for user approval.
+// Each channel (CLI, Web) provides its own implementation.
+type ApprovalHandler interface {
+	// RequestApproval sends an approval request and waits for the user's response.
+	RequestApproval(ctx context.Context, req ApprovalRequest) (ApprovalResult, error)
+}
+
+// ApprovalHook is a ToolHook that intercepts tool calls targeting privileged users.
+// It only activates when the tool call includes a run_as parameter matching the
+// configured privileged user.
+type ApprovalHook struct {
+	handler        ApprovalHandler
+	defaultUser    string // from user settings (empty = feature disabled)
+	privilegedUser string // from user settings (empty = no privileged user)
+	timeout        time.Duration
+}
+
+// NewApprovalHook creates an ApprovalHook with the given handler and user configuration.
+func NewApprovalHook(handler ApprovalHandler, defaultUser, privilegedUser string) *ApprovalHook {
+	return &ApprovalHook{
+		handler:        handler,
+		defaultUser:    defaultUser,
+		privilegedUser: privilegedUser,
+		timeout:        60 * time.Second,
+	}
+}
+
+func (h *ApprovalHook) Name() string { return "approval" }
+
+func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args string) error {
+	runAs := extractRunAs(args)
+
+	// No run_as specified — execute as current process user
+	if runAs == "" {
+		return nil
+	}
+
+	// Feature not configured — reject any run_as value
+	if h.defaultUser == "" && h.privilegedUser == "" {
+		return fmt.Errorf("permission control is not enabled: cannot use run_as %q (configure default_user or privileged_user in settings)", runAs)
+	}
+
+	// Validate run_as against configured users
+	if runAs == h.defaultUser {
+		// Default user — no approval needed
+		return nil
+	}
+
+	if runAs != h.privilegedUser {
+		// Unknown user
+		users := h.defaultUser
+		if h.privilegedUser != "" {
+			if users != "" {
+				users += " or " + h.privilegedUser
+			} else {
+				users = h.privilegedUser
+			}
+		}
+		return fmt.Errorf("unknown run_as user %q: must be %q", runAs, users)
+	}
+
+	// Privileged user — request approval with timeout
+	approvalCtx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+
+	req := ApprovalRequest{
+		ToolName: toolName,
+		ToolArgs: args,
+		RunAs:    runAs,
+	}
+
+	// Extract display details from args
+	populateApprovalDetails(&req, toolName, args)
+
+	result, err := h.handler.RequestApproval(approvalCtx, req)
+	if err != nil {
+		return fmt.Errorf("approval request failed: %w", err)
+	}
+	if result != ApprovalApproved {
+		return fmt.Errorf("user denied execution as %q", runAs)
+	}
+
+	return nil
+}
+
+func (h *ApprovalHook) PostToolUse(ctx context.Context, toolName string, args string, result *ToolResult, err error, elapsed time.Duration) {
+	// No post-action needed
+}
+
+// extractRunAs parses the "run_as" field from JSON tool arguments.
+// Returns empty string if not present or on parse error.
+func extractRunAs(args string) string {
+	var raw struct {
+		RunAs string `json:"run_as"`
+	}
+	if err := json.Unmarshal([]byte(args), &raw); err != nil {
+		return ""
+	}
+	return raw.RunAs
+}
+
+// populateApprovalDetails extracts human-readable details for the approval dialog.
+func populateApprovalDetails(req *ApprovalRequest, toolName, args string) {
+	switch toolName {
+	case "Shell":
+		var p struct {
+			Command string `json:"command"`
+		}
+		if json.Unmarshal([]byte(args), &p) == nil {
+			req.Command = p.Command
+			req.Reason = fmt.Sprintf("Execute command as %q: %s", req.RunAs, p.Command)
+		}
+	case "FileCreate":
+		var p struct {
+			Path string `json:"path"`
+		}
+		if json.Unmarshal([]byte(args), &p) == nil {
+			req.FilePath = p.Path
+			req.Reason = fmt.Sprintf("Create file as %q: %s", req.RunAs, p.Path)
+		}
+	case "FileReplace":
+		var p struct {
+			Path string `json:"path"`
+		}
+		if json.Unmarshal([]byte(args), &p) == nil {
+			req.FilePath = p.Path
+			req.Reason = fmt.Sprintf("Modify file as %q: %s", req.RunAs, p.Path)
+		}
+	}
+	if req.Reason == "" {
+		req.Reason = fmt.Sprintf("Execute %s as %q", toolName, req.RunAs)
+	}
+}

--- a/tools/approval.go
+++ b/tools/approval.go
@@ -88,7 +88,10 @@ func (h *ApprovalHook) SetHandler(handler ApprovalHandler) {
 }
 
 func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args string) error {
-	runAs := extractRunAs(args)
+	runAs, reason := extractRunAsAndReason(args)
+	if (strings.TrimSpace(runAs) == "") != (strings.TrimSpace(reason) == "") {
+		return fmt.Errorf("run_as and reason must be provided together")
+	}
 
 	// No run_as specified — execute as current process user
 	if runAs == "" {
@@ -158,16 +161,17 @@ func (h *ApprovalHook) PostToolUse(ctx context.Context, toolName string, args st
 	// No post-action needed
 }
 
-// extractRunAs parses the "run_as" field from JSON tool arguments.
-// Returns empty string if not present or on parse error.
-func extractRunAs(args string) string {
+// extractRunAsAndReason parses the "run_as" and "reason" fields from JSON tool arguments.
+// Returns empty strings if not present or on parse error.
+func extractRunAsAndReason(args string) (runAs, reason string) {
 	var raw struct {
-		RunAs string `json:"run_as"`
+		RunAs  string `json:"run_as"`
+		Reason string `json:"reason"`
 	}
 	if err := json.Unmarshal([]byte(args), &raw); err != nil {
-		return ""
+		return "", ""
 	}
-	return raw.RunAs
+	return raw.RunAs, raw.Reason
 }
 
 func truncateApprovalText(s string, max int) string {

--- a/tools/approval_reason_order_test.go
+++ b/tools/approval_reason_order_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestApprovalHook_RejectsMissingReasonBeforeRequestingApproval(t *testing.T) {
+	handler := &mockApprovalHandler{result: ApprovalResult{Approved: true}}
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error for missing reason")
+	}
+	if !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handler.called {
+		t.Fatal("approval handler should not be called when reason validation fails")
+	}
+}
+
+func TestApprovalHook_RejectsReasonWithoutRunAsBeforeRequestingApproval(t *testing.T) {
+	handler := &mockApprovalHandler{result: ApprovalResult{Approved: true}}
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls", "reason": "just because"}`)
+	if err == nil {
+		t.Fatal("expected error for reason without run_as")
+	}
+	if !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handler.called {
+		t.Fatal("approval handler should not be called when pair validation fails")
+	}
+}

--- a/tools/approval_test.go
+++ b/tools/approval_test.go
@@ -1,0 +1,155 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+// mockApprovalHandler is a test implementation of ApprovalHandler.
+type mockApprovalHandler struct {
+	result  ApprovalResult
+	err     error
+	called  bool
+	lastReq ApprovalRequest
+}
+
+func (m *mockApprovalHandler) RequestApproval(ctx context.Context, req ApprovalRequest) (ApprovalResult, error) {
+	m.called = true
+	m.lastReq = req
+	return m.result, m.err
+}
+
+func TestApprovalHook_Name(t *testing.T) {
+	h := NewApprovalHook(&mockApprovalHandler{}, "alice", "root")
+	if h.Name() != "approval" {
+		t.Errorf("expected 'approval', got %q", h.Name())
+	}
+}
+
+func TestApprovalHook_NoRunAs(t *testing.T) {
+	handler := &mockApprovalHandler{}
+	h := NewApprovalHook(handler, "alice", "root")
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls"}`)
+	if err != nil {
+		t.Errorf("expected no error for empty run_as, got %v", err)
+	}
+	if handler.called {
+		t.Error("handler should not be called for empty run_as")
+	}
+}
+
+func TestApprovalHook_DefaultUser(t *testing.T) {
+	handler := &mockApprovalHandler{}
+	h := NewApprovalHook(handler, "alice", "root")
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "alice"}`)
+	if err != nil {
+		t.Errorf("expected no error for default_user, got %v", err)
+	}
+	if handler.called {
+		t.Error("handler should not be called for default_user")
+	}
+}
+
+func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
+	handler := &mockApprovalHandler{result: ApprovalApproved}
+	h := NewApprovalHook(handler, "alice", "root")
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	if err != nil {
+		t.Errorf("expected no error for approved privileged_user, got %v", err)
+	}
+	if !handler.called {
+		t.Error("handler should be called for privileged_user")
+	}
+}
+
+func TestApprovalHook_PrivilegedUser_Denied(t *testing.T) {
+	handler := &mockApprovalHandler{result: ApprovalDenied}
+	h := NewApprovalHook(handler, "alice", "root")
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error for denied privileged_user")
+	}
+}
+
+func TestApprovalHook_UnknownUser(t *testing.T) {
+	handler := &mockApprovalHandler{}
+	h := NewApprovalHook(handler, "alice", "root")
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "hacker"}`)
+	if err == nil {
+		t.Fatal("expected error for unknown user")
+	}
+}
+
+func TestApprovalHook_FeatureDisabled(t *testing.T) {
+	handler := &mockApprovalHandler{}
+	h := NewApprovalHook(handler, "", "") // feature disabled
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error when feature is disabled")
+	}
+}
+
+func TestApprovalHook_OnlyDefaultUser(t *testing.T) {
+	handler := &mockApprovalHandler{}
+	h := NewApprovalHook(handler, "alice", "") // only default user, no privileged
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "alice"}`)
+	if err != nil {
+		t.Errorf("expected no error for default_user, got %v", err)
+	}
+	// run_as "root" should fail because privileged_user is not configured
+	err = h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error for run_as=root when privileged_user is empty")
+	}
+}
+
+func TestApprovalHook_OnlyPrivilegedUser(t *testing.T) {
+	handler := &mockApprovalHandler{result: ApprovalApproved}
+	h := NewApprovalHook(handler, "", "root") // only privileged user
+	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
+	if err != nil {
+		t.Errorf("expected no error for approved privileged_user, got %v", err)
+	}
+}
+
+func TestApprovalHook_ExtractRunAs(t *testing.T) {
+	tests := []struct {
+		args     string
+		expected string
+	}{
+		{`{"command": "ls"}`, ""},
+		{`{"command": "ls", "run_as": "root"}`, "root"},
+		{`{}`, ""},
+		{"invalid json", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractRunAs(tt.args)
+		if got != tt.expected {
+			t.Errorf("extractRunAs(%q) = %q, want %q", tt.args, got, tt.expected)
+		}
+	}
+}
+
+func TestApprovalHook_PopulateDetails(t *testing.T) {
+	req := ApprovalRequest{RunAs: "root"}
+	populateApprovalDetails(&req, "Shell", `{"command": "apt install nginx"}`)
+	if req.Command != "apt install nginx" {
+		t.Errorf("expected command 'apt install nginx', got %q", req.Command)
+	}
+	if req.Reason == "" {
+		t.Error("expected non-empty reason")
+	}
+
+	req2 := ApprovalRequest{RunAs: "root"}
+	populateApprovalDetails(&req2, "FileCreate", `{"path": "/etc/test.conf"}`)
+	if req2.FilePath != "/etc/test.conf" {
+		t.Errorf("expected file path '/etc/test.conf', got %q", req2.FilePath)
+	}
+}
+
+func TestApprovalHook_PostToolUse(t *testing.T) {
+	h := NewApprovalHook(&mockApprovalHandler{}, "alice", "root")
+	// PostToolUse should be a no-op — verify it doesn't panic
+	h.PostToolUse(context.Background(), "Shell", "", nil, nil, 0)
+}

--- a/tools/approval_test.go
+++ b/tools/approval_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -55,7 +56,7 @@ func TestApprovalHook_DefaultUser(t *testing.T) {
 }
 
 func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
-	handler := &mockApprovalHandler{result: ApprovalApproved}
+	handler := &mockApprovalHandler{result: ApprovalResult{Approved: true}}
 	h := NewApprovalHook(handler)
 	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
 	if err != nil {
@@ -67,11 +68,23 @@ func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
 }
 
 func TestApprovalHook_PrivilegedUser_Denied(t *testing.T) {
-	handler := &mockApprovalHandler{result: ApprovalDenied}
+	handler := &mockApprovalHandler{result: ApprovalResult{Approved: false}}
 	h := NewApprovalHook(handler)
 	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
 	if err == nil {
 		t.Fatal("expected error for denied privileged_user")
+	}
+}
+
+func TestApprovalHook_PrivilegedUser_DeniedWithReason(t *testing.T) {
+	handler := &mockApprovalHandler{result: ApprovalResult{Approved: false, DenyReason: "unsafe package source"}}
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error for denied privileged_user")
+	}
+	if !strings.Contains(err.Error(), "unsafe package source") {
+		t.Fatalf("expected deny reason in error, got %v", err)
 	}
 }
 
@@ -119,7 +132,7 @@ func TestApprovalHook_OnlyDefaultUser(t *testing.T) {
 }
 
 func TestApprovalHook_OnlyPrivilegedUser(t *testing.T) {
-	handler := &mockApprovalHandler{result: ApprovalApproved}
+	handler := &mockApprovalHandler{result: ApprovalResult{Approved: true}}
 	h := NewApprovalHook(handler)
 	err := h.PreToolUse(withPerm(context.Background(), "", "root"), "Shell", `{"command": "ls", "run_as": "root"}`)
 	if err != nil {
@@ -155,11 +168,30 @@ func TestApprovalHook_PopulateDetails(t *testing.T) {
 	if req.Reason == "" {
 		t.Error("expected non-empty reason")
 	}
+	if req.ArgsSummary != "apt install nginx" {
+		t.Errorf("expected args summary to match command, got %q", req.ArgsSummary)
+	}
 
 	req2 := ApprovalRequest{RunAs: "root"}
 	populateApprovalDetails(&req2, "FileCreate", `{"path": "/etc/test.conf"}`)
 	if req2.FilePath != "/etc/test.conf" {
 		t.Errorf("expected file path '/etc/test.conf', got %q", req2.FilePath)
+	}
+
+	req3 := ApprovalRequest{RunAs: "root"}
+	populateApprovalDetails(&req3, "Shell", `{"command": "apt install nginx", "reason": "Install nginx for reverse proxy"}`)
+	if req3.Reason != "Install nginx for reverse proxy" {
+		t.Errorf("expected explicit reason, got %q", req3.Reason)
+	}
+
+	longCmd := "python -c '" + strings.Repeat("x", 300) + "'"
+	req4 := ApprovalRequest{RunAs: "root"}
+	populateApprovalDetails(&req4, "Shell", `{"command": "`+longCmd+`"}`)
+	if len(req4.Command) > 160 {
+		t.Fatalf("expected truncated command <= 160 chars, got %d", len(req4.Command))
+	}
+	if !strings.HasSuffix(req4.Command, "...") {
+		t.Fatalf("expected truncated command to end with ellipsis, got %q", req4.Command)
 	}
 }
 

--- a/tools/approval_test.go
+++ b/tools/approval_test.go
@@ -46,7 +46,7 @@ func TestApprovalHook_NoRunAs(t *testing.T) {
 func TestApprovalHook_DefaultUser(t *testing.T) {
 	handler := &mockApprovalHandler{}
 	h := NewApprovalHook(handler)
-	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls", "run_as": "alice"}`)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls", "run_as": "alice", "reason": "list directory"}`)
 	if err != nil {
 		t.Errorf("expected no error for default_user, got %v", err)
 	}
@@ -58,7 +58,7 @@ func TestApprovalHook_DefaultUser(t *testing.T) {
 func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalResult{Approved: true}}
 	h := NewApprovalHook(handler)
-	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root", "reason": "install package"}`)
 	if err != nil {
 		t.Errorf("expected no error for approved privileged_user, got %v", err)
 	}
@@ -70,7 +70,7 @@ func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
 func TestApprovalHook_PrivilegedUser_Denied(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalResult{Approved: false}}
 	h := NewApprovalHook(handler)
-	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root", "reason": "install package"}`)
 	if err == nil {
 		t.Fatal("expected error for denied privileged_user")
 	}
@@ -79,7 +79,7 @@ func TestApprovalHook_PrivilegedUser_Denied(t *testing.T) {
 func TestApprovalHook_PrivilegedUser_DeniedWithReason(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalResult{Approved: false, DenyReason: "unsafe package source"}}
 	h := NewApprovalHook(handler)
-	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root", "reason": "install package"}`)
 	if err == nil {
 		t.Fatal("expected error for denied privileged_user")
 	}
@@ -120,12 +120,12 @@ func TestApprovalHook_EmptyPermUsers(t *testing.T) {
 func TestApprovalHook_OnlyDefaultUser(t *testing.T) {
 	handler := &mockApprovalHandler{}
 	h := NewApprovalHook(handler)
-	err := h.PreToolUse(withPerm(context.Background(), "alice", ""), "Shell", `{"command": "ls", "run_as": "alice"}`)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", ""), "Shell", `{"command": "ls", "run_as": "alice", "reason": "list directory"}`)
 	if err != nil {
 		t.Errorf("expected no error for default_user, got %v", err)
 	}
 	// run_as "root" should fail because privileged_user is not configured
-	err = h.PreToolUse(withPerm(context.Background(), "alice", ""), "Shell", `{"command": "ls", "run_as": "root"}`)
+	err = h.PreToolUse(withPerm(context.Background(), "alice", ""), "Shell", `{"command": "ls", "run_as": "root", "reason": "list root"}`)
 	if err == nil {
 		t.Fatal("expected error for run_as=root when privileged_user is empty")
 	}
@@ -134,27 +134,28 @@ func TestApprovalHook_OnlyDefaultUser(t *testing.T) {
 func TestApprovalHook_OnlyPrivilegedUser(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalResult{Approved: true}}
 	h := NewApprovalHook(handler)
-	err := h.PreToolUse(withPerm(context.Background(), "", "root"), "Shell", `{"command": "ls", "run_as": "root"}`)
+	err := h.PreToolUse(withPerm(context.Background(), "", "root"), "Shell", `{"command": "ls", "run_as": "root", "reason": "list root directory"}`)
 	if err != nil {
 		t.Errorf("expected no error for approved privileged_user, got %v", err)
 	}
 }
 
-func TestApprovalHook_ExtractRunAs(t *testing.T) {
+func TestApprovalHook_ExtractRunAsAndReason(t *testing.T) {
 	tests := []struct {
-		args     string
-		expected string
+		args           string
+		expectedRunAs  string
+		expectedReason string
 	}{
-		{`{"command": "ls"}`, ""},
-		{`{"command": "ls", "run_as": "root"}`, "root"},
-		{`{}`, ""},
-		{"invalid json", ""},
+		{`{"command": "ls"}`, "", ""},
+		{`{"command": "ls", "run_as": "root", "reason": "list root"}`, "root", "list root"},
+		{`{}`, "", ""},
+		{"invalid json", "", ""},
 	}
 
 	for _, tt := range tests {
-		got := extractRunAs(tt.args)
-		if got != tt.expected {
-			t.Errorf("extractRunAs(%q) = %q, want %q", tt.args, got, tt.expected)
+		runAs, reason := extractRunAsAndReason(tt.args)
+		if runAs != tt.expectedRunAs || reason != tt.expectedReason {
+			t.Errorf("extractRunAsAndReason(%q) = (%q, %q), want (%q, %q)", tt.args, runAs, reason, tt.expectedRunAs, tt.expectedReason)
 		}
 	}
 }

--- a/tools/approval_test.go
+++ b/tools/approval_test.go
@@ -19,8 +19,12 @@ func (m *mockApprovalHandler) RequestApproval(ctx context.Context, req ApprovalR
 	return m.result, m.err
 }
 
+func withPerm(ctx context.Context, defaultUser, privilegedUser string) context.Context {
+	return WithPermUsers(ctx, defaultUser, privilegedUser)
+}
+
 func TestApprovalHook_Name(t *testing.T) {
-	h := NewApprovalHook(&mockApprovalHandler{}, "alice", "root")
+	h := NewApprovalHook(&mockApprovalHandler{})
 	if h.Name() != "approval" {
 		t.Errorf("expected 'approval', got %q", h.Name())
 	}
@@ -28,8 +32,8 @@ func TestApprovalHook_Name(t *testing.T) {
 
 func TestApprovalHook_NoRunAs(t *testing.T) {
 	handler := &mockApprovalHandler{}
-	h := NewApprovalHook(handler, "alice", "root")
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls"}`)
 	if err != nil {
 		t.Errorf("expected no error for empty run_as, got %v", err)
 	}
@@ -40,8 +44,8 @@ func TestApprovalHook_NoRunAs(t *testing.T) {
 
 func TestApprovalHook_DefaultUser(t *testing.T) {
 	handler := &mockApprovalHandler{}
-	h := NewApprovalHook(handler, "alice", "root")
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "alice"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls", "run_as": "alice"}`)
 	if err != nil {
 		t.Errorf("expected no error for default_user, got %v", err)
 	}
@@ -52,8 +56,8 @@ func TestApprovalHook_DefaultUser(t *testing.T) {
 
 func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalApproved}
-	h := NewApprovalHook(handler, "alice", "root")
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
 	if err != nil {
 		t.Errorf("expected no error for approved privileged_user, got %v", err)
 	}
@@ -64,8 +68,8 @@ func TestApprovalHook_PrivilegedUser_Approved(t *testing.T) {
 
 func TestApprovalHook_PrivilegedUser_Denied(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalDenied}
-	h := NewApprovalHook(handler, "alice", "root")
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "apt install nginx", "run_as": "root"}`)
 	if err == nil {
 		t.Fatal("expected error for denied privileged_user")
 	}
@@ -73,8 +77,8 @@ func TestApprovalHook_PrivilegedUser_Denied(t *testing.T) {
 
 func TestApprovalHook_UnknownUser(t *testing.T) {
 	handler := &mockApprovalHandler{}
-	h := NewApprovalHook(handler, "alice", "root")
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "hacker"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", "root"), "Shell", `{"command": "ls", "run_as": "hacker"}`)
 	if err == nil {
 		t.Fatal("expected error for unknown user")
 	}
@@ -82,22 +86,33 @@ func TestApprovalHook_UnknownUser(t *testing.T) {
 
 func TestApprovalHook_FeatureDisabled(t *testing.T) {
 	handler := &mockApprovalHandler{}
-	h := NewApprovalHook(handler, "", "") // feature disabled
+	h := NewApprovalHook(handler)
+	// No perm users in context — feature disabled
 	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
 	if err == nil {
 		t.Fatal("expected error when feature is disabled")
 	}
 }
 
+func TestApprovalHook_EmptyPermUsers(t *testing.T) {
+	handler := &mockApprovalHandler{}
+	h := NewApprovalHook(handler)
+	// Perm users in context but both empty
+	err := h.PreToolUse(withPerm(context.Background(), "", ""), "Shell", `{"command": "ls", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error when perm users are empty")
+	}
+}
+
 func TestApprovalHook_OnlyDefaultUser(t *testing.T) {
 	handler := &mockApprovalHandler{}
-	h := NewApprovalHook(handler, "alice", "") // only default user, no privileged
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "alice"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "alice", ""), "Shell", `{"command": "ls", "run_as": "alice"}`)
 	if err != nil {
 		t.Errorf("expected no error for default_user, got %v", err)
 	}
 	// run_as "root" should fail because privileged_user is not configured
-	err = h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
+	err = h.PreToolUse(withPerm(context.Background(), "alice", ""), "Shell", `{"command": "ls", "run_as": "root"}`)
 	if err == nil {
 		t.Fatal("expected error for run_as=root when privileged_user is empty")
 	}
@@ -105,8 +120,8 @@ func TestApprovalHook_OnlyDefaultUser(t *testing.T) {
 
 func TestApprovalHook_OnlyPrivilegedUser(t *testing.T) {
 	handler := &mockApprovalHandler{result: ApprovalApproved}
-	h := NewApprovalHook(handler, "", "root") // only privileged user
-	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
+	h := NewApprovalHook(handler)
+	err := h.PreToolUse(withPerm(context.Background(), "", "root"), "Shell", `{"command": "ls", "run_as": "root"}`)
 	if err != nil {
 		t.Errorf("expected no error for approved privileged_user, got %v", err)
 	}
@@ -149,7 +164,31 @@ func TestApprovalHook_PopulateDetails(t *testing.T) {
 }
 
 func TestApprovalHook_PostToolUse(t *testing.T) {
-	h := NewApprovalHook(&mockApprovalHandler{}, "alice", "root")
+	h := NewApprovalHook(&mockApprovalHandler{})
 	// PostToolUse should be a no-op — verify it doesn't panic
 	h.PostToolUse(context.Background(), "Shell", "", nil, nil, 0)
+}
+
+func TestApprovalHook_NilHandler(t *testing.T) {
+	h := NewApprovalHook(nil)
+	ctx := withPerm(context.Background(), "", "root")
+	err := h.PreToolUse(ctx, "Shell", `{"command": "ls", "run_as": "root"}`)
+	if err == nil {
+		t.Fatal("expected error when handler is nil and privileged_user requested")
+	}
+}
+
+func TestPermUsersFromContext(t *testing.T) {
+	// Empty context
+	du, pu := PermUsersFromContext(context.Background())
+	if du != "" || pu != "" {
+		t.Errorf("expected empty users from empty context, got %q/%q", du, pu)
+	}
+
+	// With perm users
+	ctx := WithPermUsers(context.Background(), "alice", "root")
+	du, pu = PermUsersFromContext(ctx)
+	if du != "alice" || pu != "root" {
+		t.Errorf("expected alice/root, got %q/%q", du, pu)
+	}
 }

--- a/tools/edit.go
+++ b/tools/edit.go
@@ -231,12 +231,18 @@ func (t *FileReplaceTool) executeLocal(ctx *ToolContext, params FileReplaceParam
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+	mode := info.Mode().Perm()
+
 	newContent, result, err := doReplace(string(content), params, filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := cmdbuilder.WriteFileAsUser(params.RunAs, filePath, []byte(newContent), 0644); err != nil {
+	if err := cmdbuilder.WriteFileAsUser(params.RunAs, filePath, []byte(newContent), mode); err != nil {
 		return nil, fmt.Errorf("failed to write file: %w", err)
 	}
 

--- a/tools/edit.go
+++ b/tools/edit.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"xbot/internal/cmdbuilder"
 	"xbot/llm"
 )
 
@@ -36,12 +38,14 @@ func (t *FileCreateTool) Parameters() []llm.ToolParam {
 	return []llm.ToolParam{
 		{Name: "path", Type: "string", Description: "File path to create (relative to working directory or absolute)", Required: true},
 		{Name: "content", Type: "string", Description: "Content to write to the new file", Required: true},
+		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
 	}
 }
 
 type FileCreateParams struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
+	RunAs   string `json:"run_as"`
 }
 
 func (t *FileCreateTool) Execute(ctx *ToolContext, input string) (*ToolResult, error) {
@@ -82,12 +86,16 @@ func (t *FileCreateTool) executeLocal(ctx *ToolContext, params FileCreateParams)
 	// Create parent directories if needed
 	dir := filepath.Dir(filePath)
 	if dir != "." && dir != "" {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if params.RunAs != "" {
+			if err := cmdbuilder.MkdirAllAsUser(params.RunAs, dir, 0755); err != nil {
+				return nil, fmt.Errorf("failed to create directory as user %q: %w", params.RunAs, err)
+			}
+		} else if err := os.MkdirAll(dir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create directory: %w", err)
 		}
 	}
 
-	if err := os.WriteFile(filePath, []byte(params.Content), 0644); err != nil {
+	if err := cmdbuilder.WriteFileAsUser(params.RunAs, filePath, []byte(params.Content), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write file: %w", err)
 	}
 
@@ -136,6 +144,7 @@ func (t *FileReplaceTool) Parameters() []llm.ToolParam {
 		{Name: "regex", Type: "boolean", Description: "Use RE2 regex matching (default false, exact match)", Required: false},
 		{Name: "start_line", Type: "integer", Description: "Restrict search from this line, 1-based inclusive", Required: false},
 		{Name: "end_line", Type: "integer", Description: "Restrict search to this line, 1-based inclusive", Required: false},
+		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
 	}
 }
 
@@ -147,6 +156,7 @@ type FileReplaceParams struct {
 	Regex      bool   `json:"regex"`
 	StartLine  int    `json:"start_line"`
 	EndLine    int    `json:"end_line"`
+	RunAs      string `json:"run_as"`
 }
 
 func (t *FileReplaceTool) Execute(ctx *ToolContext, input string) (*ToolResult, error) {
@@ -206,7 +216,7 @@ func (t *FileReplaceTool) executeLocal(ctx *ToolContext, params FileReplaceParam
 		return nil, err
 	}
 
-	content, err := os.ReadFile(filePath)
+	content, err := cmdbuilder.ReadFileAsUser(params.RunAs, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
@@ -216,7 +226,7 @@ func (t *FileReplaceTool) executeLocal(ctx *ToolContext, params FileReplaceParam
 		return nil, err
 	}
 
-	if err := os.WriteFile(filePath, []byte(newContent), 0644); err != nil {
+	if err := cmdbuilder.WriteFileAsUser(params.RunAs, filePath, []byte(newContent), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write file: %w", err)
 	}
 

--- a/tools/edit.go
+++ b/tools/edit.go
@@ -39,6 +39,7 @@ func (t *FileCreateTool) Parameters() []llm.ToolParam {
 		{Name: "path", Type: "string", Description: "File path to create (relative to working directory or absolute)", Required: true},
 		{Name: "content", Type: "string", Description: "Content to write to the new file", Required: true},
 		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
+		{Name: "reason", Type: "string", Description: "Optional human-readable reason shown in approval requests when approval is required.", Required: false},
 	}
 }
 
@@ -46,6 +47,7 @@ type FileCreateParams struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
 	RunAs   string `json:"run_as"`
+	Reason  string `json:"reason"`
 }
 
 func (t *FileCreateTool) Execute(ctx *ToolContext, input string) (*ToolResult, error) {
@@ -55,6 +57,9 @@ func (t *FileCreateTool) Execute(ctx *ToolContext, input string) (*ToolResult, e
 	}
 	if params.Path == "" {
 		return nil, fmt.Errorf("path is required")
+	}
+	if (strings.TrimSpace(params.RunAs) == "") != (strings.TrimSpace(params.Reason) == "") {
+		return nil, fmt.Errorf("run_as and reason must be provided together")
 	}
 
 	if shouldUseSandbox(ctx) {
@@ -145,6 +150,7 @@ func (t *FileReplaceTool) Parameters() []llm.ToolParam {
 		{Name: "start_line", Type: "integer", Description: "Restrict search from this line, 1-based inclusive", Required: false},
 		{Name: "end_line", Type: "integer", Description: "Restrict search to this line, 1-based inclusive", Required: false},
 		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
+		{Name: "reason", Type: "string", Description: "Optional human-readable reason shown in approval requests when approval is required.", Required: false},
 	}
 }
 
@@ -157,6 +163,7 @@ type FileReplaceParams struct {
 	StartLine  int    `json:"start_line"`
 	EndLine    int    `json:"end_line"`
 	RunAs      string `json:"run_as"`
+	Reason     string `json:"reason"`
 }
 
 func (t *FileReplaceTool) Execute(ctx *ToolContext, input string) (*ToolResult, error) {
@@ -169,6 +176,9 @@ func (t *FileReplaceTool) Execute(ctx *ToolContext, input string) (*ToolResult, 
 	}
 	if params.OldString == "" {
 		return nil, fmt.Errorf("old_string is required")
+	}
+	if (strings.TrimSpace(params.RunAs) == "") != (strings.TrimSpace(params.Reason) == "") {
+		return nil, fmt.Errorf("run_as and reason must be provided together")
 	}
 
 	// Safety: reject oversized inputs to prevent CPU/memory exhaustion

--- a/tools/file_replace_mode_test.go
+++ b/tools/file_replace_mode_test.go
@@ -1,0 +1,41 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileReplaceTool_PreservesExistingFileMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "mode.txt")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatalf("chmod fixture: %v", err)
+	}
+
+	tool := &FileReplaceTool{}
+	ctx := &ToolContext{WorkingDir: tmpDir}
+	_, err := tool.Execute(ctx, `{"path":"`+path+`","old_string":"world","new_string":"xbot"}`)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat result: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected mode 0600 preserved, got %#o", got)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	if string(content) != "hello xbot\n" {
+		t.Fatalf("unexpected content: %q", string(content))
+	}
+}

--- a/tools/hook.go
+++ b/tools/hook.go
@@ -71,6 +71,18 @@ func (hc *HookChain) Use(hook ToolHook) error {
 	return nil
 }
 
+// Get returns a hook by name, or nil if not found.
+func (hc *HookChain) Get(name string) ToolHook {
+	hc.mu.RLock()
+	defer hc.mu.RUnlock()
+	for _, h := range hc.hooks {
+		if h.Name() == name {
+			return h
+		}
+	}
+	return nil
+}
+
 // Remove removes a hook by name.
 func (hc *HookChain) Remove(name string) {
 	hc.mu.Lock()

--- a/tools/none_sandbox.go
+++ b/tools/none_sandbox.go
@@ -14,6 +14,8 @@ import (
 	"syscall"
 	"time"
 
+	"xbot/internal/cmdbuilder"
+
 	log "xbot/logger"
 )
 
@@ -429,28 +431,15 @@ func noneSandboxExecAsync(ctx context.Context, spec ExecSpec, outputBuf func(str
 // If managedCtx is true, uses exec.CommandContext (context cancel kills the process).
 // If false, uses exec.Command (caller manages process lifecycle manually, e.g. KeepAlive).
 func buildCmdFromSpec(ctx context.Context, spec ExecSpec, managedCtx bool) (*exec.Cmd, error) {
-	var cmd *exec.Cmd
-	if spec.Shell {
-		if managedCtx {
-			cmd = exec.CommandContext(ctx, "/bin/sh", "-c", spec.Command)
-		} else {
-			cmd = exec.Command("/bin/sh", "-c", spec.Command)
-		}
-	} else {
-		if len(spec.Args) == 0 {
-			return nil, fmt.Errorf("non-shell exec requires Args to be set")
-		}
-		if managedCtx {
-			cmd = exec.CommandContext(ctx, spec.Args[0], spec.Args[1:]...)
-		} else {
-			cmd = exec.Command(spec.Args[0], spec.Args[1:]...)
-		}
+	// When managedCtx=false, pass nil context to get exec.Command (no context-based kill)
+	buildCtx := ctx
+	if !managedCtx {
+		buildCtx = nil
 	}
-	if spec.Dir != "" {
-		cmd.Dir = spec.Dir
-	}
-	if len(spec.Env) > 0 {
-		cmd.Env = append(os.Environ(), spec.Env...)
+	cmd, err := cmdbuilder.Build(buildCtx, spec.Shell, spec.Command, spec.Args,
+		spec.Dir, spec.Env, cmdbuilder.Config{RunAsUser: spec.RunAsUser})
+	if err != nil {
+		return nil, err
 	}
 	return cmd, nil
 }

--- a/tools/permission_reason_validation_test.go
+++ b/tools/permission_reason_validation_test.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShellTool_RunAsReasonPairValidation(t *testing.T) {
+	tool := &ShellTool{}
+	ctx := &ToolContext{}
+
+	_, err := tool.Execute(ctx, `{"command":"whoami","run_as":"root"}`)
+	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("expected pair-validation error for run_as only, got %v", err)
+	}
+
+	_, err = tool.Execute(ctx, `{"command":"whoami","reason":"need root"}`)
+	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("expected pair-validation error for reason only, got %v", err)
+	}
+}
+
+func TestFileCreateTool_RunAsReasonPairValidation(t *testing.T) {
+	tool := &FileCreateTool{}
+	ctx := &ToolContext{}
+
+	_, err := tool.Execute(ctx, `{"path":"/tmp/a.txt","content":"x","run_as":"root"}`)
+	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("expected pair-validation error for run_as only, got %v", err)
+	}
+
+	_, err = tool.Execute(ctx, `{"path":"/tmp/a.txt","content":"x","reason":"need root"}`)
+	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("expected pair-validation error for reason only, got %v", err)
+	}
+}
+
+func TestFileReplaceTool_RunAsReasonPairValidation(t *testing.T) {
+	tool := &FileReplaceTool{}
+	ctx := &ToolContext{}
+
+	_, err := tool.Execute(ctx, `{"path":"/tmp/a.txt","old_string":"a","new_string":"b","run_as":"root"}`)
+	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("expected pair-validation error for run_as only, got %v", err)
+	}
+
+	_, err = tool.Execute(ctx, `{"path":"/tmp/a.txt","old_string":"a","new_string":"b","reason":"need root"}`)
+	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("expected pair-validation error for reason only, got %v", err)
+	}
+}

--- a/tools/sandbox.go
+++ b/tools/sandbox.go
@@ -32,6 +32,12 @@ type ExecSpec struct {
 	// Instead, the caller takes ownership of the process via ExecResult.Process.
 	// Currently only supported by NoneSandbox.
 	KeepAlive bool
+
+	// RunAsUser is the OS username to execute the command as.
+	// When set, the command is wrapped with: sudo -n -H -u <user> --
+	// Only effective in NoneSandbox (docker/remote ignore this field).
+	// Requires NOPASSWD sudoers entry for the target user.
+	RunAsUser string
 }
 
 // ExecResult holds the result of a sandbox command execution.

--- a/tools/shell.go
+++ b/tools/shell.go
@@ -50,6 +50,7 @@ func (t *ShellTool) Parameters() []llm.ToolParam {
 		{Name: "command", Type: "string", Description: "The command to execute", Required: true},
 		{Name: "timeout", Type: "number", Description: "Timeout in seconds (default: 120, max: 600)", Required: false},
 		{Name: "background", Type: "boolean", Description: "Run command in background (for long-running tasks like dev servers). Returns task ID immediately.", Required: false},
+		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
 	}
 }
 
@@ -58,6 +59,7 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 		Command    string  `json:"command"`
 		Timeout    float64 `json:"timeout"`
 		Background bool    `json:"background"`
+		RunAs      string  `json:"run_as"`
 	}
 	if err := json.Unmarshal([]byte(input), &params); err != nil {
 		return nil, fmt.Errorf("invalid parameters: %w", err)
@@ -180,12 +182,13 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 			}
 		default:
 			return ExecSpec{
-				Command: shell,
-				Args:    []string{shell, "-l", "-c", shellCmd},
-				Shell:   false,
-				Dir:     execDir,
-				Timeout: timeout,
-				UserID:  userID,
+				Command:   shell,
+				Args:      []string{shell, "-l", "-c", shellCmd},
+				Shell:     false,
+				Dir:       execDir,
+				Timeout:   timeout,
+				UserID:    userID,
+				RunAsUser: params.RunAs,
 			}
 		}
 	}

--- a/tools/shell.go
+++ b/tools/shell.go
@@ -51,6 +51,7 @@ func (t *ShellTool) Parameters() []llm.ToolParam {
 		{Name: "timeout", Type: "number", Description: "Timeout in seconds (default: 120, max: 600)", Required: false},
 		{Name: "background", Type: "boolean", Description: "Run command in background (for long-running tasks like dev servers). Returns task ID immediately.", Required: false},
 		{Name: "run_as", Type: "string", Description: "OS username to execute as. Requires permission control to be enabled. Only effective in none sandbox mode.", Required: false},
+		{Name: "reason", Type: "string", Description: "Optional human-readable reason shown in approval requests when approval is required.", Required: false},
 	}
 }
 
@@ -60,6 +61,7 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 		Timeout    float64 `json:"timeout"`
 		Background bool    `json:"background"`
 		RunAs      string  `json:"run_as"`
+		Reason     string  `json:"reason"`
 	}
 	if err := json.Unmarshal([]byte(input), &params); err != nil {
 		return nil, fmt.Errorf("invalid parameters: %w", err)
@@ -68,6 +70,9 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	if params.Command == "" {
 		return nil, fmt.Errorf("command is required")
 	}
+	if (strings.TrimSpace(params.RunAs) == "") != (strings.TrimSpace(params.Reason) == "") {
+		return nil, fmt.Errorf("run_as and reason must be provided together")
+	}
 
 	// 检测命令中的控制字符和 null bytes
 	if strings.ContainsAny(params.Command, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f") {
@@ -75,7 +80,9 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	}
 
 	// 安全预检：拦截危险命令
-	if blocked, reason := checkDangerousCommand(params.Command); blocked {
+	// - run_as 模式下禁止任何形式的 sudo（用户切换由框架通过 cmdbuilder 处理）
+	// - permission control 启用时，即使未设置 run_as，也禁止 LLM 直接使用 sudo
+	if blocked, reason := checkDangerousCommand(toolCtx.Ctx, params.Command, params.RunAs != ""); blocked {
 		return nil, fmt.Errorf("command blocked by safety check: %s", reason)
 	}
 
@@ -602,7 +609,8 @@ var warningPatterns = []*regexp.Regexp{
 
 // checkDangerousCommand 检查命令是否包含危险模式
 // 返回 (blocked, reason)，如果 blocked=true 则应拒绝执行
-func checkDangerousCommand(cmd string) (bool, string) {
+// disallowSudo: 当为 true 时（run_as 模式），任何形式的 sudo 都被禁止
+func checkDangerousCommand(ctx context.Context, cmd string, disallowSudo bool) (bool, string) {
 	// 检查绝对禁止模式
 	for _, dp := range dangerPatterns {
 		if dp.pattern.MatchString(cmd) {
@@ -610,11 +618,21 @@ func checkDangerousCommand(cmd string) (bool, string) {
 		}
 	}
 
-	// 检查裸 sudo（无 -S / -n / NOPASSWD）：在 none sandbox 下会打开 /dev/tty 导致终端卡死
-	// 允许的写法: echo pass | sudo -S ..., sudo -n ..., sudo --non-interactive, NOPASSWD 配置
-	// NOTE: Go regexp (RE2) 不支持 lookbehind/lookahead，用单词边界 + 代码逻辑代替
+	// sudo 检查
 	sudoRe := regexp.MustCompile(`\bsudo\b`)
 	if sudoRe.MatchString(cmd) {
+		if disallowSudo {
+			// run_as 模式：用户切换由框架控制，禁止 LLM 使用任何形式的 sudo
+			return true, "sudo is not allowed when run_as is set (user switching is handled by the framework)"
+		}
+		defaultUser, privilegedUser := PermUsersFromContext(ctx)
+		if defaultUser != "" || privilegedUser != "" {
+			// Permission control enabled: all LLM-authored sudo is forbidden.
+			// User switching must go through run_as so approval/default-user policy can be enforced.
+			return true, "sudo is not allowed when permission control is enabled (use run_as instead so the framework can enforce approval policy)"
+		}
+		// 非 run_as / 非 permission-control 模式：拦截裸 sudo（无 -S / -n / NOPASSWD），防止终端卡死
+		// 允许的写法: echo pass | sudo -S ..., sudo -n ..., sudo --non-interactive, NOPASSWD 配置
 		hasSafeFlag := regexp.MustCompile(`\bsudo\s+(-[Sn]\b|--non-interactive\b)`).MatchString(cmd)
 		hasPipeOrNopasswd := strings.Contains(cmd, "|") || strings.Contains(cmd, "NOPASSWD")
 		if !hasSafeFlag && !hasPipeOrNopasswd {

--- a/tools/shell_strict_perm_test.go
+++ b/tools/shell_strict_perm_test.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCheckDangerousCommand_StrictPermControlBlocksAllSudo(t *testing.T) {
+	ctx := WithPermUsers(context.Background(), "user", "root")
+	blocked, reason := checkDangerousCommand(ctx, "sudo -n whoami", false)
+	if !blocked {
+		t.Fatal("expected sudo to be blocked when permission control is enabled")
+	}
+	if !strings.Contains(reason, "permission control is enabled") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}
+
+func TestCheckDangerousCommand_RunAsStillBlocksSudo(t *testing.T) {
+	ctx := WithPermUsers(context.Background(), "user", "root")
+	blocked, reason := checkDangerousCommand(ctx, "sudo -n whoami", true)
+	if !blocked {
+		t.Fatal("expected sudo to be blocked when run_as is set")
+	}
+	if !strings.Contains(reason, "run_as is set") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}
+
+func TestCheckDangerousCommand_NoPermControl_AllowsNonBareSudo(t *testing.T) {
+	blocked, reason := checkDangerousCommand(context.Background(), "sudo -n whoami", false)
+	if blocked {
+		t.Fatalf("expected sudo -n to remain allowed when permission control is disabled, got: %q", reason)
+	}
+}
+
+func TestCheckDangerousCommand_NoPermControl_BlocksBareSudo(t *testing.T) {
+	blocked, reason := checkDangerousCommand(context.Background(), "sudo whoami", false)
+	if !blocked {
+		t.Fatal("expected bare sudo to be blocked")
+	}
+	if !strings.Contains(reason, "bare sudo") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}


### PR DESCRIPTION
## Summary

Add opt-in permission control that leverages Linux OS user identity as the permission boundary for agent tools.

### Core Design
- Tools (Shell, FileCreate, FileReplace) gain optional `run_as` parameter
- Two configurable user profiles: `default_user` (no approval) and `privileged_user` (requires approval)
- Uses `sudo -n -H -u <user>` for user switching — kernel-enforced isolation
- Disabled by default, zero behavioral change when not configured

### Key Changes
- **`internal/cmdbuilder/`** — shared command builder with sudo wrapping (used by both server and runner)
- **`tools/approval.go`** — `ApprovalHook` (ToolHook) + channel-agnostic `ApprovalHandler` interface
- **`tools/sandbox.go`** — `ExecSpec.RunAsUser` field
- **`tools/none_sandbox.go`** — refactored to delegate to `cmdbuilder.Build()`
- **`tools/shell.go`, `tools/edit.go`** — `run_as` parameter in schema + params
- **`agent/middleware_builtin.go`** — `PermissionControlMiddleware` (conditional system prompt)
- **`agent/settings.go`** — `GetPermUsers()` method
- **`internal/runnerclient/`** — ExecSpec, NativeExecutor, handler, protocol extensions
- **`channel/i18n.go`** — settings panel entries in 3 locales (ZH/EN/JA)
- **`channel/cli_approval.go`** — CLI approval handler skeleton

### Design Doc
`docs/design/runner-permission-control.md`

### Test plan
- [x] All existing tests pass (zero regression)
- [x] `internal/cmdbuilder/cmdbuilder_test.go` — shell escape, Build with/without RunAs, file ops
- [x] `tools/approval_test.go` — 12 tests covering all ApprovalHook paths (disabled/default/privileged/denied/unknown/extract/populate)
- [x] Pre-push CI: go fmt, go vet, golangci-lint, go build, go test — all pass