### PR TITLE
feat: add Windows support for xbot-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,33 @@ jobs:
         with:
           name: coverage
           path: coverage.out
+
+  build-windows:
+    name: Build (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Build CLI binary
+        run: go build -v -o xbot-cli.exe ./cmd/xbot-cli
+
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    needs: [build-windows]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Test
+        run: go test -v -race ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,20 +31,16 @@ jobs:
           mkdir -p dist
 
           # Matrix: OS x ARCH
-          for os in linux darwin; do
+          for os in linux darwin windows; do
             for arch in amd64 arm64; do
-              suffix=""
-              if [ "$os" = "darwin" ]; then
-                suffix=""
-              fi
-              binary="xbot-cli"
+              ext=""
               if [ "$os" = "windows" ]; then
-                binary="xbot-cli.exe"
+                ext=".exe"
               fi
               echo "Building $os/$arch..."
               CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build \
                 -ldflags "$LDFLAGS" \
-                -o "dist/xbot-cli-${os}-${arch}" \
+                -o "dist/xbot-cli-${os}-${arch}${ext}" \
                 ./cmd/xbot-cli
             done
           done
@@ -63,4 +59,6 @@ jobs:
             dist/xbot-cli-linux-arm64
             dist/xbot-cli-darwin-amd64
             dist/xbot-cli-darwin-arm64
+            dist/xbot-cli-windows-amd64.exe
+            dist/xbot-cli-windows-arm64.exe
             checksums.txt

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ xbot is a Go framework for building AI agents. It provides a message bus + plugi
 Channel → Bus → Agent → LLM ↔ Tools → Bus → Channel
 ```
 
-Designed for self-hosted deployments. Supports **OpenAI** and **Anthropic** as native LLM providers, plus any OpenAI-compatible API (DeepSeek, Qwen, Ollama, etc.) via the `openai` provider with a custom `base_url`.
+Designed for self-hosted deployments. Cross-platform: Linux, macOS, and Windows (none sandbox with PowerShell). Supports **OpenAI** and **Anthropic** as native LLM providers, plus any OpenAI-compatible API (DeepSeek, Qwen, Ollama, etc.) via the `openai` provider with a custom `base_url`.
 
 ## Quick Start
 
 ### Install CLI
 
 ```bash
-# Linux / macOS (amd64, arm64) — installs xbot-cli only
+# Linux / macOS (amd64, arm64)
 curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash
 
 # Specific version
@@ -25,6 +25,17 @@ VERSION=v0.0.7 curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scr
 
 # Custom install path (default: /usr/local/bin)
 INSTALL_PATH=~/.local/bin curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+
+# Specific version
+.\install.ps1 -Version v0.0.7
+
+# Custom install path (default: ~/.local/bin)
+.\install.ps1 -InstallPath C:\Tools
 ```
 
 ### Build from Source
@@ -166,7 +177,7 @@ Browser-based chat with optional login, invite-only mode, and persona isolation.
 
 Built-in tools the agent can call during a conversation:
 
-- **Shell** — Execute commands in sandbox (Docker / remote / none)
+- **Shell** — Execute commands in sandbox (Docker / remote / none; Windows PowerShell supported in none mode)
 - **File I/O** — Read, write, Glob, Grep with workspace isolation
 - **Web** — Fetch pages, Tavily web search
 - **Context** — Edit conversation context mid-session

--- a/docs-site/content/channels/cli.md
+++ b/docs-site/content/channels/cli.md
@@ -26,6 +26,22 @@ CLI Channel 是 xbot 的默认渠道，允许用户直接在终端中与 AI Agen
 
 ## 安装与启动
 
+### 一键安装
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+```
+
+安装脚本会自动检测平台并下载对应版本。也支持从 [GitHub Releases](https://github.com/CjiW/xbot/releases) 手动下载。
+
+> **Windows 用户**：安装后如需使用 Shell 工具，建议使用 Windows Terminal 以获得最佳体验。Shell 工具在 none 沙箱模式下使用 PowerShell。
+
 ### 编译
 
 ```bash

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+    xbot-cli installer for Windows
+.DESCRIPTION
+    Downloads and installs xbot-cli from GitHub Releases.
+.PARAMETER Version
+    Specific version to install (defaults to latest release).
+.PARAMETER InstallPath
+    Installation directory (defaults to $env:USERPROFILE\.local\bin).
+.EXAMPLE
+    irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+.EXAMPLE
+    .\install.ps1 -Version v0.1.0
+.EXAMPLE
+    .\install.ps1 -InstallPath C:\Tools
+#>
+
+param(
+    [string]$Version = "",
+    [string]$InstallPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$REPO = "CjiW/xbot"
+$BINARY = "xbot-cli.exe"
+
+if (-not $InstallPath) {
+    $InstallPath = Join-Path $env:USERPROFILE ".local\bin"
+}
+
+# --- Detect platform ---
+function Get-Platform {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { return "windows-amd64" }
+        "ARM64" { return "windows-arm64" }
+        default { Write-Error "Unsupported architecture: $arch. Only AMD64 and ARM64 are supported."; exit 1 }
+    }
+}
+
+# --- Resolve version ---
+function Get-LatestVersion {
+    if ($Version) { return $Version }
+
+    try {
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers @{"User-Agent"="PowerShell"}
+        return $response.tag_name
+    } catch {
+        Write-Error "Failed to determine latest version. Set -Version explicitly, e.g.: .\install.ps1 -Version v0.1.0"
+        exit 1
+    }
+}
+
+# --- Main ---
+Write-Host ""
+Write-Host "  =======================================" -ForegroundColor Cyan
+Write-Host "         xbot-cli Installer (Windows)" -ForegroundColor Cyan
+Write-Host "  =======================================" -ForegroundColor Cyan
+Write-Host ""
+
+$platform = Get-Platform
+$tag = Get-LatestVersion
+$downloadUrl = "https://github.com/$REPO/releases/download/$tag/xbot-cli-$platform.exe"
+
+Write-Host "[INFO] Platform:  $platform" -ForegroundColor Green
+Write-Host "[INFO] Version:   $tag" -ForegroundColor Green
+Write-Host "[INFO] URL:       $downloadUrl" -ForegroundColor Green
+Write-Host "[INFO] Install:   $InstallPath\$BINARY" -ForegroundColor Green
+Write-Host ""
+
+# Create install directory
+if (-not (Test-Path $InstallPath)) {
+    New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
+    Write-Host "[INFO] Created directory: $InstallPath" -ForegroundColor Green
+}
+
+# Download
+Write-Host "[INFO] Downloading..." -ForegroundColor Green
+$tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-cli-download.exe"
+
+try {
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
+} catch {
+    Write-Error "Download failed: $_"
+    exit 1
+}
+
+# Verify checksum if possible
+$checksumUrl = "https://github.com/$REPO/releases/download/$tag/checksums.txt"
+try {
+    $checksumFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-checksums.txt"
+    Invoke-WebRequest -Uri $checksumUrl -OutFile $checksumFile -UseBasicParsing
+    $expectedLine = Get-Content $checksumFile | Where-Object { $_ -match "xbot-cli-$platform" }
+    if ($expectedLine) {
+        $expectedHash = ($expectedLine -split "\s+")[0]
+        $actualHash = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash.ToLower()
+        if ($expectedHash -ne $actualHash) {
+            Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+            Write-Error "Checksum mismatch! Expected: $expectedHash, Got: $actualHash"
+            exit 1
+        }
+        Write-Host "[INFO] Checksum verified" -ForegroundColor Green
+    }
+    Remove-Item $checksumFile -Force -ErrorAction SilentlyContinue
+} catch {
+    Write-Host "[WARN] Checksum verification skipped" -ForegroundColor Yellow
+}
+
+# Install
+Copy-Item $tmpFile (Join-Path $InstallPath $BINARY) -Force
+Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+
+Write-Host ""
+Write-Host "[OK] xbot-cli $tag installed to $InstallPath\$BINARY" -ForegroundColor Green
+Write-Host ""
+
+# Add to PATH if not already there
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$InstallPath*") {
+    [Environment]::SetEnvironmentVariable("Path", "$userPath;$InstallPath", "User")
+    $env:Path = "$env:Path;$InstallPath"
+    Write-Host "[INFO] Added $InstallPath to user PATH" -ForegroundColor Green
+    Write-Host "[INFO] Please restart your terminal for PATH changes to take effect." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "  Run 'xbot-cli' to start." -ForegroundColor Green
+Write-Host "  Project:  https://github.com/$REPO" -ForegroundColor DarkGray
+Write-Host "  License:  MIT" -ForegroundColor DarkGray
+Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ detect_platform() {
     case "$os" in
         linux)  ;;
         darwin) ;;
-        *)      error "Unsupported OS: $os. xbot-cli only supports Linux and macOS." ;;
+        *)      error "Unsupported OS: $os. Use the PowerShell installer on Windows: irm https://raw.githubusercontent.com/${REPO}/master/scripts/install.ps1 | iex" ;;
     esac
 
     case "$arch" in


### PR DESCRIPTION
## Summary

Add full Windows support for xbot-cli (none sandbox mode with PowerShell).

## Changes

### New: PowerShell install script
- `scripts/install.ps1` — one-liner install via `irm ... | iex`
- Auto-detects platform (amd64/arm64), downloads from GitHub Releases
- SHA256 checksum verification, auto-adds to user PATH

### CI: Windows build + test
- Add `build-windows` and `test-windows` jobs to CI (`windows-latest` runner)

### Release: Windows binaries
- Add `windows-amd64` and `windows-arm64` builds to release workflow
- Uploads `.exe` artifacts to GitHub Releases

### Docs
- README: add Windows PowerShell install command, note cross-platform support
- docs-site CLI page: add installation section with Linux/macOS/Windows instructions
- `install.sh`: error message now points Windows users to PowerShell script

## Verification
- [x] `go build ./...` pass
- [x] `go vet ./...` pass
- [x] `golangci-lint` pass
- [x] `go test ./...` pass (all packages)
- [x] Cross-compile `GOOS=windows amd64+arm64` pass