### PR TITLE
feat: Windows support for built-in tools (none sandbox)

### DIFF
--- a/channel/cli.go
+++ b/channel/cli.go
@@ -15,9 +15,7 @@ package channel
 import (
 	"context"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -143,16 +141,8 @@ func (c *CLIChannel) Start() error {
 	// Ctrl+Z 紧急退出：双保险
 	// 1) Key event handler (cli_update.go): raw mode 下终端可能直接传 0x1A 字节
 	// 2) SIGTSTP 信号兜底: 某些终端 emulator 在 raw mode 下仍发信号
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTSTP)
-	go func() {
-		<-sigCh
-		// 恢复终端并直接退出，不依赖 bubbletea 的 Quit 流程
-		_ = c.program.ReleaseTerminal()
-		os.Stdout = origStdout
-		os.Stderr = origStderr
-		os.Exit(0)
-	}()
+	// Note: SIGTSTP is Unix-only; handled by handleCtrlZSuspend (platform-specific).
+	setupCtrlZSuspend(c, origStdout, origStderr)
 
 	// 启动 outbound 消息处理 goroutine
 	c.wg.Add(1)

--- a/channel/cli_ctrlz_unix.go
+++ b/channel/cli_ctrlz_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package channel
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// setupCtrlZSuspend sets up a SIGTSTP (Ctrl+Z) handler that restores the terminal
+// and exits immediately. Unix-only — Windows doesn't have SIGTSTP.
+func setupCtrlZSuspend(c *CLIChannel, origStdout, origStderr *os.File) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTSTP)
+	go func() {
+		<-sigCh
+		// 恢复终端并直接退出，不依赖 bubbletea 的 Quit 流程
+		_ = c.program.ReleaseTerminal()
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		os.Exit(0)
+	}()
+}

--- a/channel/cli_ctrlz_windows.go
+++ b/channel/cli_ctrlz_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package channel
+
+import "os"
+
+// setupCtrlZSuspend is a no-op on Windows.
+// Windows uses Ctrl+Z for EOF (not SIGTSTP signal suspension).
+func setupCtrlZSuspend(_ *CLIChannel, _ *os.File, _ *os.File) {
+	// No-op: Windows doesn't have SIGTSTP.
+}

--- a/docs/agent/gotchas.md
+++ b/docs/agent/gotchas.md
@@ -26,3 +26,10 @@
 - `docs/agent/agent.md` — SubAgent deadlocks, context management
 - `docs/agent/llm.md` — streaming bugs, retry context traps
 - `docs/agent/tools.md` — tool schema Items requirement, hook chain behavior
+
+## Windows
+
+- `syscall.PROCESS_QUERY_LIMITED_INFORMATION` and `STILL_ACTIVE` are NOT in Go's stdlib `syscall` — define as uint32 constants (0x1000, 259)
+- `exec.ExitError.ExitCode()` is cross-platform; avoid `syscall.WaitStatus` type assertion (fails on Windows)
+- `signal.Notify(sigCh, syscall.SIGTSTP)` doesn't compile on Windows — use build-tagged files
+- PowerShell env output is newline-delimited, not null-delimited — different parsing needed in `mcp_common.go`

--- a/docs/agent/tools.md
+++ b/docs/agent/tools.md
@@ -19,6 +19,9 @@
 | `glob.go` | Glob tool (pattern matching) |
 | `fetch.go` | Fetch tool (HTTP → markdown) |
 | `shell.go` | Shell tool (command execution) |
+| `shell_unix.go` | Unix process helpers: setProcessAttrs (Setpgid), killProcessTree (-pgid SIGKILL), isProcessAlive (Signal(0)), defaultShell, loginShellArgs |
+| `shell_windows.go` | Windows process helpers: setProcessAttrs (CREATE_NEW_PROCESS_GROUP), killProcessTree (taskkill /T /F), isProcessAlive (OpenProcess), defaultShell (powershell.exe), loginShellArgs |
+| `none_sandbox.go` | None sandbox (local execution). Uses platform helpers from shell_unix/shell_windows.go |
 | `mcp_common.go` | MCP protocol definitions |
 | `mcp_remote_transport.go` | MCP HTTP transport |
 | `memory_tools.go` | Core memory tools (append/replace/rethink/search/recall) |
@@ -44,6 +47,15 @@ PostToolUse: guarantees all hooks run even if one panics (recover).
 
 ## Sandbox Types
 
