### PR TITLE
fix: remove legacy single-subscription panel from Feishu model tab

### DIFF
--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -189,27 +189,6 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 		}
 		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
 
-	case "settings_set_llm":
-		provider := formStr(actionData, "provider")
-		baseURL := formStr(actionData, "base_url")
-		apiKey := formStr(actionData, "api_key")
-		model := formStr(actionData, "model")
-		thinkingMode := formStr(actionData, "thinking_mode")
-		if provider == "" || baseURL == "" || apiKey == "" {
-			return nil, fmt.Errorf("请填写完整配置")
-		}
-		if f.settingsCallbacks.LLMSetConfig != nil {
-			if err := f.settingsCallbacks.LLMSetConfig(senderID, provider, baseURL, apiKey, model, 0, ""); err != nil {
-				return nil, fmt.Errorf("保存失败: %v", err)
-			}
-		}
-		if thinkingMode != "" && f.settingsCallbacks.LLMSetThinkingMode != nil {
-			if err := f.settingsCallbacks.LLMSetThinkingMode(senderID, thinkingMode); err != nil {
-				log.WithError(err).Warn("HandleSettingsAction: failed to set thinking_mode")
-			}
-		}
-		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
-
 	case "settings_set_thinking_mode":
 		mode := parsed["mode"]
 		if mode == "" {
@@ -223,14 +202,6 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 		if f.settingsCallbacks.LLMSetThinkingMode != nil {
 			if err := f.settingsCallbacks.LLMSetThinkingMode(senderID, mode); err != nil {
 				return nil, fmt.Errorf("设置思考模式失败: %v", err)
-			}
-		}
-		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
-
-	case "settings_delete_llm":
-		if f.settingsCallbacks.LLMDelete != nil {
-			if err := f.settingsCallbacks.LLMDelete(senderID); err != nil {
-				return nil, fmt.Errorf("删除失败: %v", err)
 			}
 		}
 		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
@@ -1071,124 +1042,11 @@ func (f *FeishuChannel) buildAddSubscriptionCard(senderID string) (map[string]an
 func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID string) []map[string]any {
 	var elements []map[string]any
 
-	hasCustom := false
-	var cfgProvider, cfgBaseURL, cfgModel string
-	if f.settingsCallbacks.LLMGetConfig != nil {
-		var ok bool
-		cfgProvider, cfgBaseURL, cfgModel, ok = f.settingsCallbacks.LLMGetConfig(senderID)
-		hasCustom = ok
-	}
-
-	if !hasCustom {
-		// No custom LLM — show setup form
-		elements = append(elements, map[string]any{
-			"tag":     "markdown",
-			"content": "**配置个人模型**",
-		})
-		elements = append(elements, map[string]any{
-			"tag":     "markdown",
-			"content": "当前使用系统默认模型，配置个人 LLM 后可自由选择模型。",
-		})
-
-		formElements := []map[string]any{
-			{
-				"tag":  "select_static",
-				"name": "provider",
-				"placeholder": map[string]any{
-					"tag":     "plain_text",
-					"content": "选择 Provider",
-				},
-				"options": []map[string]any{
-					{"text": map[string]any{"tag": "plain_text", "content": "OpenAI（含兼容 API）"}, "value": "openai"},
-					{"text": map[string]any{"tag": "plain_text", "content": "Anthropic"}, "value": "anthropic"},
-				},
-			},
-			{
-				"tag":  "input",
-				"name": "base_url",
-				"label": map[string]any{
-					"tag":     "plain_text",
-					"content": "API 地址",
-				},
-				"placeholder": map[string]any{
-					"tag":     "plain_text",
-					"content": "https://api.openai.com/v1",
-				},
-			},
-			{
-				"tag":  "input",
-				"name": "api_key",
-				"label": map[string]any{
-					"tag":     "plain_text",
-					"content": "API Key",
-				},
-				"placeholder": map[string]any{
-					"tag":     "plain_text",
-					"content": "sk-...",
-				},
-			},
-			{
-				"tag":  "input",
-				"name": "model",
-				"label": map[string]any{
-					"tag":     "plain_text",
-					"content": "模型名称（可选，保存后可从列表选择）",
-				},
-				"placeholder": map[string]any{
-					"tag":     "plain_text",
-					"content": "gpt-4o",
-				},
-			},
-			{
-				"tag":  "select_static",
-				"name": "thinking_mode",
-				"placeholder": map[string]any{
-					"tag":     "plain_text",
-					"content": "思考模式（可选）",
-				},
-				"options": thinkingModeOptions(),
-			},
-			{
-				"tag":         "button",
-				"name":        "llm_submit",
-				"text":        map[string]any{"tag": "plain_text", "content": "保存配置"},
-				"type":        "primary",
-				"action_type": "form_submit",
-				"value": map[string]string{
-					"action_data": mustMapToJSON(map[string]string{
-						"action": "settings_set_llm",
-					}),
-				},
-			},
-		}
-
-		elements = append(elements, map[string]any{
-			"tag":      "form",
-			"name":     "llm_setup_form",
-			"elements": formElements,
-		})
-
-		return elements
-	}
-
-	// Has custom LLM — show config info + model switch + delete
-	elements = append(elements, map[string]any{
-		"tag":     "markdown",
-		"content": "**个人模型配置**",
-	})
-
-	elements = append(elements, map[string]any{
-		"tag":     "markdown",
-		"content": fmt.Sprintf("Provider：**%s**\nAPI 地址：**%s**", cfgProvider, cfgBaseURL),
-	})
-
+	// --- Quick model switch (for active subscription) ---
 	var models []string
-	currentModel := cfgModel
+	currentModel := ""
 	if f.settingsCallbacks.LLMList != nil {
 		models, currentModel = f.settingsCallbacks.LLMList(senderID)
-	}
-	if currentModel == "" {
-		currentModel = cfgModel
 	}
 
 	maxModels := 30
@@ -1221,11 +1079,6 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 				},
 			},
 		))
