### PR TITLE
fix: wrap add-subscription card elements in body for JSON 2.0

### DIFF
--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -1026,15 +1026,17 @@ func (f *FeishuChannel) buildAddSubscriptionCard(senderID string) (map[string]an
 				"content": "➕ 添加订阅",
 			},
 		},
-		"elements": []map[string]any{
-			{
-				"tag":     "markdown",
-				"content": "填写 LLM 订阅信息。添加后可在设置页切换活跃订阅。",
-			},
-			{
-				"tag":      "form",
-				"name":     "add_subscription_form",
-				"elements": formElements,
+		"body": map[string]any{
+			"elements": []map[string]any{
+				{
+					"tag":     "markdown",
+					"content": "填写 LLM 订阅信息。添加后可在设置页切换活跃订阅。",
+				},
+				{
+					"tag":      "form",
+					"name":     "add_subscription_form",
+					"elements": formElements,
+				},
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Summary

Fix "添加订阅" card disappearing after clicking the button.

## Root Cause

Feishu JSON 2.0 cards require elements inside a `body` wrapper:

```json
{ "body": { "elements": [...] } }
```

But `buildAddSubscriptionCard` was using the JSON 1.0 structure:

```json
{ "elements": [...] }
```

Feishu silently rejected the malformed 2.0 card, causing it to disappear.

## Fix

Wrap elements in `"body": {"elements": [...]}` to match JSON 2.0 spec, consistent with `BuildSettingsCard`, `buildDangerConfirmCard`, and `buildDangerResultCard`.

## Verification

- ✅ `go build ./...`
- ✅ `gofmt` clean