### PR TITLE
fix: ActiveTools not showing in CLI progress

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2159,8 +2159,8 @@ func (a *Agent) processSubAgentBgNotification(n *tools.SubAgentBgNotify) {
 // RunSubAgent 实现 tools.SubAgentManager 接口
 // 创建一个独立的子 Agent 循环来执行任务，子 Agent 拥有自己的工具集但不能再创建子 Agent
 // allowedTools 为工具白名单，为空时使用所有工具（除 SubAgent）
-func (a *Agent) RunSubAgent(parentCtx *tools.ToolContext, task string, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, roleName string) (string, error) {
-	cfg := a.buildSubAgentRunConfig(parentCtx.Ctx, parentCtx, task, systemPrompt, allowedTools, caps, roleName, false)
+func (a *Agent) RunSubAgent(parentCtx *tools.ToolContext, task string, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, roleName, model string) (string, error) {
+	cfg := a.buildSubAgentRunConfig(parentCtx.Ctx, parentCtx, task, systemPrompt, allowedTools, caps, roleName, false, model)
 	out := Run(parentCtx.Ctx, cfg)
 	if out.Error != nil {
 		return out.Content, out.Error

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -452,8 +452,8 @@ type spawnAgentAdapter struct {
 }
 
 // RunSubAgent 实现 tools.SubAgentManager 接口。
-func (a *spawnAgentAdapter) RunSubAgent(parentCtx *tools.ToolContext, task string, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, roleName string) (string, error) {
-	msg := a.buildMsg(parentCtx, task, roleName, systemPrompt, allowedTools, caps, false, "")
+func (a *spawnAgentAdapter) RunSubAgent(parentCtx *tools.ToolContext, task string, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, roleName, model string) (string, error) {
+	msg := a.buildMsg(parentCtx, task, roleName, systemPrompt, allowedTools, caps, false, "", model)
 	out, err := a.spawnFn(parentCtx.Ctx, msg)
 	if err != nil {
 		return "", err
@@ -465,11 +465,11 @@ func (a *spawnAgentAdapter) RunSubAgent(parentCtx *tools.ToolContext, task strin
 }
 
 // SpawnInteractive 实现 InteractiveSubAgentManager.SpawnInteractive。
-func (a *spawnAgentAdapter) SpawnInteractive(parentCtx *tools.ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, instance string) (string, error) {
+func (a *spawnAgentAdapter) SpawnInteractive(parentCtx *tools.ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, instance, model string) (string, error) {
 	if a.interactiveSpawnFn == nil {
 		return "", fmt.Errorf("interactive mode not supported")
 	}
-	msg := a.buildMsg(parentCtx, task, roleName, systemPrompt, allowedTools, caps, true, instance)
+	msg := a.buildMsg(parentCtx, task, roleName, systemPrompt, allowedTools, caps, true, instance, model)
 	out, err := a.interactiveSpawnFn(parentCtx.Ctx, roleName, msg)
 	if err != nil {
 		return "", err
@@ -481,11 +481,11 @@ func (a *spawnAgentAdapter) SpawnInteractive(parentCtx *tools.ToolContext, task,
 }
 
 // SendInteractive 实现 InteractiveSubAgentManager.SendInteractive。
-func (a *spawnAgentAdapter) SendInteractive(parentCtx *tools.ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, instance string) (string, error) {
+func (a *spawnAgentAdapter) SendInteractive(parentCtx *tools.ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, instance, model string) (string, error) {
 	if a.interactiveSendFn == nil {
 		return "", fmt.Errorf("interactive mode not supported")
 	}
-	msg := a.buildMsg(parentCtx, task, roleName, systemPrompt, allowedTools, caps, true, instance)
+	msg := a.buildMsg(parentCtx, task, roleName, systemPrompt, allowedTools, caps, true, instance, model)
 	out, err := a.interactiveSendFn(parentCtx.Ctx, roleName, msg)
 	if err != nil {
 		return "", err
@@ -521,7 +521,7 @@ func (a *spawnAgentAdapter) InterruptInteractive(parentCtx *tools.ToolContext, r
 }
 
 // buildMsg 构造 SubAgent InboundMessage。
-func (a *spawnAgentAdapter) buildMsg(parentCtx *tools.ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, interactive bool, instance string) bus.InboundMessage {
+func (a *spawnAgentAdapter) buildMsg(parentCtx *tools.ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps tools.SubAgentCapabilities, interactive bool, instance, model string) bus.InboundMessage {
 	metadata := map[string]string{
 		"origin_channel": a.channel,
 		"origin_chat_id": a.chatID,
@@ -538,6 +538,10 @@ func (a *spawnAgentAdapter) buildMsg(parentCtx *tools.ToolContext, task, roleNam
 		if bg, ok := parentCtx.Metadata["background"]; ok {
 			metadata["background"] = bg
 		}
+	}
+	// Propagate model override from SubAgent role definition
+	if model != "" {
+		metadata["model"] = model
 	}
 
 	return bus.InboundMessage{

--- a/agent/engine_interactive_test.go
+++ b/agent/engine_interactive_test.go
@@ -26,7 +26,7 @@ func TestSpawnAgentAdapter_InteractiveSpawn_NilCallback(t *testing.T) {
 		SenderID: "ou_456",
 		ChatID:   "oc_123",
 		Channel:  "feishu",
-	}, "task", "reviewer", "You are a reviewer", nil, tools.SubAgentCapabilities{}, "")
+	}, "task", "reviewer", "You are a reviewer", nil, tools.SubAgentCapabilities{}, "", "")
 	if err == nil {
 		t.Fatal("expected error when interactive callbacks are nil")
 	}
@@ -41,7 +41,7 @@ func TestSpawnAgentAdapter_InteractiveSend_NilCallback(t *testing.T) {
 	}
 	_, err := adapter.SendInteractive(&tools.ToolContext{
 		Ctx: context.Background(),
-	}, "task", "reviewer", "", nil, tools.SubAgentCapabilities{}, "")
+	}, "task", "reviewer", "", nil, tools.SubAgentCapabilities{}, "", "")
 	if err == nil {
 		t.Fatal("expected error when interactive callbacks are nil")
 	}
@@ -80,7 +80,7 @@ func TestSpawnAgentAdapter_InteractiveSpawn_Success(t *testing.T) {
 		SenderID: "ou_456",
 		Channel:  "feishu",
 		ChatID:   "oc_123",
-	}, "review my code", "reviewer", "You are a code reviewer", nil, tools.SubAgentCapabilities{}, "")
+	}, "review my code", "reviewer", "You are a code reviewer", nil, tools.SubAgentCapabilities{}, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestSpawnAgentAdapter_InteractiveSend_Success(t *testing.T) {
 		SenderID: "ou_456",
 		Channel:  "feishu",
 		ChatID:   "oc_123",
-	}, "fix this bug", "writer", "", nil, tools.SubAgentCapabilities{}, "")
+	}, "fix this bug", "writer", "", nil, tools.SubAgentCapabilities{}, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestSpawnAgentAdapter_BuildMsg_Interactive(t *testing.T) {
 		SenderName: "Test User",
 		Channel:    "feishu",
 		ChatID:     "oc_abc",
-	}, "do something", "reviewer", "You are reviewer", []string{"Read", "Grep"}, tools.SubAgentCapabilities{Memory: true}, true, "")
+	}, "do something", "reviewer", "You are reviewer", []string{"Read", "Grep"}, tools.SubAgentCapabilities{Memory: true}, true, "", "")
 
 	// Check interactive flag in metadata
 	if msg.Metadata["interactive"] != "true" {
@@ -212,7 +212,7 @@ func TestSpawnAgentAdapter_BuildMsg_WithInstance(t *testing.T) {
 		SenderName: "Test User",
 		Channel:    "feishu",
 		ChatID:     "oc_abc",
-	}, "do something", "brainstorm", "You are brainstorm agent", nil, tools.SubAgentCapabilities{}, true, "architect")
+	}, "do something", "brainstorm", "You are brainstorm agent", nil, tools.SubAgentCapabilities{}, true, "architect", "")
 
 	// Check interactive flag in metadata
 	if msg.Metadata["interactive"] != "true" {
@@ -235,7 +235,7 @@ func TestSpawnAgentAdapter_BuildMsg_NonInteractive(t *testing.T) {
 	msg := adapter.buildMsg(&tools.ToolContext{
 		Ctx:      context.Background(),
 		SenderID: "ou_xyz",
-	}, "do something", "reviewer", "", nil, tools.SubAgentCapabilities{}, false, "")
+	}, "do something", "reviewer", "", nil, tools.SubAgentCapabilities{}, false, "", "")
 
 	if msg.Metadata["interactive"] == "true" {
 		t.Error("interactive flag should not be set for non-interactive mode")

--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -865,10 +865,6 @@ func (s *runState) executeToolCalls(ctx context.Context, response *llm.LLMRespon
 			s.progressLines = append(s.progressLines, fmt.Sprintf("> ⏳ %s ...", toolLabel))
 		}
 	}
-	if s.autoNotify && !s.batchProgressByIteration {
-		s.notifyProgress("")
-	}
-
 	execResults := make([]toolExecResult, len(response.ToolCalls))
 	if s.structuredProgress != nil {
 		s.structuredProgress.Phase = PhaseToolExec
@@ -883,7 +879,7 @@ func (s *runState) executeToolCalls(ctx context.Context, response *llm.LLMRespon
 			}
 		}
 	}
-	if s.autoNotify && s.batchProgressByIteration {
+	if s.autoNotify {
 		s.notifyProgress("")
 	}
 

--- a/agent/engine_test.go
+++ b/agent/engine_test.go
@@ -1002,7 +1002,7 @@ func TestSpawnAgentAdapter(t *testing.T) {
 	result, err := adapter.RunSubAgent(parentCtx, "review this code", "You are a code reviewer.", []string{"Shell", "Read"}, tools.SubAgentCapabilities{
 		Memory:      true,
 		SendMessage: true,
-	}, "code-reviewer")
+	}, "code-reviewer", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1078,7 +1078,7 @@ func TestSpawnAgentAdapter_ErrorPropagation(t *testing.T) {
 		Ctx: context.Background(),
 	}
 
-	result, err := adapter.RunSubAgent(parentCtx, "task", "", nil, tools.SubAgentCapabilities{}, "test-role")
+	result, err := adapter.RunSubAgent(parentCtx, "task", "", nil, tools.SubAgentCapabilities{}, "test-role", "")
 	if err != context.Canceled {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
@@ -1192,7 +1192,7 @@ func TestBuildToolContext(t *testing.T) {
 	}
 
 	// Verify Manager works
-	_, _ = tc.Manager.RunSubAgent(tc, "test", "prompt", nil, tools.SubAgentCapabilities{}, "test")
+	_, _ = tc.Manager.RunSubAgent(tc, "test", "prompt", nil, tools.SubAgentCapabilities{}, "test", "")
 	if !called {
 		t.Error("SpawnAgent was not called through Manager")
 	}

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -449,6 +449,7 @@ func (a *Agent) buildSubAgentRunConfig(
 	caps tools.SubAgentCapabilities,
 	roleName string,
 	interactive bool,
+	model string, // 可选：角色指定的模型，为空时继承主 Agent
 ) RunConfig {
 	parentAgentID := parentCtx.AgentID
 
@@ -567,7 +568,16 @@ func (a *Agent) buildSubAgentRunConfig(
 	subAgentID := parentAgentID + "/" + roleName
 
 	// SubAgent 继承父 Agent 的 LLM 配置（使用 OriginUserID 获取原始用户的配置）
-	llmClient, model, userMaxCtx, thinkingMode := a.llmFactory.GetLLM(originUserID)
+	// 如果角色指定了模型，则通过 GetLLMForModel 智能查找对应的订阅
+	var llmClient llm.LLM
+	var subModel string
+	var userMaxCtx int
+	var thinkingMode string
+	if model != "" {
+		llmClient, subModel, userMaxCtx, thinkingMode, _ = a.llmFactory.GetLLMForModel(originUserID, model)
+	} else {
+		llmClient, subModel, userMaxCtx, thinkingMode = a.llmFactory.GetLLM(originUserID)
+	}
 
 	// Stream — 从用户设置继承（与 buildMainRunConfig 一致）
 	stream := false
@@ -581,7 +591,7 @@ func (a *Agent) buildSubAgentRunConfig(
 
 	cfg := RunConfig{
 		LLMClient:       llmClient,
-		Model:           model,
+		Model:           subModel,
 		ThinkingMode:    thinkingMode,
 		Stream:          stream,
 		MaxOutputTokens: a.llmFactory.GetMaxOutputTokens(originUserID),
@@ -1150,7 +1160,13 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 	// 从 InboundMessage 恢复 capabilities
 	caps := tools.CapabilitiesFromMap(msg.Capabilities)
 
-	cfg := a.buildSubAgentRunConfig(ctx, parentCtx, task, systemPrompt, allowedTools, caps, roleName, false)
+	// 从 InboundMessage 元数据中获取角色指定的模型
+	subModel := ""
+	if msg.Metadata != nil {
+		subModel = msg.Metadata["model"]
+	}
+
+	cfg := a.buildSubAgentRunConfig(ctx, parentCtx, task, systemPrompt, allowedTools, caps, roleName, false, subModel)
 
 	// SubAgent 进度上报：优先使用父 Agent 注入的回调（避免并发 SubAgent 互相覆盖 patch），
 	// 否则 fallback 到直接发送消息（非并行场景）。

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -124,7 +124,11 @@ func (a *Agent) SpawnInteractiveSession(
 	subCtx := WithCallChain(ctx, cc.Spawn(roleName))
 
 	caps := tools.CapabilitiesFromMap(msg.Capabilities)
-	cfg := a.buildSubAgentRunConfig(subCtx, parentCtx, msg.Content, msg.SystemPrompt, msg.AllowedTools, caps, roleName, true)
+	subModel := ""
+	if msg.Metadata != nil {
+		subModel = msg.Metadata["model"]
+	}
+	cfg := a.buildSubAgentRunConfig(subCtx, parentCtx, msg.Content, msg.SystemPrompt, msg.AllowedTools, caps, roleName, true, subModel)
 
 	// SubAgent 进度上报：优先使用父 Agent 注入的回调（避免并发 SubAgent 互相覆盖 patch），
 	// 否则 fallback 到直接发送消息（非并行场景）。

--- a/agent/llm_factory.go
+++ b/agent/llm_factory.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"xbot/llm"
@@ -64,6 +65,9 @@ func (f *LLMFactory) GetLLM(senderID string) (llm.LLM, string, int, string) {
 	f.mu.RUnlock()
 
 	// 从数据库加载配置
+	if f.configSvc == nil {
+		return f.defaultLLM, f.defaultModel, 0, f.defaultThinkingMode
+	}
 	cfg, err := f.configSvc.GetConfig(senderID)
 	if err != nil || cfg == nil {
 		// 无配置或出错，使用默认客户端
@@ -396,4 +400,105 @@ func (f *LLMFactory) GetMaxOutputTokens(senderID string) int {
 	f.mu.RUnlock()
 	// User has no cached config (using default client) — return 0 (use default)
 	return 0
+}
+
+// GetLLMForModel 获取指定模型的 LLM 客户端，用于 SubAgent 使用不同于主 Agent 的模型。
+//
+// 查找优先级：
+//  1. 在用户所有订阅中查找 Model 字段精确匹配 targetModel 的订阅
+//  2. 使用当前活跃订阅的凭证 + targetModel
+//  3. 使用任意订阅的凭证 + targetModel（优先 Provider 匹配）
+//  4. Fallback 到主 Agent 的当前 LLM（忽略 targetModel）
+//
+// 返回: (LLM客户端, 实际模型名, maxContext, thinkingMode, 是否使用了非默认模型)
+func (f *LLMFactory) GetLLMForModel(senderID, targetModel string) (llm.LLM, string, int, string, bool) {
+	if targetModel == "" || f.subscriptionSvc == nil {
+		// 无指定模型或无订阅服务 → 使用默认
+		client, model, maxCtx, tm := f.GetLLM(senderID)
+		return client, model, maxCtx, tm, false
+	}
+
+	subs, err := f.subscriptionSvc.List(senderID)
+	if err != nil || len(subs) == 0 {
+		// 无订阅 → fallback 到默认
+		client, model, maxCtx, tm := f.GetLLM(senderID)
+		return client, model, maxCtx, tm, false
+	}
+
+	// 1. 精确匹配：订阅的 Model 字段 == targetModel
+	for _, sub := range subs {
+		if sub.Model == targetModel {
+			client := f.createClientFromSub(sub, targetModel)
+			if client != nil {
+				return client, targetModel, sub.MaxContext, sub.ThinkingMode, true
+			}
+		}
+	}
+
+	// 2. 使用活跃订阅的凭证 + targetModel
+	activeSub, err := f.subscriptionSvc.GetDefault(senderID)
+	if err == nil && activeSub != nil {
+		client := f.createClientFromSub(activeSub, targetModel)
+		if client != nil {
+			return client, targetModel, activeSub.MaxContext, activeSub.ThinkingMode, true
+		}
+	}
+
+	// 3. Provider 匹配：找 provider 能服务该模型的订阅
+	provider := guessProvider(targetModel)
+	for _, sub := range subs {
+		if provider != "" && sub.Provider == provider {
+			client := f.createClientFromSub(sub, targetModel)
+			if client != nil {
+				return client, targetModel, sub.MaxContext, sub.ThinkingMode, true
+			}
+		}
+	}
+
+	// 4. 任意可用订阅
+	for _, sub := range subs {
+		client := f.createClientFromSub(sub, targetModel)
+		if client != nil {
+			return client, targetModel, sub.MaxContext, sub.ThinkingMode, true
+		}
+	}
+
+	// 5. Fallback 到默认
+	client, model, maxCtx, tm := f.GetLLM(senderID)
+	return client, model, maxCtx, tm, false
+}
+
+// createClientFromSub 从订阅创建 LLM 客户端，使用指定的模型名（而非订阅的默认模型）
+func (f *LLMFactory) createClientFromSub(sub *sqlite.LLMSubscription, model string) llm.LLM {
+	if sub.BaseURL == "" || sub.APIKey == "" {
+		return nil
+	}
+	cfg := &sqlite.UserLLMConfig{
+		Provider:        sub.Provider,
+		BaseURL:         sub.BaseURL,
+		APIKey:          sub.APIKey,
+		Model:           model,
+		MaxOutputTokens: sub.MaxOutputTokens,
+	}
+	client, _ := f.createClient(cfg)
+	return client
+}
+
+// guessProvider 根据模型名猜测 provider。
+// 返回空字符串表示无法猜测。
+func guessProvider(model string) string {
+	switch {
+	case strings.Contains(model, "claude"):
+		return "anthropic"
+	case strings.Contains(model, "gpt") || strings.Contains(model, "o1") || strings.Contains(model, "o3") || strings.Contains(model, "chatgpt"):
+		return "openai"
+	case strings.Contains(model, "deepseek"):
+		return "deepseek"
+	case strings.Contains(model, "gemini"):
+		return "google"
+	case strings.Contains(model, "qwen"):
+		return "qwen"
+	default:
+		return ""
+	}
 }

--- a/agent/llm_factory_test.go
+++ b/agent/llm_factory_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import "testing"
+
+func TestGuessProvider(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"claude-sonnet-4-20250514", "anthropic"},
+		{"claude-opus-4-20250115", "anthropic"},
+		{"gpt-4o", "openai"},
+		{"gpt-4.1", "openai"},
+		{"o1-preview", "openai"},
+		{"o3-mini", "openai"},
+		{"deepseek-chat", "deepseek"},
+		{"deepseek-reasoner", "deepseek"},
+		{"gemini-2.0-flash", "google"},
+		{"qwen-max", "qwen"},
+		{"unknown-model", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := guessProvider(tt.model)
+			if got != tt.want {
+				t.Errorf("guessProvider(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLLMForModel_EmptyTarget(t *testing.T) {
+	// Empty target model → should return default model name without hitting subscription logic
+	f := NewLLMFactory(nil, nil, "default-model")
+	f.defaultThinkingMode = "auto"
+
+	// Verify the early return path: targetModel="" should not try to list subscriptions
+	// (subscriptionSvc is nil, so if it tried, we'd get a different error)
+	_, model, _, tm, usedCustom := f.GetLLMForModel("user1", "")
+	if model != "default-model" {
+		t.Errorf("model = %q, want %q", model, "default-model")
+	}
+	if usedCustom {
+		t.Error("usedCustom should be false for empty target model")
+	}
+	if tm != "auto" {
+		t.Errorf("thinkingMode = %q, want %q", tm, "auto")
+	}
+}
+
+func TestGetLLMForModel_NilSubscriptionSvc(t *testing.T) {
+	f := NewLLMFactory(nil, nil, "default-model")
+	f.defaultThinkingMode = "auto"
+
+	// No subscriptionSvc → should fallback to default (not panic)
+	_, model, _, _, usedCustom := f.GetLLMForModel("user1", "claude-opus-4-20250115")
+	if model != "default-model" {
+		t.Errorf("model = %q, want default-model (fallback when no subscriptionSvc)", model)
+	}
+	if usedCustom {
+		t.Error("usedCustom should be false when no subscriptionSvc")
+	}
+}

--- a/agent/progress.go
+++ b/agent/progress.go
@@ -298,15 +298,55 @@ func isSubAgentLine(line string) bool {
 // isStatusEmojiLine 检查行是否以状态 emoji 开头并包含冒号（子 Agent 格式化输出的特征）。
 // 注意：⏳ 不在此列表中 — ⏳ 仅用于工具占位行（> ⏳ ToolName: args），
 // 工具占位行由 isSubAgentLine 的其他分支处理（⏳ SubAgent [...] 专用匹配）。
+//
+// 为避免将 LLM 输出中引用的工具结果（如 "❌ Shell: cmd"）误判为子 Agent 行，
+// 冒号前的名称需通过 isPlausibleAgentRole 检查。
 func isStatusEmojiLine(line string) bool {
 	for _, prefix := range []string{"🔄 ", "✅ ", "❌ "} {
 		if strings.HasPrefix(line, prefix) {
-			if idx := strings.Index(line, ":"); idx > 0 {
-				return true
+			rest := line[len(prefix):]
+			if idx := strings.Index(rest, ":"); idx > 0 {
+				candidate := strings.TrimSpace(rest[:idx])
+				if isPlausibleAgentRole(candidate) {
+					return true
+				}
 			}
 		}
 	}
 	return false
+}
+
+// isPlausibleAgentRole 检查名称是否像 SubAgent 角色名而非工具名。
+// SubAgent 角色名特征：
+//   - 全小写英文 + 连字符/下划线，如 "crown-prince", "ministry-works", "explore"
+//   - 中文角色名，如 "刑部", "工部", "中书省"
+//
+// 工具名特征：首字母大写英文，如 "Shell", "Read", "FileCreate", "SubAgent"。
+// 也排除路径（含 /）和其他非角色名模式。
+func isPlausibleAgentRole(name string) bool {
+	if name == "" {
+		return false
+	}
+	// 含路径分隔符 → 不是角色名
+	if strings.Contains(name, "/") {
+		return false
+	}
+	runes := []rune(name)
+	firstRune := runes[0]
+	// 首字母是大写 ASCII → 工具名（Shell, Read, FileCreate, SubAgent, Grep, ...）
+	if firstRune >= 'A' && firstRune <= 'Z' {
+		return false
+	}
+	// 首字母是非 ASCII（中文等）→ 角色名
+	if firstRune > 127 {
+		return true
+	}
+	// ASCII 小写开头 → 角色名（如 "explore", "crown-prince"）
+	// 但需排除含空格的句子
+	if strings.Contains(name, " ") {
+		return false
+	}
+	return true
 }
 
 // parseSubAgentLine 解析子 Agent 进度行，提取角色名和状态。
@@ -360,6 +400,12 @@ func parseSubAgentLine(line string) (childAgentStatus, bool) {
 	// 清理角色名：如果格式为 "SubAgent [actual-role]"，提取实际角色名
 	if strings.HasPrefix(role, "SubAgent [") && strings.HasSuffix(role, "]") {
 		role = role[10 : len(role)-1]
+	}
+
+	// Defense: reject tool names (PascalCase) parsed as agent roles.
+	// This prevents LLM content like "❌ Shell: cmd" from being misidentified.
+	if !isPlausibleAgentRole(role) {
+		return childAgentStatus{}, false
 	}
 
 	return childAgentStatus{Role: role, Status: status, Desc: desc}, true

--- a/agent/progress_test.go
+++ b/agent/progress_test.go
@@ -178,12 +178,69 @@ func TestIsStatusEmojiLine(t *testing.T) {
 		{"🔄 role", false},          // 无冒号
 		{"💡 thinking", false},      // 非 status emoji
 		{"", false},
+		// Tool names rejected (PascalCase = not agent role)
+		{"❌ Shell: kubectl get pods", false},
+		{"✅ Read: /home/user/src/xbot-1/tools/shell.go", false},
+		{"🔄 FileCreate: test.go", false},
+		{"❌ SubAgent: task", false},
+		{"✅ Grep: pattern", false},
+		// Chinese role names accepted
+		{"🔄 刑部: 审查中", true},
+		{"✅ 工部:", true},
+		{"❌ 中书省: 方案有问题", true},
+		// Real agent roles accepted
+		{"🔄 crown-prince: 调度中", true},
+		{"✅ ministry-works:", true},
+		{"❌ explore: 分析失败", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.line, func(t *testing.T) {
 			got := isStatusEmojiLine(tt.line)
 			if got != tt.want {
 				t.Errorf("isStatusEmojiLine(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPlausibleAgentRole(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Agent roles → true
+		{"crown-prince", true},
+		{"ministry-works", true},
+		{"explore", true},
+		{"department-state", true},
+		{"刑部", true},
+		{"工部", true},
+		{"中书省", true},
+		{"role", true},
+		{"test-agent_v2", true},
+		// Tool names → false (PascalCase)
+		{"Shell", false},
+		{"Read", false},
+		{"FileCreate", false},
+		{"SubAgent", false},
+		{"Grep", false},
+		{"Glob", false},
+		{"Fetch", false},
+		{"AskUser", false},
+		// Paths → false
+		{"/home/user/src", false},
+		{"src/main.go", false},
+		// Sentences → false
+		{"some random text", false},
+		{"The environment changed", false},
+		// Empty → false
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPlausibleAgentRole(tt.name)
+			if got != tt.want {
+				t.Errorf("isPlausibleAgentRole(%q) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -297,12 +297,12 @@ type cliModel struct {
 	panelOnCancel        func()                          // callback on cancel
 
 	// --- Bg Tasks Panel ---
-	panelBgTasks    []*tools.BackgroundTask // cached task list
-	panelBgAgents   []panelAgentEntry       // cached agent list
-	panelBgCursor   int                     // selected item index (tasks first, then agents)
-	panelBgViewing  bool                    // true = viewing log of selected task
-	panelBgScroll   int                     // log view scroll offset
-	panelBgLogLines []string                // cached log lines for viewing
+	panelBgTasks   []*tools.BackgroundTask // cached task list
+	panelBgAgents  []panelAgentEntry       // cached agent list
+	panelBgCursor  int                     // selected item index (tasks first, then agents)
+	panelBgViewing bool                    // true = viewing log of selected task
+
+	panelBgLogLines []string // cached log lines for viewing
 
 	// --- Danger Zone Panel ---
 	panelDangerItems   []dangerItem

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -161,7 +161,7 @@ func (m *cliModel) closePanel() {
 	m.panelBgTasks = nil
 	m.panelBgAgents = nil
 	m.panelBgViewing = false
-	m.panelBgScroll = 0
+	m.panelScrollY = 0
 	m.panelBgLogLines = nil
 	// Danger zone cleanup
 	m.panelDangerItems = nil
@@ -199,7 +199,7 @@ func (m *cliModel) openBgTasksPanel() {
 
 	m.panelBgCursor = 0
 	m.panelBgViewing = false
-	m.panelBgScroll = 0
+	m.panelScrollY = 0
 	m.panelBgLogLines = nil
 	// Clamp cursor
 	totalItems := len(m.panelBgTasks) + len(m.panelBgAgents)
@@ -228,42 +228,28 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		switch {
 		case msg.Code == tea.KeyEsc || msg.String() == "ctrl+c":
 			m.panelBgViewing = false
-			m.panelBgScroll = 0
+			m.panelScrollY = 0
 			m.panelBgLogLines = nil
 			return true, m, nil
 		case msg.Code == tea.KeyUp:
-			m.panelBgScroll -= 5
-			if m.panelBgScroll < 0 {
-				m.panelBgScroll = 0
+			m.panelScrollY -= 5
+			if m.panelScrollY < 0 {
+				m.panelScrollY = 0
 			}
 			return true, m, nil
 		case msg.Code == tea.KeyDown:
-			maxScroll := len(m.panelBgLogLines) - 20
-			if maxScroll < 0 {
-				maxScroll = 0
-			}
-			m.panelBgScroll += 5
-			if m.panelBgScroll > maxScroll {
-				m.panelBgScroll = maxScroll
-			}
+			m.panelScrollY += 5
 			return true, m, nil
 		case msg.Code == tea.KeyPgUp:
-			m.panelBgScroll -= 18
-			if m.panelBgScroll < 0 {
-				m.panelBgScroll = 0
+			m.panelScrollY -= m.panelVisibleHeight()
+			if m.panelScrollY < 0 {
+				m.panelScrollY = 0
 			}
 			return true, m, nil
 		default:
 			// PgDn: bubbletea doesn't have a constant, match by string
 			if msg.String() == "pgdown" {
-				maxScroll := len(m.panelBgLogLines) - 20
-				if maxScroll < 0 {
-					maxScroll = 0
-				}
-				m.panelBgScroll += 18
-				if m.panelBgScroll > maxScroll {
-					m.panelBgScroll = maxScroll
-				}
+				m.panelScrollY += m.panelVisibleHeight()
 				return true, m, nil
 			}
 		}
@@ -296,7 +282,7 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 				m.panelBgLogLines = []string{"(no output)"}
 			}
 			m.panelBgViewing = true
-			m.panelBgScroll = 0
+			m.panelScrollY = 0
 		} else if m.panelBgCursor >= len(m.panelBgTasks) && m.panelBgAgents != nil {
 			// Agent entry: inspect recent activity
 			agentIdx := m.panelBgCursor - len(m.panelBgTasks)
@@ -312,7 +298,7 @@ func (m *cliModel) updateBgTasksPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 						m.panelBgLogLines = splitLines(result)
 					}
 					m.panelBgViewing = true
-					m.panelBgScroll = 0
+					m.panelScrollY = 0
 				}
 			}
 		}
@@ -455,6 +441,7 @@ func (m *cliModel) viewBgTaskList() string {
 }
 
 // viewBgTaskLog renders the log viewer for a selected task.
+// Returns the FULL content — scrolling is handled by the outer clampPanelScroll + cli_view.go slicing.
 func (m *cliModel) viewBgTaskLog() string {
 	// §20 使用缓存样式
 	s := &m.styles
@@ -467,18 +454,14 @@ func (m *cliModel) viewBgTaskLog() string {
 			cmd = cmd[:37] + "..."
 		}
 		title = fmt.Sprintf(m.locale.BgTaskLogTitle, task.ID, cmd)
+	} else if m.panelBgAgents != nil {
+		agentIdx := m.panelBgCursor - len(m.panelBgTasks)
+		if agentIdx >= 0 && agentIdx < len(m.panelBgAgents) {
+			ag := m.panelBgAgents[agentIdx]
+			title = fmt.Sprintf("%s/%s", ag.Role, ag.Instance)
+		}
 	}
 	help := s.PanelDesc.Render(m.locale.BgTaskLogHelp)
-
-	maxLines := 18
-	start := m.panelBgScroll
-	if start > len(m.panelBgLogLines) {
-		start = len(m.panelBgLogLines)
-	}
-	end := start + maxLines
-	if end > len(m.panelBgLogLines) {
-		end = len(m.panelBgLogLines)
-	}
 
 	var sb strings.Builder
 	sb.WriteString(s.PanelHeader.Render(title))
@@ -486,13 +469,8 @@ func (m *cliModel) viewBgTaskLog() string {
 	sb.WriteString(help)
 	sb.WriteString("\n")
 
-	for _, line := range m.panelBgLogLines[start:end] {
+	for _, line := range m.panelBgLogLines {
 		sb.WriteString(line)
-		sb.WriteString("\n")
-	}
-
-	if end < len(m.panelBgLogLines) {
-		sb.WriteString(s.PanelDesc.Render(fmt.Sprintf(m.locale.BgTaskLogMore, len(m.panelBgLogLines)-end)))
 		sb.WriteString("\n")
 	}
 

--- a/tools/approval.go
+++ b/tools/approval.go
@@ -28,6 +28,13 @@ type PermUsersPair struct {
 	PrivilegedUser string
 }
 
+// isPermControlActiveFromCtx checks if permission control is active from context.
+// Returns false when no perm users are configured (both empty).
+func isPermControlActiveFromCtx(ctx context.Context) bool {
+	defaultUser, privilegedUser := PermUsersFromContext(ctx)
+	return defaultUser != "" || privilegedUser != ""
+}
+
 // WithPermUsers injects the permission control user config into the context.
 func WithPermUsers(ctx context.Context, defaultUser, privilegedUser string) context.Context {
 	return context.WithValue(ctx, permUsersKey, &PermUsersPair{
@@ -88,6 +95,14 @@ func (h *ApprovalHook) SetHandler(handler ApprovalHandler) {
 }
 
 func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args string) error {
+	// Read user configuration from context first (per-request, from user_settings)
+	defaultUser, privilegedUser := PermUsersFromContext(ctx)
+
+	// Feature not configured — ignore any run_as/reason (may be stale LLM context)
+	if defaultUser == "" && privilegedUser == "" {
+		return nil
+	}
+
 	runAs, reason := extractRunAsAndReason(args)
 	if (strings.TrimSpace(runAs) == "") != (strings.TrimSpace(reason) == "") {
 		return fmt.Errorf("run_as and reason must be provided together")
@@ -96,14 +111,6 @@ func (h *ApprovalHook) PreToolUse(ctx context.Context, toolName string, args str
 	// No run_as specified — execute as current process user
 	if runAs == "" {
 		return nil
-	}
-
-	// Read user configuration from context (per-request, from user_settings)
-	defaultUser, privilegedUser := PermUsersFromContext(ctx)
-
-	// Feature not configured — reject any run_as value
-	if defaultUser == "" && privilegedUser == "" {
-		return fmt.Errorf("permission control is not enabled: cannot use run_as %q (configure default_user or privileged_user in settings)", runAs)
 	}
 
 	// Validate run_as against configured users

--- a/tools/approval_test.go
+++ b/tools/approval_test.go
@@ -100,20 +100,20 @@ func TestApprovalHook_UnknownUser(t *testing.T) {
 func TestApprovalHook_FeatureDisabled(t *testing.T) {
 	handler := &mockApprovalHandler{}
 	h := NewApprovalHook(handler)
-	// No perm users in context — feature disabled
+	// No perm users in context — feature disabled, stale run_as should be silently ignored
 	err := h.PreToolUse(context.Background(), "Shell", `{"command": "ls", "run_as": "root"}`)
-	if err == nil {
-		t.Fatal("expected error when feature is disabled")
+	if err != nil {
+		t.Fatalf("expected nil when perm control is disabled (stale run_as should be ignored), got %v", err)
 	}
 }
 
 func TestApprovalHook_EmptyPermUsers(t *testing.T) {
 	handler := &mockApprovalHandler{}
 	h := NewApprovalHook(handler)
-	// Perm users in context but both empty
+	// Perm users in context but both empty — feature disabled, stale run_as should be ignored
 	err := h.PreToolUse(withPerm(context.Background(), "", ""), "Shell", `{"command": "ls", "run_as": "root"}`)
-	if err == nil {
-		t.Fatal("expected error when perm users are empty")
+	if err != nil {
+		t.Fatalf("expected nil when perm users are both empty (stale run_as should be ignored), got %v", err)
 	}
 }
 

--- a/tools/edit.go
+++ b/tools/edit.go
@@ -58,6 +58,13 @@ func (t *FileCreateTool) Execute(ctx *ToolContext, input string) (*ToolResult, e
 	if params.Path == "" {
 		return nil, fmt.Errorf("path is required")
 	}
+
+	// When permission control is disabled, ignore stale run_as/reason from LLM cache
+	if ctx.Ctx == nil || !isPermControlActiveFromCtx(ctx.Ctx) {
+		params.RunAs = ""
+		params.Reason = ""
+	}
+
 	if (strings.TrimSpace(params.RunAs) == "") != (strings.TrimSpace(params.Reason) == "") {
 		return nil, fmt.Errorf("run_as and reason must be provided together")
 	}
@@ -177,6 +184,13 @@ func (t *FileReplaceTool) Execute(ctx *ToolContext, input string) (*ToolResult, 
 	if params.OldString == "" {
 		return nil, fmt.Errorf("old_string is required")
 	}
+
+	// When permission control is disabled, ignore stale run_as/reason from LLM cache
+	if ctx.Ctx == nil || !isPermControlActiveFromCtx(ctx.Ctx) {
+		params.RunAs = ""
+		params.Reason = ""
+	}
+
 	if (strings.TrimSpace(params.RunAs) == "") != (strings.TrimSpace(params.Reason) == "") {
 		return nil, fmt.Errorf("run_as and reason must be provided together")
 	}

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -78,7 +78,8 @@ type SubAgentManager interface {
 	// RunSubAgent 创建并运行一个 SubAgent，返回最终响应文本
 	// allowedTools 为工具白名单，为空时使用所有工具（除 SubAgent）
 	// caps 声明 SubAgent 可获得的能力（memory、send_message 等）
-	RunSubAgent(parentCtx *ToolContext, task string, systemPrompt string, allowedTools []string, caps SubAgentCapabilities, roleName string) (string, error)
+	// model 为可选的模型覆盖，为空时继承主 Agent 模型
+	RunSubAgent(parentCtx *ToolContext, task string, systemPrompt string, allowedTools []string, caps SubAgentCapabilities, roleName string, model string) (string, error)
 }
 
 // ToolResult 工具执行结果

--- a/tools/path_guard.go
+++ b/tools/path_guard.go
@@ -28,7 +28,7 @@ func defaultWorkspaceRoot(ctx *ToolContext) string {
 func resolveScopedBase(ctx *ToolContext) (string, error) {
 	root := defaultWorkspaceRoot(ctx)
 	if root == "" {
-		cwd, err := os.Getwd()
+		cwd, err := effectiveCWD(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get working directory: %w", err)
 		}
@@ -39,6 +39,22 @@ func resolveScopedBase(ctx *ToolContext) (string, error) {
 		return "", fmt.Errorf("invalid workspace root: %w", err)
 	}
 	return absRoot, nil
+}
+
+// effectiveCWD returns the current working directory for path resolution.
+// Priority: ctx.CurrentDir (set by Cd tool) > effectiveCWD(ctx) (process CWD).
+//
+// Bug fix: In unrestricted mode (none/remote sandbox), all path resolution
+// functions used os.Getwd() which returns the OS process CWD, not the
+// virtual CWD set by the Cd tool. The Cd tool only sets ctx.CurrentDir
+// (session-persisted), it does NOT call os.Chdir(). This caused relative
+// paths in Read/FileCreate/FileReplace/Grep/Glob to resolve against the
+// wrong directory after a Cd.
+func effectiveCWD(ctx *ToolContext) (string, error) {
+	if ctx != nil && ctx.CurrentDir != "" {
+		return ctx.CurrentDir, nil
+	}
+	return os.Getwd()
 }
 
 // isUnrestricted returns true when path restrictions should be skipped.
@@ -66,7 +82,7 @@ func ResolveWritePath(ctx *ToolContext, inputPath string) (string, error) {
 		if filepath.IsAbs(inputPath) {
 			return cleanAbsPath(inputPath)
 		}
-		cwd, err := os.Getwd()
+		cwd, err := effectiveCWD(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get working directory: %w", err)
 		}
@@ -77,7 +93,7 @@ func ResolveWritePath(ctx *ToolContext, inputPath string) (string, error) {
 		if filepath.IsAbs(inputPath) {
 			return cleanAbsPath(inputPath)
 		}
-		cwd, err := os.Getwd()
+		cwd, err := effectiveCWD(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get working directory: %w", err)
 		}
@@ -138,7 +154,7 @@ func ResolveReadPath(ctx *ToolContext, inputPath string) (string, error) {
 		if filepath.IsAbs(inputPath) {
 			return cleanAbsPath(inputPath)
 		}
-		cwd, err := os.Getwd()
+		cwd, err := effectiveCWD(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get working directory: %w", err)
 		}
@@ -149,7 +165,7 @@ func ResolveReadPath(ctx *ToolContext, inputPath string) (string, error) {
 		if filepath.IsAbs(inputPath) {
 			return cleanAbsPath(inputPath)
 		}
-		cwd, err := os.Getwd()
+		cwd, err := effectiveCWD(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get working directory: %w", err)
 		}

--- a/tools/path_guard_test.go
+++ b/tools/path_guard_test.go
@@ -396,3 +396,53 @@ func TestReadTool_Fallthrough_CurrentDir(t *testing.T) {
 		t.Errorf("expected 'root content' in result, got: %s", result.Summary)
 	}
 }
+
+// TestResolveReadPath_Unrestricted_CurrentDir verifies that in unrestricted mode
+// (none sandbox), relative paths resolve against CurrentDir, not os.Getwd().
+func TestResolveReadPath_Unrestricted_CurrentDir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "test.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ToolContext{
+		CurrentDir: sub,
+		Sandbox:    &mockSandbox{name: "none"},
+	}
+
+	resolved, err := ResolveReadPath(ctx, "test.txt")
+	if err != nil {
+		t.Fatalf("ResolveReadPath(unrestricted, relative) failed: %v", err)
+	}
+	want := filepath.Join(sub, "test.txt")
+	if resolved != want {
+		t.Errorf("ResolveReadPath = %q, want %q (should resolve against CurrentDir, not os.Getwd())", resolved, want)
+	}
+}
+
+// TestResolveWritePath_Unrestricted_CurrentDir verifies the same fix for write paths.
+func TestResolveWritePath_Unrestricted_CurrentDir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ToolContext{
+		CurrentDir: sub,
+		Sandbox:    &mockSandbox{name: "none"},
+	}
+
+	resolved, err := ResolveWritePath(ctx, "new-file.txt")
+	if err != nil {
+		t.Fatalf("ResolveWritePath(unrestricted, relative) failed: %v", err)
+	}
+	want := filepath.Join(sub, "new-file.txt")
+	if resolved != want {
+		t.Errorf("ResolveWritePath = %q, want %q (should resolve against CurrentDir, not os.Getwd())", resolved, want)
+	}
+}

--- a/tools/permission_reason_validation_test.go
+++ b/tools/permission_reason_validation_test.go
@@ -1,13 +1,16 @@
 package tools
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
 
 func TestShellTool_RunAsReasonPairValidation(t *testing.T) {
 	tool := &ShellTool{}
-	ctx := &ToolContext{}
+	// Must have perm control enabled for pair validation to apply
+	permCtx := WithPermUsers(context.Background(), "alice", "root")
+	ctx := &ToolContext{Ctx: permCtx}
 
 	_, err := tool.Execute(ctx, `{"command":"whoami","run_as":"root"}`)
 	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
@@ -22,7 +25,8 @@ func TestShellTool_RunAsReasonPairValidation(t *testing.T) {
 
 func TestFileCreateTool_RunAsReasonPairValidation(t *testing.T) {
 	tool := &FileCreateTool{}
-	ctx := &ToolContext{}
+	permCtx := WithPermUsers(context.Background(), "alice", "root")
+	ctx := &ToolContext{Ctx: permCtx}
 
 	_, err := tool.Execute(ctx, `{"path":"/tmp/a.txt","content":"x","run_as":"root"}`)
 	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
@@ -37,7 +41,8 @@ func TestFileCreateTool_RunAsReasonPairValidation(t *testing.T) {
 
 func TestFileReplaceTool_RunAsReasonPairValidation(t *testing.T) {
 	tool := &FileReplaceTool{}
-	ctx := &ToolContext{}
+	permCtx := WithPermUsers(context.Background(), "alice", "root")
+	ctx := &ToolContext{Ctx: permCtx}
 
 	_, err := tool.Execute(ctx, `{"path":"/tmp/a.txt","old_string":"a","new_string":"b","run_as":"root"}`)
 	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
@@ -47,5 +52,27 @@ func TestFileReplaceTool_RunAsReasonPairValidation(t *testing.T) {
 	_, err = tool.Execute(ctx, `{"path":"/tmp/a.txt","old_string":"a","new_string":"b","reason":"need root"}`)
 	if err == nil || !strings.Contains(err.Error(), "run_as and reason must be provided together") {
 		t.Fatalf("expected pair-validation error for reason only, got %v", err)
+	}
+}
+
+// TestPermDisabledIgnoresStaleRunAs verifies that stale run_as/reason from
+// cached LLM context are silently ignored when permission control is disabled.
+func TestPermDisabledIgnoresStaleRunAs(t *testing.T) {
+	shellTool := &ShellTool{}
+
+	// No perm users → perm control disabled
+	ctx := &ToolContext{Ctx: context.Background(), WorkingDir: "/tmp"}
+
+	// Shell: stale run_as alone should be stripped, not cause pair-validation error
+	_, err := shellTool.Execute(ctx, `{"command":"echo hi","run_as":"root"}`)
+	// Execution may fail for other reasons (sandbox etc), but NOT pair-validation
+	if err != nil && strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("stale run_as should be ignored when perm control is disabled, got %v", err)
+	}
+
+	// Shell: stale reason alone should be stripped too
+	_, err = shellTool.Execute(ctx, `{"command":"echo hi","reason":"need root"}`)
+	if err != nil && strings.Contains(err.Error(), "run_as and reason must be provided together") {
+		t.Fatalf("stale reason should be ignored when perm control is disabled, got %v", err)
 	}
 }

--- a/tools/shell.go
+++ b/tools/shell.go
@@ -70,6 +70,14 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 	if params.Command == "" {
 		return nil, fmt.Errorf("command is required")
 	}
+
+	// When permission control is disabled, ignore any stale run_as/reason
+	// the LLM might send from cached context.
+	if toolCtx.Ctx == nil || !isPermControlActiveFromCtx(toolCtx.Ctx) {
+		params.RunAs = ""
+		params.Reason = ""
+	}
+
 	if (strings.TrimSpace(params.RunAs) == "") != (strings.TrimSpace(params.Reason) == "") {
 		return nil, fmt.Errorf("run_as and reason must be provided together")
 	}

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -13,9 +13,10 @@ type InteractiveSubAgentManager interface {
 	SubAgentManager
 	// SpawnInteractive 创建/复用 interactive SubAgent session 并执行任务。
 	// instance 为空时行为与旧版一致；设置 instance 后同一 role 可创建多个独立 session。
-	SpawnInteractive(ctx *ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps SubAgentCapabilities, instance string) (string, error)
+	// model 为可选的模型覆盖，为空时继承主 Agent 模型。
+	SpawnInteractive(ctx *ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps SubAgentCapabilities, instance, model string) (string, error)
 	// SendInteractive 向已有的 interactive session 发送消息。
-	SendInteractive(ctx *ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps SubAgentCapabilities, instance string) (string, error)
+	SendInteractive(ctx *ToolContext, task, roleName, systemPrompt string, allowedTools []string, caps SubAgentCapabilities, instance, model string) (string, error)
 	// UnloadInteractive 结束 interactive session（巩固记忆 + 清理）。
 	UnloadInteractive(ctx *ToolContext, roleName, instance string) error
 	// InspectInteractive 返回 interactive session 的最近活动摘要（tail 风格）。
@@ -175,7 +176,7 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 			if params.Task == "" {
 				return nil, fmt.Errorf("task is required for action=\"send\"")
 			}
-			result, err := im.SendInteractive(ctx, params.Task, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance)
+			result, err := im.SendInteractive(ctx, params.Task, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance, role.Model)
 			if err != nil {
 				return nil, fmt.Errorf("interactive send failed: %w", err)
 			}
@@ -210,7 +211,7 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 				ctx.Metadata["background"] = "true"
 			}
 			// action="" + interactive=true → spawn/reuse
-			result, err := im.SpawnInteractive(ctx, params.Task, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance)
+			result, err := im.SpawnInteractive(ctx, params.Task, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance, role.Model)
 			if err != nil {
 				return nil, fmt.Errorf("interactive spawn failed: %w", err)
 			}
@@ -223,7 +224,7 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 	}
 
 	// Default: one-shot mode
-	result, err := ctx.Manager.RunSubAgent(ctx, params.Task, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Role)
+	result, err := ctx.Manager.RunSubAgent(ctx, params.Task, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Role, role.Model)
 	if err != nil {
 		return nil, fmt.Errorf("sub-agent failed: %w", err)
 	}

--- a/tools/subagent_loader.go
+++ b/tools/subagent_loader.go
@@ -75,7 +75,7 @@ func ParseAgentFile(path string) (SubAgentRole, error) {
 	}
 
 	// 解析 frontmatter 字段
-	name, description, allowedTools, caps, err := parseFrontmatter(frontmatter)
+	name, description, model, allowedTools, caps, err := parseFrontmatter(frontmatter)
 	if err != nil {
 		return SubAgentRole{}, fmt.Errorf("parse frontmatter: %w", err)
 	}
@@ -90,6 +90,7 @@ func ParseAgentFile(path string) (SubAgentRole, error) {
 	return SubAgentRole{
 		Name:         name,
 		Description:  description,
+		Model:        model,
 		SystemPrompt: strings.TrimSpace(body),
 		AllowedTools: allowedTools,
 		Capabilities: caps,
@@ -104,7 +105,7 @@ func ParseAgentFileContent(data []byte, fallbackName string) (SubAgentRole, erro
 	if err != nil {
 		return SubAgentRole{}, fmt.Errorf("invalid frontmatter: %w", err)
 	}
-	name, description, allowedTools, caps, err := parseFrontmatter(frontmatter)
+	name, description, model, allowedTools, caps, err := parseFrontmatter(frontmatter)
 	if err != nil {
 		return SubAgentRole{}, fmt.Errorf("parse frontmatter: %w", err)
 	}
@@ -114,6 +115,7 @@ func ParseAgentFileContent(data []byte, fallbackName string) (SubAgentRole, erro
 	return SubAgentRole{
 		Name:         name,
 		Description:  description,
+		Model:        model,
 		SystemPrompt: strings.TrimSpace(body),
 		AllowedTools: allowedTools,
 		Capabilities: caps,
@@ -150,9 +152,9 @@ func splitFrontmatter(content string) (frontmatter, body string, err error) {
 }
 
 // parseFrontmatter 手动解析简单 YAML frontmatter
-// 支持 name, description（字符串）、tools（列表）和 capabilities（子字段）
+// 支持 name, description（字符串）、tools（列表）、model（字符串）和 capabilities（子字段）
 // 默认 spawn_agent=true，除非显式设置 spawn_agent: false
-func parseFrontmatter(fm string) (name, description string, tools []string, caps SubAgentCapabilities, err error) {
+func parseFrontmatter(fm string) (name, description, model string, tools []string, caps SubAgentCapabilities, err error) {
 	caps = SubAgentCapabilities{
 		SpawnAgent: true, // 默认允许 spawn 子 agent
 	}
@@ -219,6 +221,9 @@ func parseFrontmatter(fm string) (name, description string, tools []string, caps
 		case "description":
 			description = value
 			currentField = "description"
+		case "model":
+			model = value
+			currentField = "model"
 		case "tools":
 			currentField = "tools"
 			// tools 的值可能在同一行（如 tools: [a, b]）或后续行（列表格式）
@@ -234,7 +239,7 @@ func parseFrontmatter(fm string) (name, description string, tools []string, caps
 	if name != "" {
 		for _, c := range name {
 			if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '-' && c != '_' {
-				return "", "", nil, SubAgentCapabilities{}, fmt.Errorf("invalid agent name %q: only letters (including CJK), digits, hyphens and underscores are allowed", name)
+				return "", "", "", nil, SubAgentCapabilities{}, fmt.Errorf("invalid agent name %q: only letters (including CJK), digits, hyphens and underscores are allowed", name)
 			}
 		}
 	}
@@ -242,16 +247,16 @@ func parseFrontmatter(fm string) (name, description string, tools []string, caps
 	// 校验 tools 列表格式
 	for _, t := range tools {
 		if t == "" {
-			return "", "", nil, SubAgentCapabilities{}, fmt.Errorf("empty tool name in tools list")
+			return "", "", "", nil, SubAgentCapabilities{}, fmt.Errorf("empty tool name in tools list")
 		}
 		for _, c := range t {
 			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' && c != '_' && c != '.' {
-				return "", "", nil, SubAgentCapabilities{}, fmt.Errorf("invalid tool name %q: only letters, digits, hyphens, underscores and dots are allowed", t)
+				return "", "", "", nil, SubAgentCapabilities{}, fmt.Errorf("invalid tool name %q: only letters, digits, hyphens, underscores and dots are allowed", t)
 			}
 		}
 	}
 
-	return name, description, tools, caps, nil
+	return name, description, model, tools, caps, nil
 }
 
 // isTruthy 判断字符串是否表示 true

--- a/tools/subagent_loader_test.go
+++ b/tools/subagent_loader_test.go
@@ -16,7 +16,7 @@ capabilities:
   memory: true
   send_message: true`
 
-	name, desc, tools, caps, err := parseFrontmatter(fm)
+	name, desc, _, tools, caps, err := parseFrontmatter(fm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -47,7 +47,7 @@ description: "Simple agent"
 tools:
   - Shell`
 
-	_, _, _, caps, err := parseFrontmatter(fm)
+	_, _, _, _, caps, err := parseFrontmatter(fm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -68,7 +68,7 @@ capabilities:
   send_message: true
   spawn_agent: true`
 
-	_, _, _, caps, err := parseFrontmatter(fm)
+	_, _, _, _, caps, err := parseFrontmatter(fm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -128,7 +128,7 @@ capabilities:
   memory: true
   spawn_agent: true`
 
-	name, desc, _, caps, err := parseFrontmatter(fm)
+	name, desc, _, _, caps, err := parseFrontmatter(fm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestParseFrontmatter_MixedName(t *testing.T) {
 	fm := `name: 工部-dev_01
 description: "Mixed CJK and ASCII name"`
 
-	name, _, _, _, err := parseFrontmatter(fm)
+	name, _, _, _, _, err := parseFrontmatter(fm)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,8 +159,60 @@ description: "Mixed CJK and ASCII name"`
 func TestParseFrontmatter_InvalidNameWithSpaces(t *testing.T) {
 	fm := `name: 中书 省`
 
-	_, _, _, _, err := parseFrontmatter(fm)
+	_, _, _, _, _, err := parseFrontmatter(fm)
 	if err == nil {
 		t.Fatal("expected error for name with spaces, got nil")
+	}
+}
+
+func TestParseFrontmatter_ModelField(t *testing.T) {
+	fm := `---
+name: test-role
+description: A test role
+model: claude-sonnet-4-20250514
+tools:
+  - Read
+  - Grep
+---
+System prompt here.`
+
+	name, desc, model, tools, caps, err := parseFrontmatter(fm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "test-role" {
+		t.Errorf("name = %q, want %q", name, "test-role")
+	}
+	if desc != "A test role" {
+		t.Errorf("desc = %q, want %q", desc, "A test role")
+	}
+	if model != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %q, want %q", model, "claude-sonnet-4-20250514")
+	}
+	if len(tools) != 2 || tools[0] != "Read" || tools[1] != "Grep" {
+		t.Errorf("tools = %v, want [Read Grep]", tools)
+	}
+	if !caps.SpawnAgent {
+		t.Error("caps.SpawnAgent should be true by default")
+	}
+}
+
+func TestParseFrontmatter_NoModelField(t *testing.T) {
+	fm := `---
+name: test-role
+tools:
+  - Read
+---
+System prompt.`
+
+	name, _, model, _, _, err := parseFrontmatter(fm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "test-role" {
+		t.Errorf("name = %q", name)
+	}
+	if model != "" {
+		t.Errorf("model = %q, want empty string", model)
 	}
 }

--- a/tools/subagent_roles.go
+++ b/tools/subagent_roles.go
@@ -14,6 +14,7 @@ type SubAgentRole struct {
 	Description  string
 	SystemPrompt string
 	AllowedTools []string
+	Model        string // 可选：指定使用的 LLM 模型（如 "claude-sonnet-4-20250514"）。为空时继承主 Agent 模型。
 
 	Capabilities SubAgentCapabilities
 }


### PR DESCRIPTION
CLI progress block does not show ActiveTools. Root cause: notifyProgress() called before structuredProgress.ActiveTools was populated in the CLI path. Fix: move ActiveTools setup before notifyProgress.