-	} else {
-		elements = append(elements, map[string]any{
-			"tag":     "markdown",
-			"content": fmt.Sprintf("当前模型：**%s**", currentModel),
-		})
 	}
 
 	// Max context setting
@@ -1437,21 +1290,6 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 			},
 		})
 	}
-
-	elements = append(elements, map[string]any{"tag": "hr"})
-	elements = append(elements, map[string]any{
-		"tag": "button",
-		"text": map[string]any{
-			"tag":     "plain_text",
-			"content": "🗑️ 删除个人配置，恢复系统默认",
-		},
-		"type": "danger",
-		"value": map[string]string{
-			"action_data": mustMapToJSON(map[string]string{
-				"action": "settings_delete_llm",
-			}),
-		},
-	})
 
 	return elements
 }

--- a/channel/feishu_settings_test.go
+++ b/channel/feishu_settings_test.go
@@ -335,122 +335,11 @@ func TestHandleApprovalCardAction_RejectsWrongUser(t *testing.T) {
 	}
 }
 
-func TestBuildSettingsCard_ModelTab_NoCustomLLM(t *testing.T) {
-	f := newTestFeishuChannel()
-	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "", "", "", false
-		},
-	})
-
-	card, err := f.BuildSettingsCard(context.Background(), "user1", "chat1", "model")
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	s := cardJSON(card)
-
-	if !cardContainsTag(card, "form") {
-		t.Error("should show setup form when no custom LLM")
-	}
-	if !strings.Contains(s, "配置个人模型") {
-		t.Error("should show setup title")
-	}
-	if strings.Contains(s, "/set-llm") {
-		t.Error("should NOT show command instructions")
-	}
-
-	selects := collectSelectsFromCard(card)
-	for _, ad := range selects {
-		if strings.Contains(ad, "settings_set_model") {
-			t.Error("should NOT have model switcher without custom LLM")
-		}
-	}
-}
-
-func TestBuildSettingsCard_ModelTab_WithCustomLLM(t *testing.T) {
-	f := newTestFeishuChannel()
-	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "openai", "https://api.example.com/v1", "gpt-4", true
-		},
-		LLMList: func(senderID string) ([]string, string) {
-			return []string{"gpt-4", "claude-3"}, "gpt-4"
-		},
-	})
-
-	card, err := f.BuildSettingsCard(context.Background(), "user1", "chat1", "model")
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	s := cardJSON(card)
-
-	if strings.Contains(s, "api_key") || strings.Contains(s, "sk-") {
-		t.Error("API key must NEVER appear in card")
-	}
-	if !strings.Contains(s, "openai") {
-		t.Error("should show provider")
-	}
-	if !strings.Contains(s, "api.example.com") {
-		t.Error("should show base URL")
-	}
-
-	selects := collectSelectsFromCard(card)
-	hasModel := false
-	for _, ad := range selects {
-		if strings.Contains(ad, "settings_set_model") {
-			hasModel = true
-		}
-	}
-	if !hasModel {
-		t.Error("should have model select when custom LLM configured")
-	}
-
-	var buttons []string
-	elements, _ := getCardElements(card)
-	collectInteractiveRecursive(elements, &buttons, nil)
-	hasDelete := false
-	for _, ad := range buttons {
-		if strings.Contains(ad, "settings_delete_llm") {
-			hasDelete = true
-		}
-	}
-	if !hasDelete {
-		t.Error("should have delete button when custom LLM configured")
-	}
-}
-
-func TestBuildSettingsCard_ModelTab_NoAPIKeyExposed(t *testing.T) {
-	f := newTestFeishuChannel()
-	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "openai", "https://api.openai.com/v1", "gpt-4o", true
-		},
-		LLMList: func(senderID string) ([]string, string) {
-			return []string{"gpt-4o"}, "gpt-4o"
-		},
-	})
-
-	card, err := f.BuildSettingsCard(context.Background(), "user1", "chat1", "model")
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-
-	s := cardJSON(card)
-	if strings.Contains(s, "api_key") || strings.Contains(s, "API Key") {
-		t.Error("API key field should not appear in existing config display")
-	}
-}
-
 func TestHandleSettingsAction_SetModel(t *testing.T) {
 	f := newTestFeishuChannel()
 	var setModel string
 	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMSet: func(senderID, model string) error { setModel = model; return nil },
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "openai", "https://api.openai.com/v1", "claude-3", true
-		},
+		LLMSet:  func(senderID, model string) error { setModel = model; return nil },
 		LLMList: func(senderID string) ([]string, string) { return []string{"gpt-4", "claude-3"}, "claude-3" },
 	})
 
