### PR TITLE
fix: SQLite time.Scan errors across all storage files

### DIFF
--- a/storage/sqlite/db.go
+++ b/storage/sqlite/db.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	log "xbot/logger"
 
@@ -113,4 +114,23 @@ func (db *DB) initSchema() error {
 		return db.migrateSchema(version)
 	}
 	return nil
+}
+
+// parseSQLiteTime parses a time string from SQLite into time.Time.
+// SQLite datetime('now') produces "2006-01-02 15:04:05" format,
+// but some code may store RFC3339. This function tries both formats.
+func parseSQLiteTime(s string) time.Time {
+	for _, layout := range []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02T15:04:05.999999999",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }

--- a/storage/sqlite/tenant.go
+++ b/storage/sqlite/tenant.go
@@ -107,9 +107,12 @@ func (s *TenantService) ListTenants() ([]TenantInfo, error) {
 	var tenants []TenantInfo
 	for rows.Next() {
 		var t TenantInfo
-		if err := rows.Scan(&t.ID, &t.Channel, &t.ChatID, &t.CreatedAt, &t.LastActiveAt); err != nil {
+		var createdAt, lastActiveAt string
+		if err := rows.Scan(&t.ID, &t.Channel, &t.ChatID, &createdAt, &lastActiveAt); err != nil {
 			return nil, fmt.Errorf("scan tenant: %w", err)
 		}
+		t.CreatedAt = parseSQLiteTime(createdAt)
+		t.LastActiveAt = parseSQLiteTime(lastActiveAt)
 		tenants = append(tenants, t)
 	}
 	if err := rows.Err(); err != nil {

--- a/storage/sqlite/user_llm_config.go
+++ b/storage/sqlite/user_llm_config.go
@@ -38,13 +38,13 @@ func (s *UserLLMConfigService) GetConfig(senderID string) (*UserLLMConfig, error
 	conn := s.db.Conn()
 
 	var cfg UserLLMConfig
-	var createdAt, updatedAt sql.NullTime
+	var createdAt, updatedAt string
 	err := conn.QueryRow(`
-			SELECT sender_id, provider, base_url, api_key, model, max_context, max_output_tokens, thinking_mode, created_at, updated_at
-			FROM user_llm_subscriptions
-			WHERE sender_id = ? AND is_default = 1
-			LIMIT 1
-		`, senderID).Scan(
+				SELECT sender_id, provider, base_url, api_key, model, max_context, max_output_tokens, thinking_mode, created_at, updated_at
+				FROM user_llm_subscriptions
+				WHERE sender_id = ? AND is_default = 1
+				LIMIT 1
+			`, senderID).Scan(
 		&cfg.SenderID, &cfg.Provider, &cfg.BaseURL, &cfg.APIKey, &cfg.Model,
 		&cfg.MaxContext, &cfg.MaxOutputTokens, &cfg.ThinkingMode,
 		&createdAt, &updatedAt,
@@ -57,12 +57,8 @@ func (s *UserLLMConfigService) GetConfig(senderID string) (*UserLLMConfig, error
 		return nil, fmt.Errorf("query user llm config: %w", err)
 	}
 
-	if createdAt.Valid {
-		cfg.CreatedAt = createdAt.Time
-	}
-	if updatedAt.Valid {
-		cfg.UpdatedAt = updatedAt.Time
-	}
+	cfg.CreatedAt = parseSQLiteTime(createdAt)
+	cfg.UpdatedAt = parseSQLiteTime(updatedAt)
 
 	// Decrypt API key
 	if cfg.APIKey != "" {

--- a/storage/sqlite/user_llm_subscription.go
+++ b/storage/sqlite/user_llm_subscription.go
@@ -48,16 +48,8 @@ func scanSubscription(scanner interface{ Scan(...interface{}) error }, sub *LLMS
 		return "", 0, err
 	}
 	sub.IsDefault = isDefault == 1
-	if t, err := time.Parse(time.RFC3339, createdAt); err == nil {
-		sub.CreatedAt = t
-	} else if t, err := time.Parse("2006-01-02 15:04:05", createdAt); err == nil {
-		sub.CreatedAt = t
-	}
-	if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
-		sub.UpdatedAt = t
-	} else if t, err := time.Parse("2006-01-02 15:04:05", updatedAt); err == nil {
-		sub.UpdatedAt = t
-	}
+	sub.CreatedAt = parseSQLiteTime(createdAt)
+	sub.UpdatedAt = parseSQLiteTime(updatedAt)
 	return encryptedAPIKey, isDefault, nil
 }
 


### PR DESCRIPTION
## Summary

Fix all remaining SQLite `time.Scan` errors across the storage layer. The previous fix (#442) only addressed `user_llm_subscription.go`, but the same pattern exists in `user_llm_config.go` and `tenant.go`.

## Root Cause

`modernc.org/sqlite` stores `datetime('now')` columns as `TEXT`. Direct `Scan()` into `time.Time` or `sql.NullTime` fails with:

```
unsupported Scan, storing driver.Value type string into type *time.Time
```

## Changes

| File | Change |
|------|--------|
| `db.go` | Add `parseSQLiteTime()` — public helper that tries RFC3339, RFC3339Nano, `2006-01-02 15:04:05`, and other common SQLite datetime formats |
| `user_llm_config.go` | Replace `sql.NullTime` with string scan + `parseSQLiteTime()` |
| `tenant.go` | Replace direct `time.Time` scan with string scan + `parseSQLiteTime()` |
| `user_llm_subscription.go` | Simplify `scanSubscription()` to use `parseSQLiteTime()` instead of inline format attempts |

## Files with time.Time Scan patterns (status)

| File | Status |
|------|--------|
| `user_llm_subscription.go` | ✅ Fixed in #442, simplified here |
| `user_llm_config.go` | ✅ Fixed here |
| `tenant.go` | ✅ Fixed here |
| `cron.go` | ✅ Already correct (scans to string, then time.Parse) |
| `trigger.go` | ✅ Already correct (scans to string, then parseTriggerTimes) |
| `session.go` | ✅ Already correct (scans to string) |

## Test

- ✅ `go build ./...`
- ✅ `go test ./storage/sqlite/...` all pass (15.3s)
- ✅ `gofmt` clean
- ✅ `go vet` clean
- ✅ `golangci-lint` 0 issues