-- `none`: direct execution (default)
-- `docker`: Docker container per OS user
-- `remote`: remote runner process via runner protocol
+- `none`: direct execution (default). Uses `/bin/bash -l -c` on Unix, `powershell.exe -Command` on Windows
+- `docker`: Docker container per OS user (always Linux)
+- `remote`: remote runner process via runner protocol (always Linux)
+
+## Windows Support
+
+- **None sandbox only** — docker/remote sandboxes are always Linux
+- Shell: `powershell.exe -Command` replaces `/bin/bash -l -c`
+- Process management: `taskkill /T /F` replaces `kill(-pgid, SIGKILL)`; `CREATE_NEW_PROCESS_GROUP` replaces `Setpgid`
+- `run_as` (sudo) not supported on Windows — returns error
+- Platform helpers in `shell_unix.go` / `shell_windows.go`: `setProcessAttrs`, `killProcessTree`, `isProcessAlive`, `defaultShell`, `loginShellArgs`
+- `cmdbuilder` uses `defaultShell`/`defaultShellFlag` constants from `shell_default.go` / `shell_windows.go`

--- a/internal/cmdbuilder/cmdbuilder.go
+++ b/internal/cmdbuilder/cmdbuilder.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -23,17 +24,20 @@ type Config struct {
 
 // Build creates an *exec.Cmd with optional OS user switching.
 //
-// When cfg.RunAsUser is set, the command is wrapped with sudo:
+// When cfg.RunAsUser is set (Unix only), the command is wrapped with sudo:
 //
-//	sudo -n -H -u <user> -- /bin/sh -c "<command>"
+//	sudo -n -H -u <user> -- <shell> <flag> "<command>"
 //
 // When cfg.RunAsUser is empty, the command is constructed directly:
 //
-//	/bin/sh -c "<command>"
+//	<shell> <flag> "<command>"
+//
+// On Windows, RunAsUser is not supported and returns an error.
+// The default shell is /bin/sh on Unix and powershell.exe on Windows.
 //
 // Parameters:
 //   - ctx: context for cancellation (nil → no context)
-//   - shell: true → use "sh -c <command>"; false → use args directly
+//   - shell: true → use shell command; false → use args directly
 //   - command: the command string (used when shell=true)
 //   - args: the arg list (used when shell=false, must be non-empty)
 //   - dir: working directory
@@ -45,9 +49,13 @@ func Build(ctx context.Context, shell bool, command string, args []string,
 	var cmd *exec.Cmd
 
 	if cfg.RunAsUser != "" {
+		// OS user switching via sudo is not supported on Windows.
+		if runtime.GOOS == "windows" {
+			return nil, fmt.Errorf("run_as (user switching) is not supported on Windows")
+		}
 		// Wrap with sudo -n -H -u <user> --
 		if shell {
-			sudoArgs := []string{"-n", "-H", "-u", cfg.RunAsUser, "--", "/bin/sh", "-c", command}
+			sudoArgs := []string{"-n", "-H", "-u", cfg.RunAsUser, "--", defaultShell, defaultShellFlag, command}
 			if ctx != nil {
 				cmd = exec.CommandContext(ctx, "sudo", sudoArgs...)
 			} else {
@@ -68,9 +76,9 @@ func Build(ctx context.Context, shell bool, command string, args []string,
 		// No user switching — direct execution
 		if shell {
 			if ctx != nil {
-				cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command)
+				cmd = exec.CommandContext(ctx, defaultShell, defaultShellFlag, command)
 			} else {
-				cmd = exec.Command("/bin/sh", "-c", command)
+				cmd = exec.Command(defaultShell, defaultShellFlag, command)
 			}
 		} else {
 			if len(args) == 0 {
@@ -102,12 +110,12 @@ func WriteFileAsUser(runAsUser, path string, data []byte, perm os.FileMode) erro
 	}
 
 	// Use sudo to write as the target user:
-	// sudo -n -H -u <user> -- /bin/sh -c "cat > '<escaped_path>' && chmod <perm> '<escaped_path>'"
+	// sudo -n -H -u <user> -- <shell> <flag> "cat > '<escaped_path>' && chmod <perm> '<escaped_path>'"
 	escaped := shellEscape(path)
 	permStr := fmt.Sprintf("%o", perm)
 	shellCmd := fmt.Sprintf("cat > %s && chmod %s %s", escaped, permStr, escaped)
 
-	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "/bin/sh", "-c", shellCmd)
+	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", defaultShell, defaultShellFlag, shellCmd)
 	cmd.Stdin = bytes.NewReader(data)
 
 	var stderr bytes.Buffer
@@ -151,7 +159,7 @@ func MkdirAllAsUser(runAsUser, path string, perm os.FileMode) error {
 	permStr := fmt.Sprintf("%o", perm)
 	shellCmd := fmt.Sprintf("mkdir -p %s && chmod %s %s", escaped, permStr, escaped)
 
-	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", "/bin/sh", "-c", shellCmd)
+	cmd := exec.Command("sudo", "-n", "-H", "-u", runAsUser, "--", defaultShell, defaultShellFlag, shellCmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 

--- a/internal/cmdbuilder/cmdbuilder_test.go
+++ b/internal/cmdbuilder/cmdbuilder_test.go
@@ -32,8 +32,8 @@ func TestBuild_NoRunAs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cmd.Path != "/bin/sh" {
-		t.Errorf("expected /bin/sh, got %s", cmd.Path)
+	if cmd.Path != defaultShell {
+		t.Errorf("expected %s, got %s", defaultShell, cmd.Path)
 	}
 }
 

--- a/internal/cmdbuilder/shell_default.go
+++ b/internal/cmdbuilder/shell_default.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package cmdbuilder
+
+// defaultShell is the shell binary used for shell-mode command execution.
+const defaultShell = "/bin/sh"
+
+// defaultShellFlag is the flag used to pass a command string to the shell.
+// /bin/sh -c "command"
+const defaultShellFlag = "-c"

--- a/internal/cmdbuilder/shell_windows.go
+++ b/internal/cmdbuilder/shell_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cmdbuilder
+
+// defaultShell is the shell binary used for shell-mode command execution on Windows.
+const defaultShell = "powershell.exe"
+
+// defaultShellFlag is the flag used to pass a command string to the shell.
+// powershell.exe -Command "command"
+const defaultShellFlag = "-Command"

--- a/internal/runnerclient/bg_task.go
+++ b/internal/runnerclient/bg_task.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"xbot/internal/runnerproto"
@@ -103,7 +102,7 @@ func (t *bgTask) runNative(m *bgTaskManager) (int, string) {
 	}
 
 	// 创建进程组以便 kill 整个进程树
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessAttrs(cmd)
 
 	dir := t.req.Dir
 	if dir == "" {
@@ -125,9 +124,7 @@ func (t *bgTask) runNative(m *bgTaskManager) (int, string) {
 	err := cmd.Run()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				return ws.ExitStatus(), "failed"
-			}
+			return exitErr.ExitCode(), "failed"
 		}
 		return -1, "failed"
 	}
@@ -164,9 +161,7 @@ func (t *bgTask) dockerRun(de *DockerExecutor, args []string, stdin string) (int
 	err := cmd.Run()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				return ws.ExitStatus(), "failed"
-			}
+			return exitErr.ExitCode(), "failed"
 		}
 		return -1, "failed"
 	}
@@ -194,7 +189,7 @@ func (m *bgTaskManager) Kill(req runnerproto.BgKillRequest) error {
 			t.cmd.Process.Kill()
 		} else {
 			// Kill 整个进程组
-			syscall.Kill(-t.cmd.Process.Pid, syscall.SIGKILL)
+			killProcessTree(t.cmd.Process.Pid)
 		}
 		t.status = "killed"
 		callLogf(m.logf, "  bg_kill [id=%s]: killed", req.TaskID)
@@ -236,7 +231,7 @@ func (m *bgTaskManager) Cleanup() {
 			if m.dockerMode {
 				t.cmd.Process.Kill()
 			} else {
-				syscall.Kill(-t.cmd.Process.Pid, syscall.SIGKILL)
+				killProcessTree(t.cmd.Process.Pid)
 			}
 			t.status = "killed"
 		}

--- a/internal/runnerclient/native.go
+++ b/internal/runnerclient/native.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"xbot/internal/cmdbuilder"
@@ -42,7 +41,7 @@ func (e *NativeExecutor) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, 
 	}
 
 	// 创建新进程组，超时时可以 kill 所有子进程
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessAttrs(cmd)
 	if spec.Dir != "" {
 		cmd.Dir = filepath.Clean(spec.Dir)
 	} else {
@@ -67,13 +66,11 @@ func (e *NativeExecutor) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, 
 		timedOut = true
 		exitCode = -1
 		if cmd.Process != nil {
-			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			killProcessTree(cmd.Process.Pid)
 		}
 	} else if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				exitCode = status.ExitStatus()
-			}
+			exitCode = exitErr.ExitCode()
 		} else {
 			return nil, err
 		}

--- a/internal/runnerclient/proc_unix.go
+++ b/internal/runnerclient/proc_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package runnerclient
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessAttrs sets Unix process group attributes for the command.
+func setProcessAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessTree kills the entire process group (Unix).
+func killProcessTree(pid int) {
+	syscall.Kill(-pid, syscall.SIGKILL)
+}
+
+// signalProcess sends a signal to a process (Unix).
+func signalProcess(pid int, sig syscall.Signal) {
+	proc, _ := os.FindProcess(pid)
+	if proc != nil {
+		proc.Signal(sig) //nolint:errcheck
+	}
+}

--- a/internal/runnerclient/proc_windows.go
+++ b/internal/runnerclient/proc_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package runnerclient
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+// setProcessAttrs sets Windows process group attributes for the command.
+func setProcessAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+// killProcessTree kills a process and all its children (Windows).
+func killProcessTree(pid int) {
+	exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+}
+
+// signalProcess sends a signal to a process (Windows).
+// Windows doesn't have SIGTERM; maps to process kill.
+func signalProcess(pid int, sig syscall.Signal) {
+	proc, _ := os.FindProcess(pid)
+	if proc != nil {
+		proc.Kill() //nolint:errcheck
+	}
+}

--- a/internal/runnerclient/shell.go
+++ b/internal/runnerclient/shell.go
@@ -3,6 +3,7 @@ package runnerclient
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -23,7 +24,16 @@ func DetectShell(dockerMode bool, executor Executor) string {
 			}
 		}
 	}