@@ -467,80 +356,6 @@ func TestHandleSettingsAction_SetModel(t *testing.T) {
 	}
 	if setModel != "claude-3" {
 		t.Errorf("expected model=claude-3, got %q", setModel)
-	}
-}
-
-func TestHandleSettingsAction_SetLLM(t *testing.T) {
-	f := newTestFeishuChannel()
-	var gotProvider, gotURL, gotKey, gotModel string
-	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMSetConfig: func(senderID, provider, baseURL, apiKey, model string, maxOutputTokens int, thinkingMode string) error {
-			gotProvider = provider
-			gotURL = baseURL
-			gotKey = apiKey
-			gotModel = model
-			return nil
-		},
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return gotProvider, gotURL, gotModel, gotProvider != ""
-		},
-	})
-
-	actionData := map[string]any{
-		"action_data": `{"action":"settings_set_llm"}`,
-		"provider":    "openai",
-		"base_url":    "https://api.openai.com/v1",
-		"api_key":     "sk-test123",
-		"model":       "gpt-4o",
-	}
-	card, err := f.HandleSettingsAction(context.Background(), actionData, "user1", "chat1", "msg1")
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-	if card == nil {
-		t.Fatal("expected card")
-	}
-	if gotProvider != "openai" || gotURL != "https://api.openai.com/v1" || gotKey != "sk-test123" || gotModel != "gpt-4o" {
-		t.Errorf("unexpected config: provider=%q url=%q key=%q model=%q", gotProvider, gotURL, gotKey, gotModel)
-	}
-}
-
-func TestHandleSettingsAction_SetLLM_MissingFields(t *testing.T) {
-	f := newTestFeishuChannel()
-	f.SetSettingsCallbacks(SettingsCallbacks{})
-
-	actionData := map[string]any{
-		"action_data": `{"action":"settings_set_llm"}`,
-		"provider":    "openai",
-	}
-	_, err := f.HandleSettingsAction(context.Background(), actionData, "user1", "chat1", "msg1")
-	if err == nil {
-		t.Error("should fail with missing required fields")
-	}
-}
-
-func TestHandleSettingsAction_DeleteLLM(t *testing.T) {
-	f := newTestFeishuChannel()
-	deleted := false
-	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMDelete: func(senderID string) error { deleted = true; return nil },
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "", "", "", false
-		},
-	})
-
-	actionData := map[string]any{
-		"action_data": `{"action":"settings_delete_llm"}`,
-	}
-	card, err := f.HandleSettingsAction(context.Background(), actionData, "user1", "chat1", "msg1")
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-	if card == nil {
-		t.Fatal("expected card")
-	}
-	if !deleted {
-		t.Error("LLMDelete should have been called")
 	}
 }
 
