### PR TITLE
fix: skill-creator and agent-creator point to correct runtime directory

### DIFF
--- a/tools/embed_skills/agent-creator/SKILL.md
+++ b/tools/embed_skills/agent-creator/SKILL.md
@@ -18,7 +18,9 @@ Ask the user:
 
 ### Step 2: Create Agent File
 
-Create `agents/{agent-name}.md` in the workspace root. This is the user's personal agents directory — files here are loaded automatically and override same-name global agents.
+**IMPORTANT**: Create agent files in the correct agents directory, NOT in the current working directory. The correct path follows the same pattern as the system prompt's **"Skills 存储目录"** but with `agents` instead of `skills`. For example, if Skills 存储目录 is `/opt/xbot/.xbot/skills`, then agents go in `/opt/xbot/.xbot/agents/{agent-name}.md`.
+
+To find the correct path, check the system prompt's `Available Agents` section, or derive it from `Skill(name=agent-creator, action=list_files)` — replace `skills` with `agents` in the parent path.
 
 Agent definition uses YAML frontmatter + Markdown body:
 

--- a/tools/embed_skills/skill-creator/SKILL.md
+++ b/tools/embed_skills/skill-creator/SKILL.md
@@ -16,7 +16,11 @@ skills/{skill-name}/
 └── assets/               # Optional: templates, config files
 ```
 
-Create skills under `skills/` in the working directory. The `Skill` tool auto-discovers them by name.
+**IMPORTANT**: Create skills under the directory shown in the system prompt's **"Skills 存储目录"** line (e.g. `/opt/xbot/.xbot/skills/`). Do NOT use the current working directory or project root — the running xbot instance only scans its configured skills directory.
+
+To find the correct path, look at the system prompt section `# Available Skills` → `**Skills 存储目录**`.
+
+Alternatively, use `Skill(name=skill-creator, action=list_files)` to get this skill's own directory, then derive the parent as the skills root.
 
 ## Lifecycle
 


### PR DESCRIPTION
## Problem

When using skill-creator or agent-creator in a deployed xbot instance, created skills/agents were placed in the current working directory (e.g. `/root/xbot/.xbot/skills/`), but the running xbot only scans its configured `SkillsDir` (e.g. `/opt/xbot/.xbot/skills/`). This made created skills/agents invisible to the `Skill` tool.

## Root Cause

Both embedded creators instructed the LLM to create files in `skills/` or `agents/` relative to the working directory, without clarifying that the correct path is the runtime-configured SkillsDir shown in the system prompt.

## Fix

Updated both `skill-creator/SKILL.md` and `agent-creator/SKILL.md` to:

1. **Instruct LLM to use the system prompt's "Skills 存储目录" path** instead of assuming the current directory
2. **Provide a fallback** via `Skill(action=list_files)` to derive the correct path dynamically
3. **Add prominent warnings** that the working/project directory is NOT the right place

## Files Changed

| File | Change |
|------|--------|
| `tools/embed_skills/skill-creator/SKILL.md` | Point to runtime Skills 存储目录 instead of working directory |
| `tools/embed_skills/agent-creator/SKILL.md` | Point to runtime agents directory instead of working directory |