### PR TITLE
fix: kill process group before closing pipes in TestExecKeepAlive_ChildHoldsPipeOpen

### DIFF
--- a/tools/none_sandbox_test.go
+++ b/tools/none_sandbox_test.go
@@ -47,7 +47,11 @@ func TestExecKeepAlive_ChildHoldsPipeOpen(t *testing.T) {
 	go capture(&stdoutBuf, stdoutPipe)
 	go capture(&stderrBuf, stderrPipe)
 
-	// Use cmd.Process.Wait() + close pipes approach
+	// Use cmd.Process.Wait() + kill process group + close pipes approach.
+	// After the direct child exits, grandchild processes (e.g. "sleep 300 &")
+	// may still hold pipe FDs open. We must kill the entire process group
+	// before closing pipes, otherwise Read() in capture goroutines never
+	// returns EOF and wg.Wait() hangs.
 	waitCh := make(chan int, 1)
 	go func() {
 		state, err := cmd.Process.Wait()
@@ -55,6 +59,8 @@ func TestExecKeepAlive_ChildHoldsPipeOpen(t *testing.T) {
 		if err == nil && state != nil {
 			code = extractExitCodeFromState(state)
 		}
+		// Kill the entire process group to release pipe FDs held by grandchildren
+		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		stdoutPipe.Close()
 		stderrPipe.Close()
 		wg.Wait()


### PR DESCRIPTION
## Summary

Fix `TestExecKeepAlive_ChildHoldsPipeOpen` hang under race detector / CI.

## Root Cause

After `cmd.Process.Wait()` returns, grandchild processes spawned by the shell (e.g. `sleep 300 &` from `(sleep 300 &); echo done`) still hold pipe FDs open. Simply closing the read end of the pipe does **not** cause `Read()` in capture goroutines to return EOF, because the write end is still open in the grandchild.

Under `-race`, the timing changes enough that `closePipes()` happens before the background `sleep` exits, causing `wg.Wait()` to hang forever → test timeout.

## Fix

Add `syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)` to kill the entire process group **before** closing pipes. This matches the pattern used in `execKeepAlive()` production code (`none_sandbox.go`).

## Changes

| File | Change |
|------|--------|
| `tools/none_sandbox_test.go` | Kill process group before closing pipes in `TestExecKeepAlive_ChildHoldsPipeOpen` |

## Test

```
go test -v -race -run 'TestExecKeepAlive' -timeout 60s ./tools/
--- PASS: TestExecKeepAlive_ChildHoldsPipeOpen (0.00s)
--- PASS: TestExecKeepAlive_ContextCancel (0.10s)
```