@@ -1145,10 +960,7 @@ func TestSettingsCard_NoUnsupportedV2Tags(t *testing.T) {
 	f := newTestFeishuChannel()
 	f.SetSettingsCallbacks(SettingsCallbacks{
 		ContextModeGet: func() string { return "phase1" },
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "openai", "https://api.openai.com/v1", "gpt-4", true
-		},
-		LLMList: func(senderID string) ([]string, string) { return []string{"gpt-4"}, "gpt-4" },
+		LLMList:        func(senderID string) ([]string, string) { return []string{"gpt-4"}, "gpt-4" },
 		RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
 			return []sqlite.SharedEntry{{ID: 1, Name: "test"}}, nil
 		},
@@ -1175,9 +987,6 @@ func TestSettingsCard_NoCommandReferences(t *testing.T) {
 	f := newTestFeishuChannel()
 	f.SetSettingsCallbacks(SettingsCallbacks{
 		ContextModeGet: func() string { return "phase1" },
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "", "", "", false
-		},
 		RegistryBrowse: func(entryType string, limit, offset int) ([]sqlite.SharedEntry, error) {
 			return nil, nil
 		},
@@ -1259,9 +1068,6 @@ func TestHandleSettingsAction_SetConcurrency_Error(t *testing.T) {
 func TestBuildSettingsCard_ModelTab_WithConcurrency(t *testing.T) {
 	f := newTestFeishuChannel()
 	f.SetSettingsCallbacks(SettingsCallbacks{
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return "openai", "https://api.example.com/v1", "gpt-4", true
-		},
 		LLMList: func(senderID string) ([]string, string) {
 			return []string{"gpt-4", "gpt-4o"}, "gpt-4"
 		},

--- a/main.go
+++ b/main.go
@@ -276,29 +276,6 @@ func buildWebCallbacks(cfg *config.Config, agentLoop *agent.Agent) channel.WebCa
 		LLMSet: func(senderID, model string) error {
 			return agentLoop.SetUserModel(senderID, model)
 		},
-		LLMGetConfig: func(senderID string) (string, string, string, bool) {
-			return agentLoop.GetUserLLMConfig(senderID)
-		},
-		IsProcessing: agentLoop.IsProcessing,
-		LLMSetConfig: func(senderID, provider, baseURL, apiKey, model string, maxOutputTokens int, thinkingMode string) error {
-			if err := agentLoop.SetUserLLM(senderID, provider, baseURL, apiKey, model); err != nil {
-				return err
-			}
-			if maxOutputTokens > 0 {
-				if err := agentLoop.SetUserMaxOutputTokens(senderID, maxOutputTokens); err != nil {
-					log.WithError(err).WithField("sender_id", senderID).Warn("failed to set user max output tokens")
-				}
-			}
-			if thinkingMode != "" {
-				if err := agentLoop.SetUserThinkingMode(senderID, thinkingMode); err != nil {
-					log.WithError(err).WithField("sender_id", senderID).Warn("failed to set user thinking mode")
-				}
-			}
-			return nil
-		},
-		LLMDelete: func(senderID string) error {
-			return agentLoop.DeleteUserLLM(senderID)
-		},
 		LLMGetMaxContext: func(senderID string) int {
 			return agentLoop.GetUserMaxContext(senderID)
 		},
@@ -646,28 +623,6 @@ func main() {
 			},
 			LLMSet: func(senderID, model string) error {
 				return agentLoop.SetUserModel(senderID, model)
-			},
-			LLMGetConfig: func(senderID string) (string, string, string, bool) {
-				return agentLoop.GetUserLLMConfig(senderID)
-			},
-			LLMSetConfig: func(senderID, provider, baseURL, apiKey, model string, maxOutputTokens int, thinkingMode string) error {
-				if err := agentLoop.SetUserLLM(senderID, provider, baseURL, apiKey, model); err != nil {
-					return err
-				}
-				if maxOutputTokens > 0 {
-					if err := agentLoop.SetUserMaxOutputTokens(senderID, maxOutputTokens); err != nil {
-						log.WithError(err).WithField("sender_id", senderID).Warn("failed to set user max output tokens")
-					}
-				}
-				if thinkingMode != "" {
-					if err := agentLoop.SetUserThinkingMode(senderID, thinkingMode); err != nil {
-						log.WithError(err).WithField("sender_id", senderID).Warn("failed to set user thinking mode")
-					}
-				}
-				return nil
-			},
-			LLMDelete: func(senderID string) error {
-				return agentLoop.DeleteUserLLM(senderID)
 			},
 			LLMGetMaxContext: func(senderID string) int {
 				return agentLoop.GetUserMaxContext(senderID)


### PR DESCRIPTION
## Root Cause

`buildModelTabContent` had an early return (L1171) when user had no legacy LLM config. This prevented the subscription management section (L1367+) from ever rendering — users without a legacy config saw only the old setup form and could never access subscription management.

## Changes

- **Remove legacy single-sub panel**: setup form, config info display, "删除个人配置" button
- **Remove `settings_set_llm` / `settings_delete_llm`** action handlers
- **Remove `LLMGetConfig`/`LLMSetConfig`/`LLMDelete`** wiring from Feishu SettingsCallbacks
- **Keep**: quick model switch, per-user settings (max context, output tokens, concurrency, thinking mode), subscription management (now always visible)
- **Tests**: removed 6 legacy tests, fixed `TestHandleSettingsAction_SetModel`

## Verification
- `go test ./...` — all pass
- `golangci-lint run ./...` — zero issues
- Pre-push hooks: fmt, vet, lint, build, test — all green
