### PR TITLE
fix: add missing schema 2.0 to add-subscription card (error 200830)

### DIFF
--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -1016,6 +1016,7 @@ func (f *FeishuChannel) buildAddSubscriptionCard(senderID string) (map[string]an
 	}
 
 	return map[string]any{
+		"schema": "2.0",
 		"config": map[string]any{
 			"wide_screen_mode": true,
 		},


### PR DESCRIPTION
## Summary

Fix Feishu error **200830** when clicking "添加订阅" in the settings panel.

## Root Cause

Feishu error code 200830: *"JSON 2.0 结构的卡片无法更新为 JSON 1.0 结构卡片"*

The main settings card uses `"schema": "2.0"` (JSON 2.0), but `buildAddSubscriptionCard()` was missing this field, returning a JSON 1.0 card. When the callback response replaces the card, Feishu rejects the downgrade from 2.0 → 1.0.

## Fix

Add missing `"schema": "2.0"` to `buildAddSubscriptionCard()` return value.

## Verification

- ✅ `go build ./...`
- ✅ `gofmt` clean