### PR TITLE
fix(cli): use correct send path for queued messages

### DIFF
--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -37,6 +37,7 @@ func (m *cliModel) toggleToolSummary() {
 // startAgentTurn transitions the model into the "agent processing" state:
 // sets typing=true, updates placeholder, disables input, and resets progress.
 func (m *cliModel) startAgentTurn() {
+	m.agentTurnID++
 	m.typing = true
 	m.updatePlaceholder()
 	m.inputReady = false
@@ -44,9 +45,14 @@ func (m *cliModel) startAgentTurn() {
 }
 
 // endAgentTurn resets all agent-turn tracking state and returns to idle.
-// This is the unified cleanup for both normal completion (handleAgentMessage)
-// and error/cancel paths (cliProgressMsg PhaseDone).
-func (m *cliModel) endAgentTurn() {
+// Takes the turnID that triggered this end. If a new turn has already
+// started (turnID != m.agentTurnID), the call is a no-op — this prevents
+// stale completion signals (cliOutboundMsg / PhaseDone) from killing a
+// new turn's animation.
+func (m *cliModel) endAgentTurn(turnID uint64) {
+	if turnID != m.agentTurnID {
+		return // new turn already started — stale signal, ignore
+	}
 	m.lastCompletedTools = nil
 	m.iterationHistory = nil
 	m.lastSeenIteration = 0

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -72,6 +72,9 @@ func (m *cliModel) flushMessageQueue() tea.Cmd {
 }
 
 // sendMessageFromQueue sends the current textarea content as a queued message.
+// Uses the same send path as sendMessage() — includes @ file parsing,
+// viewport scroll, and correct ReplyPolicyAuto — so queued messages behave
+// identically to directly-sent ones.
 func (m *cliModel) sendMessageFromQueue() tea.Cmd {
 	content := strings.TrimSpace(m.textarea.Value())
 	if content == "" {
@@ -79,9 +82,15 @@ func (m *cliModel) sendMessageFromQueue() tea.Cmd {
 	}
 	m.textarea.Reset()
 	m.autoExpandInput()
-	m.sendToAgent(content)
-	// Start tick chain for the new agent turn — the previous chain may have
-	// already transitioned to idleTickCmd (3s) after endAgentTurn set typing=false.
+
+	// Reuse sendMessage()'s logic (file refs, viewport scroll, reply policy).
+	// sendMessage() calls startAgentTurn() internally.
+	m.sendMessage(content)
+
+	// Must explicitly return tickCmd() because the wasTyping guard at the
+	// bottom of Update() won't detect the typing transition: in the flush
+	// scenario, the same Update call first sets typing=false (endAgentTurn)
+	// then typing=true (startAgentTurn), so wasTyping==m.typing==true.
 	return tickCmd()
 }
 

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -223,6 +223,7 @@ func (m *cliModel) sendMessage(content string) tea.Cmd {
 		timestamp: time.Now(),
 		dirty:     true,
 	})
+	m.renderCacheValid = false // ensure viewport rebuilds with new message
 
 	// 更新显示并强制滚动到底部（用户发送新消息时始终可见）
 	m.updateViewportContent()
@@ -485,6 +486,7 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 
 // handleAgentMessage 处理 agent 回复
 func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
+	turnID := m.agentTurnID // capture at entry for stale-signal guard
 	content := msg.Content
 
 	// 处理 __FEISHU_CARD__ 协议（简化显示）
@@ -492,14 +494,19 @@ func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
 		content = ConvertFeishuCard(content)
 	}
 
-	// Empty content with no waiting user: clear progress/typing state without
-	// appending a blank message. This happens when Optional reply policy produces
-	// no response (e.g. LLM returned empty).
+	// Empty content with no waiting user: end turn and flush queue,
+	// but don't append a blank message. This happens when Optional reply
+	// policy produces no response (e.g. LLM returned empty).
 	if content == "" && !msg.WaitingUser && len(msg.ToolsUsed) == 0 {
 		m.streamingMsgIdx = -1
 		m.progress = nil
-		m.typing = false
-		m.updatePlaceholder()
+		m.endAgentTurn(turnID)
+		if turnID == m.agentTurnID {
+			m.inputReady = true
+			if len(m.messageQueue) > 0 {
+				m.needFlushQueue = true
+			}
+		}
 		return
 	}
 
@@ -540,7 +547,12 @@ func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
 		// 重置流式状态
 		m.streamingMsgIdx = -1
 		// 清除进度信息（保留 TODO，可跨 turn 存活）
-		m.progress = nil
+		// Only clear progress if this is the current turn — a stale
+		// handleAgentMessage from the previous turn must not wipe the
+		// new turn's progress state.
+		if turnID == m.agentTurnID {
+			m.progress = nil
+		}
 		m.renderCacheValid = false
 		m.updateViewportContent()
 
@@ -690,11 +702,13 @@ func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
 		}
 
 		// 重置迭代追踪状态
-		m.endAgentTurn()
-		m.inputReady = true
-		// §Q 标记需要刷新消息队列（由 Update 循环检查）
-		if len(m.messageQueue) > 0 {
-			m.needFlushQueue = true
+		m.endAgentTurn(turnID)
+		if turnID == m.agentTurnID {
+			m.inputReady = true
+			// §Q 标记需要刷新消息队列（由 Update 循环检查）
+			if len(m.messageQueue) > 0 {
+				m.needFlushQueue = true
+			}
 		}
 
 	}

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -195,6 +195,7 @@ type cliModel struct {
 	ready           bool                  // 是否已初始化
 
 	// --- Agent state ---
+	agentTurnID     uint64                    // monotonically increasing turn counter
 	typing          bool                      // agent 是否正在回复
 	typingStartTime time.Time                 // 本次处理开始时间
 	inputReady      bool                      // 输入就绪状态（agent 回复期间禁止发送）

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -57,12 +57,14 @@ func (m *cliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	default:
 	}
 
-	// Drain pending cmds queued by helpers (e.g. showTempStatus)
+	// Drain pending cmds queued by helpers (e.g. showTempStatus).
+	// Prepend to cmds so they get batched with any cmds produced by the
+	// switch cases below — do NOT return early here, or the tick chain
+	// breaks (e.g. a pending tempStatus clear would prevent cliTickMsg
+	// from emitting the next tickCmd).
 	if len(m.pendingCmds) > 0 {
-		cmds := m.pendingCmds
+		cmds = append(cmds, m.pendingCmds...)
 		m.pendingCmds = nil
-		// Return batched cmd via tea.Batch
-		return m, tea.Batch(cmds...)
 	}
 
 	// i18n: locale 变更通知

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -116,7 +116,10 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				return m, nil, true
 			}
 			m.sendCancel()
-			return m, cmds, true
+			// Ensure tick chain stays alive after cancel — typing is still
+			// true until PhaseDone arrives, but the early return skips the
+			// normal tickCmd emission at the bottom of Update().
+			return m, []tea.Cmd{tickCmd()}, true
 		}
 		// 非处理状态：清空输入
 		if m.textarea.Value() != "" {
@@ -338,6 +341,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 
 // handleProgressMsg processes progress update events from the agent.
 func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
+	turnID := m.agentTurnID // capture before any mutation
 	prev := m.progress
 	m.progress = msg.payload
 	// Update bg task count from callback
@@ -466,11 +470,13 @@ func (m *cliModel) handleProgressMsg(msg cliProgressMsg) {
 			// Reset all iteration tracking state (always, even if handleAgentMessage ran first)
 			m.todos = nil
 			m.todosDoneCleared = false
-			m.endAgentTurn()
-			m.inputReady = true
-			// §Q 刷新消息队列（PhaseDone 可能先于 cliOutboundMsg 到达）
-			if len(m.messageQueue) > 0 {
-				m.needFlushQueue = true
+			m.endAgentTurn(turnID)
+			if turnID == m.agentTurnID {
+				m.inputReady = true
+				// §Q 刷新消息队列（PhaseDone 可能先于 cliOutboundMsg 到达）
+				if len(m.messageQueue) > 0 {
+					m.needFlushQueue = true
+				}
 			}
 			m.relayoutViewport()
 		}


### PR DESCRIPTION
## Problem

Queued messages (sent while agent is processing) used `sendToAgent()` instead of `sendMessage()`, which meant:

1. **ReplyPolicyOptional** instead of **ReplyPolicyAuto** — agent might not reply to queued messages
2. **No @ file reference parsing** — `@path` in queued messages sent as plain text
3. **No viewport scroll** — user message not scrolled into view when dequeued
4. **No slash command handling** — queued `/help` etc sent as plain text

## Fix

`sendMessageFromQueue()` now calls `sendMessage()` internally, reusing the full send pipeline (file refs, viewport scroll, reply policy, slash commands). Explicitly returns `tickCmd()` because the `wasTyping` guard at the bottom of `Update()` cannot detect the typing transition within the same flush cycle (endAgentTurn→startAgentTurn within one Update call).