### PR TITLE
fix: 13 columns but 12 placeholders in subscription INSERT

### DIFF
--- a/storage/sqlite/user_llm_subscription.go
+++ b/storage/sqlite/user_llm_subscription.go
@@ -174,7 +174,7 @@ func (s *LLMSubscriptionService) Add(sub *LLMSubscription) error {
 	}
 	_, err = tx.Exec(`
 		INSERT INTO user_llm_subscriptions (id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sub.ID, sub.SenderID, sub.Name, sub.Provider, sub.BaseURL, encryptedAPIKey, sub.Model, isDefault, sub.MaxContext, sub.MaxOutputTokens, sub.ThinkingMode, now, now)
 	if err != nil {
 		return fmt.Errorf("insert subscription: %w", err)


### PR DESCRIPTION
## Summary

Fix "12 values for 13 columns" error when saving a new subscription via Feishu settings.

## Root Cause

`user_llm_subscription.go` Add() method: INSERT statement declares 13 columns but VALUES has only 12 `?` placeholders.

```sql
-- Before (broken): 13 columns, 12 placeholders
INSERT INTO user_llm_subscriptions (id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, created_at, updated_at)
VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  -- ← missing one ?
```

## Fix

Add the missing 13th `?` placeholder.

## Full Audit

All other INSERT/UPDATE statements in the codebase were audited — no mismatches found:

| File | Table | Cols | Placeholders | Status |
|------|-------|------|-------------|--------|
| cron.go | cron_jobs | 13 | 13 | ✅ |
| trigger.go | event_triggers | 13 | 13 | ✅ |
| session.go | session_messages | 11 | 11 | ✅ |
| user_llm_config.go | user_llm_subscriptions | 13 | 12 + 1 hardcoded | ✅ |
| user_llm_subscription.go | user_llm_subscriptions | 13 | **12** | ❌ **fixed** |
| user_settings.go | user_settings | 5 | 5 | ✅ |
| user_profile.go | user_profiles | 3 | 3 | ✅ |
| registry.go | shared_registry | 9 | 9 | ✅ |
| user_token_usage.go | user_token_usage | 8 | 7 + 1 CURRENT_TIMESTAMP | ✅ |
| user_token_usage.go | daily_token_usage | 9 | 8 + 1 CURRENT_TIMESTAMP | ✅ |
| memory.go | long_term_memory | 2 | 2 | ✅ |
| core_memory.go | core_memory_blocks | 5 | 5 | ✅ |

## Verification

- ✅ `go build ./...`
- ✅ `go test ./storage/sqlite/...` all pass
- ✅ `gofmt` clean