-	// 回退：检查宿主机或默认
+
+	// Platform-specific fallback
+	if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("powershell.exe"); err == nil {
+			return "powershell.exe"
+		}
+		return "cmd.exe"
+	}
+
+	// Unix fallback
 	for _, candidate := range []string{"/bin/bash", "/usr/bin/bash", "/bin/sh"} {
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate

--- a/internal/runnerclient/stdio.go
+++ b/internal/runnerclient/stdio.go
@@ -154,7 +154,7 @@ func (sm *stdioManager) HandleClose(msg runnerproto.RunnerMessage) *runnerproto.
 	select {
 	case <-proc.done:
 	case <-time.After(5 * time.Second):
-		proc.cmd.Process.Signal(syscall.SIGTERM) //nolint:errcheck
+		signalProcess(proc.cmd.Process.Pid, syscall.SIGTERM)
 		select {
 		case <-proc.done:
 		case <-time.After(3 * time.Second):

--- a/tools/mcp_common.go
+++ b/tools/mcp_common.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -198,13 +199,22 @@ func buildMinimalExecEnv(envList []string) []string {
 	return env
 }
 
-// getLoginShellEnv runs `bash -l -c 'env -0'` to capture the full environment
-// from a login shell. Returns empty slice on failure (caller will use fallback).
+// getLoginShellEnv runs a login shell command to capture the full environment.
+// Unix: bash -l -c 'env -0'
+// Windows: powershell.exe -Command "[Environment]::GetEnvironmentVariables() | ..."
+// Returns empty slice on failure (caller will use fallback).
 func getLoginShellEnv() []string {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bash", "-l", "-c", "env -0")
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		// PowerShell: list env vars as KEY=VALUE lines
+		cmd = exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-Command",
+			"Get-ChildItem Env: | ForEach-Object { $_.Name + '=' + $_.Value }")
+	} else {
+		cmd = exec.CommandContext(ctx, "bash", "-l", "-c", "env -0")
+	}
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = nil // discard stderr (shell startup noise)
@@ -214,26 +224,38 @@ func getLoginShellEnv() []string {
 		return nil
 	}
 
-	// Parse null-delimited output
+	// Parse output
 	output := stdout.Bytes()
 	if len(output) == 0 {
 		return nil
 	}
 
 	var env []string
-	for len(output) > 0 {
-		idx := bytes.IndexByte(output, 0)
-		if idx < 0 {
-			idx = len(output)
+	if runtime.GOOS == "windows" {
+		// PowerShell outputs newline-delimited KEY=VALUE lines
+		scanner := bufio.NewScanner(bytes.NewReader(output))
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.IndexByte(line, '=') > 0 {
+				env = append(env, line)
+			}
 		}
-		line := string(output[:idx])
-		if idx2 := strings.IndexByte(line, '='); idx2 > 0 {
-			env = append(env, line)
+	} else {
+		// Unix: null-delimited output
+		for len(output) > 0 {
+			idx := bytes.IndexByte(output, 0)
+			if idx < 0 {
+				idx = len(output)
+			}
+			line := string(output[:idx])
+			if idx2 := strings.IndexByte(line, '='); idx2 > 0 {
+				env = append(env, line)
+			}
+			if idx >= len(output) {
+				break
+			}
+			output = output[idx+1:]
 		}
-		if idx >= len(output) {
-			break
-		}
-		output = output[idx+1:]
 	}
 
 	sort.Strings(env)

--- a/tools/none_sandbox.go
+++ b/tools/none_sandbox.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"xbot/internal/cmdbuilder"
@@ -37,7 +36,7 @@ func (s *NoneSandbox) IsExporting(userID string) bool      { return false }
 func (s *NoneSandbox) ExportAndImport(userID string) error { return nil }
 
 func (s *NoneSandbox) GetShell(userID string, workspace string) (string, error) {
-	return "/bin/bash", nil
+	return defaultShell(), nil
 }
 
 func (s *NoneSandbox) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, error) {
@@ -55,10 +54,7 @@ func (s *NoneSandbox) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, err
 	}
 
 	// Always use process group so we can kill the entire tree on cancel.
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	cmd.SysProcAttr.Setpgid = true
+	setProcessAttrs(cmd)
 
 	if spec.Stdin != "" {
 		cmd.Stdin = bytes.NewBufferString(spec.Stdin)
@@ -109,7 +105,7 @@ func (s *NoneSandbox) Exec(ctx context.Context, spec ExecSpec) (*ExecResult, err
 // the caller takes ownership via ExecResult.Process.
 func (s *NoneSandbox) execKeepAlive(ctx context.Context, cmd *exec.Cmd, timeout time.Duration) (*ExecResult, error) {
 	// Setpgid so we can kill the process group independently
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessAttrs(cmd)
 
 	stdoutPipe, stderrPipe, err := setupPipes(cmd)
 	if err != nil {
@@ -253,15 +249,10 @@ func (s *NoneSandbox) execKeepAlive(ctx context.Context, cmd *exec.Cmd, timeout 
 	}
 }
 
-// killProcessGroup sends SIGKILL to the entire process group.
+// killProcessGroup sends a kill signal to the entire process tree.
+// This is a legacy wrapper — callers should use killProcessTree directly.
 func killProcessGroup(proc *os.Process) {
-	if proc == nil || proc.Pid == 0 {
-		return
-	}
-	// Try process group first (-pid), fall back to single process
-	if err := syscall.Kill(-proc.Pid, syscall.SIGKILL); err != nil {
-		proc.Kill()
-	}
+	killProcessTree(proc)
 }
 
 func (s *NoneSandbox) ReadFile(ctx context.Context, path string, userID string) ([]byte, error) {
@@ -379,7 +370,7 @@ func noneSandboxExecAsync(ctx context.Context, spec ExecSpec, outputBuf func(str
 	}
 
 	// Setpgid: create new process group so kill kills all children
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessAttrs(cmd)
 
 	stdoutPipe, stderrPipe, err := setupPipes(cmd)
 	if err != nil {

--- a/tools/none_sandbox_test.go
+++ b/tools/none_sandbox_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package tools
 
 import (

--- a/tools/sandbox_router_test.go
+++ b/tools/sandbox_router_test.go
@@ -233,10 +233,10 @@ func TestSandboxRouter_Delegation_NoneSandbox(t *testing.T) {
 		t.Errorf("Workspace() = %q, want empty string", ws)
 	}
 
-	// GetShell：NoneSandbox 返回 /bin/bash
+	// GetShell：NoneSandbox 返回平台默认 shell
 	shell, err := r.GetShell("user1", "")
-	if err != nil || shell != "/bin/bash" {
-		t.Errorf("GetShell() = %q, %v, want /bin/bash, nil", shell, err)
+	if err != nil || shell != defaultShell() {
+		t.Errorf("GetShell() = %q, %v, want %s, nil", shell, err, defaultShell())
 	}
 }
 

--- a/tools/shell.go
+++ b/tools/shell.go
@@ -196,9 +196,13 @@ func (t *ShellTool) Execute(toolCtx *ToolContext, input string) (*ToolResult, er
 				UserID:  userID,
 			}
 		default:
+			// None sandbox: use platform-aware shell args.
+			// Unix: bash -l -c "command" (login shell, loads profile)
+			// Windows: powershell.exe -Command "command" (loads profile by default)
+			args := loginShellArgs(shell, shellCmd)
 			return ExecSpec{
 				Command:   shell,
-				Args:      []string{shell, "-l", "-c", shellCmd},
+				Args:      args,
 				Shell:     false,
 				Dir:       execDir,
 				Timeout:   timeout,

--- a/tools/shell_unix.go
+++ b/tools/shell_unix.go
@@ -3,9 +3,19 @@
 package tools
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
+
+// defaultShell returns the default shell for the current platform.
+func defaultShell() string { return "/bin/bash" }
+
+// loginShellArgs returns the command-line arguments for executing a command in a login shell.
+// Bash: ["bash", "-l", "-c", command] (-l = login shell, loads profile)
+func loginShellArgs(shell, command string) []string {
+	return []string{shell, "-l", "-c", command}
+}
 
 // setProcessAttrs 设置 Unix 平台的进程属性
 // 使用进程组，超时时可以杀掉整棵进程树
@@ -16,8 +26,30 @@ func setProcessAttrs(cmd *exec.Cmd) {
 // killProcess 杀掉进程组
 func killProcess(cmd *exec.Cmd) {
 	if cmd.Process != nil {
-		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		killProcessTree(cmd.Process)
 	}
+}
+
+// killProcessTree kills a process and its entire process group on Unix.
+// Equivalent to kill(-pgid, SIGKILL).
+func killProcessTree(proc *os.Process) {
+	if proc == nil || proc.Pid == 0 {
+		return
+	}
+	// Try process group first (-pid), fall back to single process
+	if err := syscall.Kill(-proc.Pid, syscall.SIGKILL); err != nil {
+		proc.Kill()
+	}
+}
+
+// isProcessAlive checks whether a process with the given PID is still running.
+// Uses Signal(0) on Unix (doesn't actually send a signal, just checks existence).
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // SetProcessAttrs 是 setProcessAttrs 的导出版本，供其他包使用

--- a/tools/shell_windows.go
+++ b/tools/shell_windows.go
@@ -3,24 +3,68 @@
 package tools
 
 import (
+	"os"
 	"os/exec"
+	"strconv"
+	"syscall"
 )
 
-// setProcessAttrs 设置 Windows 平台的进程属性
-// Windows 不支持进程组，使用默认行为
-func setProcessAttrs(cmd *exec.Cmd) {
-	// Windows 上不需要特殊设置
+// defaultWindowsShell is the shell used on Windows (none sandbox).
+const defaultWindowsShell = "powershell.exe"
+
+// defaultShell returns the default shell for the current platform.
+func defaultShell() string { return defaultWindowsShell }
+
+// loginShellArgs returns the command-line arguments for executing a command in a login shell.
+// PowerShell: ["powershell.exe", "-Command", command] (loads profile by default)
+func loginShellArgs(shell, command string) []string {
+	return []string{shell, "-Command", command}
 }
 
-// killProcess 杀掉进程
-func killProcess(cmd *exec.Cmd) {
-	if cmd.Process != nil {
-		cmd.Process.Kill()
+// setProcessAttrs sets Windows-specific process attributes.
+// CREATE_NEW_PROCESS_GROUP enables killing the process tree via taskkill.
+func setProcessAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
 }
 
-// SetProcessAttrs 是 setProcessAttrs 的导出版本，供其他包使用
+// killProcess kills the process tree of the given command.
+func killProcess(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		killProcessTree(cmd.Process)
+	}
+}
+
+// killProcessTree kills a process and all its children on Windows.
+// Uses taskkill /T /F which is the Windows equivalent of Unix kill(-pgid, SIGKILL).
+func killProcessTree(proc *os.Process) {
+	if proc == nil || proc.Pid == 0 {
+		return
+	}
+	// Best-effort: ignore errors (process may have already exited).
+	exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(proc.Pid)).Run()
+}
+
+// isProcessAlive checks whether a process with the given PID is still running.
+// Uses OpenProcess + GetExitCodeProcess on Windows.
+func isProcessAlive(pid int) bool {
+	const (
+		_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+		_STILL_ACTIVE                    = 259
+	)
+	handle, err := syscall.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(handle)
+	var exitCode uint32
+	err = syscall.GetExitCodeProcess(handle, &exitCode)
+	return err == nil && exitCode == _STILL_ACTIVE
+}
+
+// SetProcessAttrs is the exported version of setProcessAttrs.
 func SetProcessAttrs(cmd *exec.Cmd) { setProcessAttrs(cmd) }
 
-// KillProcess 是 killProcess 的导出版本，供其他包使用
+// KillProcess is the exported version of killProcess.
 func KillProcess(cmd *exec.Cmd) { killProcess(cmd) }

--- a/tools/task_manager.go
+++ b/tools/task_manager.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	log "xbot/logger"
@@ -243,7 +242,7 @@ func (m *BackgroundTaskManager) Adopt(
 			case <-ticker.C:
 				// Poll fallback: channel might never fire if cmd.Wait already returned
 				for {
-					if err := proc.Signal(syscall.Signal(0)); err != nil {
+					if !isProcessAlive(proc.Pid) {
 						// Process dead, try non-blocking read from channel
 						select {
 						case code := <-exitCodeCh:
@@ -257,12 +256,12 @@ func (m *BackgroundTaskManager) Adopt(
 				}
 			}
 		} else {
-			// No channel provided — use Signal(0) polling heuristic.
+			// No channel provided — use isProcessAlive polling heuristic.
 			ticker := time.NewTicker(500 * time.Millisecond)
 			defer ticker.Stop()
 
 			for range ticker.C {
-				if err := proc.Signal(syscall.Signal(0)); err != nil {
+				if !isProcessAlive(proc.Pid) {
 					exitCode = 0
 					break
 				}
@@ -332,11 +331,10 @@ func (m *BackgroundTaskManager) Kill(taskID string) error {
 		return fmt.Errorf("task %s is not running (status: %s)", taskID, task.Status)
 	}
 
-	// Kill the OS process group directly (covers Adopt tasks with no cancel func)
+	// Kill the OS process tree directly (covers Adopt tasks with no cancel func)
 	task.mu.Lock()
 	if task.process != nil {
-		// Kill the entire process group (negative PID)
-		syscall.Kill(-task.process.Pid, syscall.SIGKILL)
+		killProcessTree(task.process)
 	}
 	task.killed = true
 	task.Status = BgTaskKilled


### PR DESCRIPTION
## Summary

Add Windows support for built-in tools when using `sandbox=none` mode.

## Changes

### Shell & Process Management
- **Shell tool**: uses `powershell.exe -Command` on Windows instead of `/bin/bash -l -c`
- **Process tree killing**: `taskkill /T /F /PID` replaces `kill(-pgid, SIGKILL)`
- **Process group**: `CREATE_NEW_PROCESS_GROUP` replaces `Setpgid`
- **Process alive check**: `OpenProcess` + `GetExitCodeProcess` replaces `Signal(0)`

### Platform Abstraction
- `tools/shell_unix.go` / `tools/shell_windows.go` — platform helpers: `setProcessAttrs`, `killProcessTree`, `isProcessAlive`, `defaultShell`, `loginShellArgs`
- `internal/cmdbuilder/shell_default.go` / `shell_windows.go` — shell constants
- `internal/runnerclient/proc_unix.go` / `proc_windows.go` — runnerclient process helpers
- `channel/cli_ctrlz_unix.go` / `cli_ctrlz_windows.go` — SIGTSTP handler (Unix-only)

### Behavior Differences on Windows
- `run_as` (sudo) returns error — Windows has no sudo equivalent
- MCP env capture uses PowerShell instead of bash
- SIGTSTP (Ctrl+Z suspend) is not available on Windows

### Scope
- **None sandbox only** — docker and remote sandboxes always run Linux
- File tools use Go stdlib — already cross-platform

## Verification
- `go build ./...` (Linux)
- `GOOS=windows go build ./...` (cross-compile)
- `go test ./...` — all pass
- `golangci-lint run ./...` — zero issues
