### PR TITLE
feat: model tier system (Vanguard/Balance/Swift) + AskUser panel improvements

### DIFF
--- a/agent/llm_factory.go
+++ b/agent/llm_factory.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"xbot/config"
 	"xbot/llm"
 	"xbot/storage/sqlite"
 )
@@ -18,6 +19,7 @@ type LLMFactory struct {
 	defaultLLM          llm.LLM
 	defaultModel        string
 	defaultThinkingMode string
+	tierModels          config.LLMConfig
 
 	// LLMSemaphoreManager 管理 per-tenant LLM 并发信号量
 	llmSemManager *llm.LLMSemaphoreManager
@@ -48,6 +50,13 @@ func NewLLMFactory(configSvc *sqlite.UserLLMConfigService, defaultLLM llm.LLM, d
 		thinkingModes:   make(map[string]string),
 		// hasCustomLLMCache 使用零值 sync.Map，无需初始化
 	}
+}
+
+// SetModelTiers updates the configured tier-to-model mappings used by SubAgent model resolution.
+func (f *LLMFactory) SetModelTiers(cfg config.LLMConfig) {
+	f.mu.Lock()
+	f.tierModels = cfg
+	f.mu.Unlock()
 }
 
 // GetLLM 获取用户的 LLM 客户端，如果没有自定义配置则返回默认客户端
@@ -330,6 +339,36 @@ func (f *LLMFactory) ListModels() []string {
 	return f.defaultLLM.ListModels()
 }
 
+// ListAllModelsForUser returns model names from the default LLM plus all subscription
+// Model fields for a given user. Used for global tier settings where the user should
+// see models across all their subscriptions.
+func (f *LLMFactory) ListAllModelsForUser(senderID string) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	// Default LLM models
+	for _, m := range f.defaultLLM.ListModels() {
+		if !seen[m] {
+			seen[m] = true
+			result = append(result, m)
+		}
+	}
+
+	// All subscription model fields (no API calls, just DB records)
+	if f.subscriptionSvc != nil && senderID != "" {
+		if subs, err := f.subscriptionSvc.List(senderID); err == nil {
+			for _, sub := range subs {
+				if sub.Model != "" && !seen[sub.Model] {
+					seen[sub.Model] = true
+					result = append(result, sub.Model)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
 // GetLLMConcurrency 读取用户配置的个人 LLM 并发上限。
 // 未配置时使用默认值 DefaultLLMConcurrencyPersonal。
 func (f *LLMFactory) GetLLMConcurrency(senderID string) int {
@@ -434,60 +473,60 @@ func (f *LLMFactory) GetMaxOutputTokens(senderID string) int {
 //
 // 返回: (LLM客户端, 实际模型名, maxContext, thinkingMode, 是否使用了非默认模型)
 func (f *LLMFactory) GetLLMForModel(senderID, targetModel string) (llm.LLM, string, int, string, bool) {
-	if targetModel == "" || f.subscriptionSvc == nil {
-		// 无指定模型或无订阅服务 → 使用默认
+	resolvedModel, _ := f.resolveTierModel(targetModel)
+	if resolvedModel == "" {
+		// 无指定模型 → 使用默认
 		client, model, maxCtx, tm := f.GetLLM(senderID)
 		return client, model, maxCtx, tm, false
 	}
 
-	subs, err := f.subscriptionSvc.List(senderID)
-	if err != nil || len(subs) == 0 {
-		// 无订阅 → fallback 到默认
-		client, model, maxCtx, tm := f.GetLLM(senderID)
-		return client, model, maxCtx, tm, false
-	}
+	// Tier resolved or explicit model name specified — try subscription matching first
+	if f.subscriptionSvc != nil {
+		subs, err := f.subscriptionSvc.List(senderID)
+		if err == nil && len(subs) > 0 {
+			// 1. 精确匹配：订阅的 Model 字段 == resolvedModel
+			for _, sub := range subs {
+				if sub.Model == resolvedModel {
+					client := f.createClientFromSub(sub, resolvedModel)
+					if client != nil {
+						return client, resolvedModel, sub.MaxContext, sub.ThinkingMode, true
+					}
+				}
+			}
 
-	// 1. 精确匹配：订阅的 Model 字段 == targetModel
-	for _, sub := range subs {
-		if sub.Model == targetModel {
-			client := f.createClientFromSub(sub, targetModel)
-			if client != nil {
-				return client, targetModel, sub.MaxContext, sub.ThinkingMode, true
+			// 2. 使用活跃订阅的凭证 + resolvedModel
+			activeSub, err := f.subscriptionSvc.GetDefault(senderID)
+			if err == nil && activeSub != nil {
+				client := f.createClientFromSub(activeSub, resolvedModel)
+				if client != nil {
+					return client, resolvedModel, activeSub.MaxContext, activeSub.ThinkingMode, true
+				}
+			}
+
+			// 3. Provider 匹配：找 provider 能服务该模型的订阅
+			provider := guessProvider(resolvedModel)
+			for _, sub := range subs {
+				if provider != "" && sub.Provider == provider {
+					client := f.createClientFromSub(sub, resolvedModel)
+					if client != nil {
+						return client, resolvedModel, sub.MaxContext, sub.ThinkingMode, true
+					}
+				}
+			}
+
+			// 4. 任意可用订阅
+			for _, sub := range subs {
+				client := f.createClientFromSub(sub, resolvedModel)
+				if client != nil {
+					return client, resolvedModel, sub.MaxContext, sub.ThinkingMode, true
+				}
 			}
 		}
 	}
 
-	// 2. 使用活跃订阅的凭证 + targetModel
-	activeSub, err := f.subscriptionSvc.GetDefault(senderID)
-	if err == nil && activeSub != nil {
-		client := f.createClientFromSub(activeSub, targetModel)
-		if client != nil {
-			return client, targetModel, activeSub.MaxContext, activeSub.ThinkingMode, true
-		}
-	}
-
-	// 3. Provider 匹配：找 provider 能服务该模型的订阅
-	provider := guessProvider(targetModel)
-	for _, sub := range subs {
-		if provider != "" && sub.Provider == provider {
-			client := f.createClientFromSub(sub, targetModel)
-			if client != nil {
-				return client, targetModel, sub.MaxContext, sub.ThinkingMode, true
-			}
-		}
-	}
-
-	// 4. 任意可用订阅
-	for _, sub := range subs {
-		client := f.createClientFromSub(sub, targetModel)
-		if client != nil {
-			return client, targetModel, sub.MaxContext, sub.ThinkingMode, true
-		}
-	}
-
-	// 5. Fallback 到默认
-	client, model, maxCtx, tm := f.GetLLM(senderID)
-	return client, model, maxCtx, tm, false
+	// Fallback: use default client with resolved model name (works for CLI mode without subscriptions)
+	client, _, maxCtx, tm := f.GetLLM(senderID)
+	return client, resolvedModel, maxCtx, tm, true
 }
 
 // createClientFromSub 从订阅创建 LLM 客户端，使用指定的模型名（而非订阅的默认模型）
@@ -504,6 +543,46 @@ func (f *LLMFactory) createClientFromSub(sub *sqlite.LLMSubscription, model stri
 	}
 	client, _ := f.createClient(cfg)
 	return client
+}
+
+func normalizeModelTier(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "vanguard", "strong":
+		return "vanguard"
+	case "balance", "medium":
+		return "balance"
+	case "swift", "weak":
+		return "swift"
+	default:
+		return ""
+	}
+}
+
+func (f *LLMFactory) resolveTierModel(value string) (string, bool) {
+	tier := normalizeModelTier(value)
+	if tier == "" {
+		return value, false
+	}
+
+	f.mu.RLock()
+	tiers := f.tierModels
+	f.mu.RUnlock()
+
+	switch tier {
+	case "vanguard":
+		if strings.TrimSpace(tiers.VanguardModel) != "" {
+			return strings.TrimSpace(tiers.VanguardModel), true
+		}
+	case "balance":
+		if strings.TrimSpace(tiers.BalanceModel) != "" {
+			return strings.TrimSpace(tiers.BalanceModel), true
+		}
+	case "swift":
+		if strings.TrimSpace(tiers.SwiftModel) != "" {
+			return strings.TrimSpace(tiers.SwiftModel), true
+		}
+	}
+	return "", true
 }
 
 // guessProvider 根据模型名猜测 provider。

--- a/agent/llm_factory_test.go
+++ b/agent/llm_factory_test.go
@@ -1,6 +1,10 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"xbot/config"
+)
 
 func TestGuessProvider(t *testing.T) {
 	tests := []struct {
@@ -53,12 +57,149 @@ func TestGetLLMForModel_NilSubscriptionSvc(t *testing.T) {
 	f := NewLLMFactory(nil, nil, "default-model")
 	f.defaultThinkingMode = "auto"
 
-	// No subscriptionSvc → should fallback to default (not panic)
+	// No subscriptionSvc but explicit model → fallback to default client with target model name
 	_, model, _, _, usedCustom := f.GetLLMForModel("user1", "claude-opus-4-20250115")
-	if model != "default-model" {
-		t.Errorf("model = %q, want default-model (fallback when no subscriptionSvc)", model)
+	if model != "claude-opus-4-20250115" {
+		t.Errorf("model = %q, want claude-opus-4-20250115 (fallback uses target model name)", model)
 	}
-	if usedCustom {
-		t.Error("usedCustom should be false when no subscriptionSvc")
+	if !usedCustom {
+		t.Error("usedCustom should be true when target model is specified")
+	}
+}
+
+func TestNormalizeModelTier(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"vanguard", "vanguard"},
+		{"VANGUARD", "vanguard"},
+		{"Vanguard", "vanguard"},
+		{"strong", "vanguard"},
+		{"Strong", "vanguard"},
+		{"balance", "balance"},
+		{"medium", "balance"},
+		{"swift", "swift"},
+		{"weak", "swift"},
+		{"gpt-4o", ""},
+		{"", ""},
+		{"unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeModelTier(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeModelTier(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTierModel(t *testing.T) {
+	f := NewLLMFactory(nil, nil, "default-model")
+
+	// No tiers configured → tier keywords are recognized but model is empty
+	model, usedTier := f.resolveTierModel("vanguard")
+	if !usedTier {
+		t.Error("usedTier should be true (keyword recognized)")
+	}
+	if model != "" {
+		t.Errorf("model = %q, want empty", model)
+	}
+
+	// Non-tier value passes through unchanged
+	model, usedTier = f.resolveTierModel("gpt-4o")
+	if usedTier {
+		t.Error("usedTier should be false for non-tier value")
+	}
+	if model != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", model)
+	}
+
+	// Configure tiers
+	f.SetModelTiers(config.LLMConfig{
+		VanguardModel: "claude-opus-4-20250115",
+		BalanceModel:  "claude-sonnet-4-20250514",
+		SwiftModel:    "gpt-4o-mini",
+	})
+
+	model, usedTier = f.resolveTierModel("vanguard")
+	if !usedTier {
+		t.Error("usedTier should be true")
+	}
+	if model != "claude-opus-4-20250115" {
+		t.Errorf("model = %q, want claude-opus-4-20250115", model)
+	}
+
+	model, usedTier = f.resolveTierModel("balance")
+	if !usedTier {
+		t.Error("usedTier should be true")
+	}
+	if model != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %q, want claude-sonnet-4-20250514", model)
+	}
+
+	model, usedTier = f.resolveTierModel("swift")
+	if !usedTier {
+		t.Error("usedTier should be true")
+	}
+	if model != "gpt-4o-mini" {
+		t.Errorf("model = %q, want gpt-4o-mini", model)
+	}
+
+	// Aliases: strong/medium/weak
+	model, _ = f.resolveTierModel("strong")
+	if model != "claude-opus-4-20250115" {
+		t.Errorf("model = %q, want claude-opus-4-20250115", model)
+	}
+
+	model, _ = f.resolveTierModel("medium")
+	if model != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %q, want claude-sonnet-4-20250514", model)
+	}
+
+	model, _ = f.resolveTierModel("weak")
+	if model != "gpt-4o-mini" {
+		t.Errorf("model = %q, want gpt-4o-mini", model)
+	}
+
+	// Partial config: only vanguard set
+	f.SetModelTiers(config.LLMConfig{
+		VanguardModel: "opus",
+	})
+	model, usedTier = f.resolveTierModel("balance")
+	if !usedTier {
+		t.Error("usedTier should be true even for unconfigured tier")
+	}
+	if model != "" {
+		t.Errorf("model = %q, want empty for unconfigured tier", model)
+	}
+}
+
+func TestGetLLMForModel_TierResolution(t *testing.T) {
+	f := NewLLMFactory(nil, nil, "default-model")
+	f.defaultThinkingMode = "auto"
+
+	// Tier with no subscriptionSvc → fallback to default client with resolved model name
+	f.SetModelTiers(config.LLMConfig{
+		VanguardModel: "claude-opus-4-20250115",
+	})
+
+	// Without subscriptionSvc, tier resolves and uses default client with resolved name
+	_, model, _, _, usedCustom := f.GetLLMForModel("user1", "vanguard")
+	if !usedCustom {
+		t.Error("usedCustom should be true for tier resolution")
+	}
+	if model != "claude-opus-4-20250115" {
+		t.Errorf("model = %q, want claude-opus-4-20250115", model)
+	}
+
+	// Non-tier model with no subscriptionSvc → fallback to default client with target model
+	_, model, _, _, usedCustom = f.GetLLMForModel("user1", "gpt-4o")
+	if !usedCustom {
+		t.Error("usedCustom should be true when target model is specified")
+	}
+	if model != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", model)
 	}
 }

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -28,28 +28,29 @@ func (m *cliModel) invalidateAllCache(updateViewport bool) {
 
 // toggleToolSummary toggles the tool-summary expanded state,
 // invalidates all cached rendering, clears cachedHistory, and refreshes the viewport.
-// It preserves the viewport scroll position so Ctrl+O doesn't cause a jarring jump.
+// It preserves the viewport scroll position anchored to the first visible message,
+// so Ctrl+O doesn't cause a jarring jump when tool summary lines change.
 func (m *cliModel) toggleToolSummary() {
-	// Save current scroll position (the first visible line).
+	// Find the first visible message index before toggling.
 	prevYOffset := m.viewport.YOffset()
 	prevAtBottom := m.viewport.AtBottom()
+	anchorMsgIdx := -1
+	if !prevAtBottom && len(m.msgLineOffsets) > 0 {
+		for i := len(m.msgLineOffsets) - 1; i >= 0; i-- {
+			if m.msgLineOffsets[i] <= prevYOffset {
+				anchorMsgIdx = i
+				break
+			}
+		}
+	}
 
 	m.toolSummaryExpanded = !m.toolSummaryExpanded
 	m.cachedHistory = ""
 	m.invalidateAllCache(true)
 
-	// Restore scroll position. After toggle, content height changes (tool summary
-	// lines expand/collapse), so we need to clamp to the new valid range.
-	// If the user was at the bottom, keep them at the bottom.
-	if !prevAtBottom {
-		maxOff := m.viewport.TotalLineCount() - m.viewport.Height()
-		if maxOff < 0 {
-			maxOff = 0
-		}
-		if prevYOffset > maxOff {
-			prevYOffset = maxOff
-		}
-		m.viewport.SetYOffset(prevYOffset)
+	// Restore scroll position anchored to the same message.
+	if !prevAtBottom && anchorMsgIdx >= 0 && anchorMsgIdx < len(m.msgLineOffsets) {
+		m.viewport.SetYOffset(m.msgLineOffsets[anchorMsgIdx])
 	}
 }
 
@@ -281,7 +282,7 @@ func (m *cliModel) clampPanelScroll(rawContent string) {
 // The visible height depends on viewport height + fixed chrome, not panelVisibleHeight().
 func (m *cliModel) clampAskUserPanelScroll(rawContent string) {
 	total := strings.Count(rawContent, "\n") + 1
-	fixedLines := 3 // titleBar + footer + toast
+	fixedLines := 2 // titleBar + toast (no separate footer — hints are in-panel)
 	panelBorder := 2
 	viewportH := m.layoutViewportHeight()
 	visible := m.height - fixedLines - viewportH - panelBorder
@@ -291,6 +292,11 @@ func (m *cliModel) clampAskUserPanelScroll(rawContent string) {
 	if total <= visible {
 		m.askPanelScrollY = 0
 		return
+	}
+	// When content overflows, default to showing the bottom (hints) rather than the top.
+	// Only respect user's explicit scroll position if they've scrolled away from default.
+	if m.askPanelScrollY == 0 {
+		m.askPanelScrollY = total - visible
 	}
 	if m.askPanelScrollY < 0 {
 		m.askPanelScrollY = 0
@@ -302,7 +308,7 @@ func (m *cliModel) clampAskUserPanelScroll(rawContent string) {
 
 // askUserPanelVisibleHeight returns how many lines the askuser panel can display.
 func (m *cliModel) askUserPanelVisibleHeight() int {
-	fixedLines := 3
+	fixedLines := 2 // titleBar + toast (no separate footer — hints are in-panel)
 	panelBorder := 2
 	viewportH := m.layoutViewportHeight()
 	visible := m.height - fixedLines - viewportH - panelBorder

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -28,10 +28,92 @@ func (m *cliModel) invalidateAllCache(updateViewport bool) {
 
 // toggleToolSummary toggles the tool-summary expanded state,
 // invalidates all cached rendering, clears cachedHistory, and refreshes the viewport.
+// It preserves the viewport scroll position so Ctrl+O doesn't cause a jarring jump.
 func (m *cliModel) toggleToolSummary() {
+	// Save current scroll position (the first visible line).
+	prevYOffset := m.viewport.YOffset()
+	prevAtBottom := m.viewport.AtBottom()
+
 	m.toolSummaryExpanded = !m.toolSummaryExpanded
 	m.cachedHistory = ""
 	m.invalidateAllCache(true)
+
+	// Restore scroll position. After toggle, content height changes (tool summary
+	// lines expand/collapse), so we need to clamp to the new valid range.
+	// If the user was at the bottom, keep them at the bottom.
+	if !prevAtBottom {
+		maxOff := m.viewport.TotalLineCount() - m.viewport.Height()
+		if maxOff < 0 {
+			maxOff = 0
+		}
+		if prevYOffset > maxOff {
+			prevYOffset = maxOff
+		}
+		m.viewport.SetYOffset(prevYOffset)
+	}
+}
+
+// openSettingsFromQuickSwitch restores the settings panel after a subscription quick switch.
+// The subscription generation guard (in onSubmit) prevents stale LLM fields from being
+// written back. Here we only need to refresh LLM display values from the new active
+// subscription and preserve global settings from the backup.
+func (m *cliModel) openSettingsFromQuickSwitch() {
+	if m.channel == nil || len(m.panelValuesBackup) == 0 {
+		return
+	}
+	schema := m.channel.SettingsSchema()
+	if len(schema) == 0 {
+		return
+	}
+	// Refresh model list options in the schema (subscription change may affect available models)
+	if m.channel.modelLister != nil {
+		allModels := m.channel.modelLister.ListAllModels()
+		for i, s := range schema {
+			if (s.Key == "llm_model" || s.Key == "vanguard_model" || s.Key == "balance_model" || s.Key == "swift_model") && len(allModels) > 0 {
+				opts := make([]SettingOption, len(allModels))
+				for j, ml := range allModels {
+					opts[j] = SettingOption{Label: ml, Value: ml}
+				}
+				schema[i].Options = opts
+			}
+		}
+	}
+	// Re-read ALL values fresh (including LLM fields from new active subscription)
+	values := make(map[string]string)
+	if m.channel.config.GetCurrentValues != nil {
+		for k, v := range m.channel.config.GetCurrentValues() {
+			values[k] = v
+		}
+	}
+	if m.channel.settingsSvc != nil {
+		vals, err := m.channel.settingsSvc.GetSettings(m.channelName, m.senderID)
+		if err == nil {
+			for k, v := range vals {
+				switch k {
+				case "llm_provider", "llm_model", "llm_base_url", "llm_api_key", "vanguard_model", "balance_model", "swift_model":
+					continue
+				}
+				values[k] = v
+			}
+		}
+	}
+	// Overlay non-LLM settings from backup (preserves user's in-memory edits for global settings)
+	perSubKeys := map[string]bool{
+		"llm_provider": true, "llm_api_key": true, "llm_model": true, "llm_base_url": true,
+	}
+	for k, v := range m.panelValuesBackup {
+		if !perSubKeys[k] {
+			values[k] = v
+		}
+	}
+	cursor := m.panelCursorBackup
+	onSubmit := m.panelOnSubmitBackup
+	// Clear backup
+	m.panelValuesBackup = nil
+	m.panelOnSubmitBackup = nil
+	// Open panel with restored state
+	m.openSettingsPanel(schema, values, onSubmit)
+	m.panelCursor = cursor
 }
 
 // startAgentTurn transitions the model into the "agent processing" state:

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -277,6 +277,60 @@ func (m *cliModel) clampPanelScroll(rawContent string) {
 	}
 }
 
+// clampAskUserPanelScroll adjusts askPanelScrollY for the askuser split layout.
+// The visible height depends on viewport height + fixed chrome, not panelVisibleHeight().
+func (m *cliModel) clampAskUserPanelScroll(rawContent string) {
+	total := strings.Count(rawContent, "\n") + 1
+	fixedLines := 3 // titleBar + footer + toast
+	panelBorder := 2
+	viewportH := m.layoutViewportHeight()
+	visible := m.height - fixedLines - viewportH - panelBorder
+	if visible < 3 {
+		visible = 3
+	}
+	if total <= visible {
+		m.askPanelScrollY = 0
+		return
+	}
+	if m.askPanelScrollY < 0 {
+		m.askPanelScrollY = 0
+	}
+	if m.askPanelScrollY > total-visible {
+		m.askPanelScrollY = total - visible
+	}
+}
+
+// askUserPanelVisibleHeight returns how many lines the askuser panel can display.
+func (m *cliModel) askUserPanelVisibleHeight() int {
+	fixedLines := 3
+	panelBorder := 2
+	viewportH := m.layoutViewportHeight()
+	visible := m.height - fixedLines - viewportH - panelBorder
+	if visible < 3 {
+		return 3
+	}
+	return visible
+}
+
+// ensureAskPanelCursorVisible scrolls the askuser panel so the current cursor line is visible.
+func (m *cliModel) ensureAskPanelCursorVisible() {
+	// The cursor is at approximately: tab bar (1-2 lines) + question (1) + gap (1) + cursor position
+	lineOfCursor := 2 // question + gap
+	if m.panelTab > 0 {
+		lineOfCursor = 2 // tab bar + gap
+	}
+	cursor := m.panelOptCursor[m.panelTab]
+	lineOfCursor += cursor + 1 // +1 for the option line itself
+
+	visible := m.askUserPanelVisibleHeight()
+	if m.askPanelScrollY+visible <= lineOfCursor {
+		m.askPanelScrollY = lineOfCursor - visible + 1
+	}
+	if m.askPanelScrollY > lineOfCursor {
+		m.askPanelScrollY = lineOfCursor
+	}
+}
+
 // applyLanguageChange applies a language/locale change and invalidates cache.
 // Uses setLocale() instead of SetLocale() to avoid sending on localeChangeCh,
 // which would cause a redundant fullRebuild in the next Update cycle.

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -333,7 +333,7 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 						for k, v := range vals {
 							// Skip LLM fields — they come from config (single source of truth)
 							switch k {
-							case "llm_provider", "llm_model", "llm_base_url", "llm_api_key":
+							case "llm_provider", "llm_model", "llm_base_url", "llm_api_key", "vanguard_model", "balance_model", "swift_model":
 								continue
 							}
 							currentValues[k] = v
@@ -341,26 +341,38 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 					}
 				}
 				// Inject model list into combo options
+				// ALL model dropdowns (llm_model + tiers) use ListAllModels() which includes
+				// default LLM models + all subscription Model fields, so newly added
+				// subscriptions are always visible without restart.
 				if m.channel.modelLister != nil {
-					models := m.channel.modelLister.ListModels()
+					allModels := m.channel.modelLister.ListAllModels()
 					for i, s := range schema {
-						if s.Key == "llm_model" && len(models) > 0 {
-							opts := make([]SettingOption, len(models))
-							for j, m := range models {
-								opts[j] = SettingOption{Label: m, Value: m}
+						if (s.Key == "llm_model" || s.Key == "vanguard_model" || s.Key == "balance_model" || s.Key == "swift_model") && len(allModels) > 0 {
+							opts := make([]SettingOption, len(allModels))
+							for j, ml := range allModels {
+								opts[j] = SettingOption{Label: ml, Value: ml}
 							}
 							schema[i].Options = opts
-							break
 						}
 					}
 				}
 				m.openSettingsPanel(schema, currentValues, func(values map[string]string) {
+					// --- Subscription generation guard ---
+					// If the active subscription changed since this panel was opened,
+					// the per-subscription LLM fields (provider/key/model/base_url) are STALE
+					// and must NOT be written back — they would overwrite the new subscription.
+					// This is the structural guarantee against subscription data corruption.
+					if m.panelSubGeneration != m.subGeneration {
+						for _, k := range []string{"llm_provider", "llm_model", "llm_base_url", "llm_api_key"} {
+							delete(values, k)
+						}
+					}
 					// Persist non-LLM settings to SettingsService (SQLite).
 					// LLM settings go only to config.json (single source of truth).
 					if m.channel.settingsSvc != nil {
 						for k, v := range values {
 							switch k {
-							case "llm_provider", "llm_model", "llm_base_url", "llm_api_key":
+							case "llm_provider", "llm_model", "llm_base_url", "llm_api_key", "vanguard_model", "balance_model", "swift_model":
 								continue
 							}
 							_ = m.channel.settingsSvc.SetSetting(m.channelName, m.senderID, k, v)

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -282,13 +282,14 @@ type cliModel struct {
 	panelCursorBackup   int                            // saved panelCursor before quick switch
 	panelOnSubmitBackup func(values map[string]string) // saved onSubmit callback
 	// --- AskUser panel ---
-	panelItems     []askItem            // askuser panel: question items
-	panelTab       int                  // askuser panel: current tab (question index)
-	panelOptSel    map[int]map[int]bool // askuser panel: selected option indices per question
-	panelOptCursor map[int]int          // askuser panel: highlighted option index per question
-	panelAnswerTA  textarea.Model       // askuser panel: free-input editor (no-options mode)
-	panelOtherTI   textinput.Model      // askuser panel: single-line Other input
-	panelSchema    []SettingDefinition  // settings panel: schema copy
+	panelItems      []askItem            // askuser panel: question items
+	panelTab        int                  // askuser panel: current tab (question index)
+	panelOptSel     map[int]map[int]bool // askuser panel: selected option indices per question
+	panelOptCursor  map[int]int          // askuser panel: highlighted option index per question
+	panelAnswerTA   textarea.Model       // askuser panel: free-input editor (no-options mode)
+	panelOtherTI    textinput.Model      // askuser panel: single-line Other input
+	askPanelScrollY int                  // askuser panel: internal scroll offset for long content
+	panelSchema     []SettingDefinition  // settings panel: schema copy
 	// --- Approval panel ---
 	approvalRequest      *tools.ApprovalRequest // pending approval request
 	approvalResultCh     chan<- tools.ApprovalResult

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -277,6 +277,10 @@ type cliModel struct {
 	panelEditTA   textarea.Model // settings panel: inline editor
 	panelCombo    bool           // settings panel: combo dropdown open
 	panelComboIdx int            // settings panel: combo selected option index
+	// --- Panel state backup (for quick switch round-trip) ---
+	panelValuesBackup   map[string]string              // saved panelValues before quick switch
+	panelCursorBackup   int                            // saved panelCursor before quick switch
+	panelOnSubmitBackup func(values map[string]string) // saved onSubmit callback
 	// --- AskUser panel ---
 	panelItems     []askItem            // askuser panel: question items
 	panelTab       int                  // askuser panel: current tab (question index)
@@ -322,11 +326,20 @@ type cliModel struct {
 	checkingUpdate       bool                // true while /update is in progress
 
 	// --- §15 Subscription / Model Quick Switch ---
-	quickSwitchMode   string              // ""=off, "subscription"=selecting subscription, "model"=selecting model
-	quickSwitchList   []Subscription      // available subscriptions or models
-	quickSwitchCursor int                 // selected index
-	subscriptionMgr   SubscriptionManager // injected by CLIChannel
-	llmSubscriber     LLMSubscriber       // injected by CLIChannel
+	quickSwitchMode          string              // ""=off, "subscription"=selecting subscription, "model"=selecting model
+	quickSwitchList          []Subscription      // available subscriptions or models
+	quickSwitchCursor        int                 // selected index
+	quickSwitchReturnToPanel bool                // true = return to settings panel after switch completes
+	subscriptionMgr          SubscriptionManager // injected by CLIChannel
+	llmSubscriber            LLMSubscriber       // injected by CLIChannel
+
+	// --- §16 Subscription generation guard ---
+	// subGeneration increments every time the active subscription actually changes.
+	// panelSubGeneration captures the generation when the settings panel opens.
+	// ApplySettings REFUSES to write per-subscription LLM fields if generations don't match.
+	// This is the structural guarantee against stale LLM values overwriting a new subscription.
+	subGeneration      int
+	panelSubGeneration int
 
 	// --- §14 Splash 画面 ---
 	splashDone  bool // true = splash 动画结束，进入正常界面

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -868,6 +868,24 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 
 	// Panel-internal scroll for long content (PgUp/PgDn)
 	switch {
+	case msg.String() == "ctrl+o":
+		// §11 Ctrl+O toggles tool summary expand/collapse — must work in askuser mode too
+		m.toggleToolSummary()
+		return true, m, nil
+	case msg.Code == tea.KeyHome:
+		// Home/End jump to top/bottom of viewport (iteration history above the panel)
+		m.viewport.GotoTop()
+		return true, m, nil
+	case msg.Code == tea.KeyEnd:
+		m.viewport.GotoBottom()
+		m.newContentHint = false
+		return true, m, nil
+	case msg.String() == "shift+up":
+		m.viewport.ScrollUp(1)
+		return true, m, nil
+	case msg.String() == "shift+down":
+		m.viewport.ScrollDown(1)
+		return true, m, nil
 	case msg.String() == "pgup":
 		m.askPanelScrollY -= 5
 		if m.askPanelScrollY < 0 {
@@ -1469,7 +1487,7 @@ func (m *cliModel) viewAskUserPanel() string {
 			hints = append(hints, m.locale.PanelAskNewline)
 		}
 	}
-	hints = append(hints, m.locale.PanelAskCancel)
+	hints = append(hints, "Shift+↑↓ scroll history", "Ctrl+O expand tools", m.locale.PanelAskCancel)
 	sb.WriteString(hintStyle.Render("  " + strings.Join(hints, " · ")))
 
 	return sb.String()

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -29,6 +29,7 @@ func (m *cliModel) openSettingsPanel(schema []SettingDefinition, values map[stri
 	m.panelCursor = 0
 	m.panelEdit = false
 	m.panelScrollY = 0
+	m.panelSubGeneration = m.subGeneration // capture current subscription generation
 	m.panelSchema = make([]SettingDefinition, len(schema))
 	copy(m.panelSchema, schema)
 	m.panelValues = make(map[string]string, len(values))
@@ -787,10 +788,18 @@ func (m *cliModel) updateSettingsPanel(msg tea.KeyPressMsg) (bool, tea.Model, te
 				m.openDangerPanelFromSettings()
 				return true, m, nil
 			}
-			// Subscription management entry — close settings, open quick switch
+			// Subscription management entry — save panel state, open quick switch
 			if def.Key == "subscription_manage" {
+				// Backup current panel state so we can restore after quick switch
+				m.panelValuesBackup = make(map[string]string, len(m.panelValues))
+				for k, v := range m.panelValues {
+					m.panelValuesBackup[k] = v
+				}
+				m.panelCursorBackup = m.panelCursor
+				m.panelOnSubmitBackup = m.panelOnSubmit
 				m.panelMode = ""
 				m.relayoutViewport()
+				m.quickSwitchReturnToPanel = true
 				m.openQuickSwitch("subscription")
 				return true, m, nil
 			}
@@ -1624,6 +1633,7 @@ func (m *cliModel) applyQuickSwitch() {
 		if m.llmSubscriber != nil {
 			m.llmSubscriber.SwitchModel(m.senderID, selected.Model)
 			m.cachedModelName = selected.Model
+			m.subGeneration++ // model switch also changes effective subscription state
 			// Update quickSwitchList so the panel reflects the new model
 			m.updateQuickSwitchModels(selected.Model)
 			m.showTempStatus(fmt.Sprintf("Model switched to: %s", selected.Model))
@@ -1661,6 +1671,37 @@ func (m *cliModel) renameQuickSwitchEntry() {
 			}
 		}
 	})
+}
+
+// deleteQuickSwitchEntry deletes the selected subscription (with confirmation if it's active).
+func (m *cliModel) deleteQuickSwitchEntry() {
+	if m.quickSwitchCursor >= len(m.quickSwitchList) {
+		return
+	}
+	selected := m.quickSwitchList[m.quickSwitchCursor]
+	if selected.ID == "__add__" {
+		return
+	}
+	if m.subscriptionMgr == nil {
+		return
+	}
+	// Don't allow deleting the active subscription without a fallback
+	subs, err := m.subscriptionMgr.List("")
+	if err != nil || len(subs) <= 1 {
+		m.showTempStatus("Cannot delete the last subscription")
+		return
+	}
+	if selected.Active {
+		m.showTempStatus("Cannot delete active subscription — switch to another first")
+		return
+	}
+	if err := m.subscriptionMgr.Remove(selected.ID); err != nil {
+		m.showTempStatus(fmt.Sprintf("Failed to delete: %v", err))
+		return
+	}
+	m.showTempStatus(fmt.Sprintf("Deleted: %s", selected.Name))
+	// Refresh the list
+	m.openQuickSwitch(m.quickSwitchMode)
 }
 
 // updateQuickSwitchModels updates the model field in quickSwitchList for the active subscription.
@@ -1721,7 +1762,7 @@ func (m *cliModel) viewQuickSwitch(width, height int) string {
 	box := m.styles.PanelBox.Render(panelContent)
 
 	// Hint line below the box
-	hint := m.styles.PanelHint.Render(" ↑↓ Navigate  Enter Select  E Rename  Esc Close")
+	hint := m.styles.PanelHint.Render(" ↑↓ Navigate  Enter Select  E Rename  D Delete  Esc Close")
 
 	// Center vertically
 	listH := len(m.quickSwitchList) + 3 // header + spacer + items + borders(~2)
@@ -1746,7 +1787,12 @@ func (m *cliModel) handleQuickSwitchKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	}
 	switch msg.Code {
 	case tea.KeyEsc:
+		returnToSettings := m.quickSwitchReturnToPanel
+		m.quickSwitchReturnToPanel = false
 		m.quickSwitchMode = ""
+		if returnToSettings {
+			m.openSettingsFromQuickSwitch()
+		}
 		return true, nil
 	case tea.KeyUp:
 		if m.quickSwitchCursor > 0 {
@@ -1770,6 +1816,11 @@ func (m *cliModel) handleQuickSwitchKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	// E: rename selected subscription
 	if msg.String() == "e" {
 		m.renameQuickSwitchEntry()
+		return true, nil
+	}
+	// D: delete selected subscription
+	if msg.String() == "d" {
+		m.deleteQuickSwitchEntry()
 		return true, nil
 	}
 	return true, nil // block all other keys

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -113,11 +113,12 @@ var dangerConfirmStrings = map[string]string{
 // openAskUserPanel activates the ask-user panel overlay.
 func (m *cliModel) openAskUserPanel(items []askItem, onAnswer func(map[string]string), onCancel func()) {
 	m.panelMode = "askuser"
-	m.relayoutViewport() // 缩小 viewport 为 panel 腾出空间
+	m.relayoutViewport() // viewport gets split-layout height
 	m.panelItems = items
 	m.panelTab = 0
 	m.panelOptSel = make(map[int]map[int]bool)
 	m.panelOptCursor = make(map[int]int)
+	m.askPanelScrollY = 0
 	ta := textarea.New()
 	ta.Placeholder = m.locale.PanelEditPlaceholder
 	ta.Prompt = "  "
@@ -864,6 +865,21 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 	if m.panelTab < 0 || m.panelTab >= len(m.panelItems) {
 		return true, m, nil
 	}
+
+	// Panel-internal scroll for long content (PgUp/PgDn)
+	switch {
+	case msg.String() == "pgup":
+		m.askPanelScrollY -= 5
+		if m.askPanelScrollY < 0 {
+			m.askPanelScrollY = 0
+		}
+		return true, m, nil
+	case msg.String() == "pgdown":
+		m.askPanelScrollY += 5
+		// clamp happens in View via clampAskUserPanelScroll
+		return true, m, nil
+	}
+
 	item := &m.panelItems[m.panelTab]
 	numOpts := len(item.Options)
 	hasOpts := numOpts > 0
@@ -900,11 +916,13 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 		if hasOpts {
 			if onOther {
 				m.panelOptCursor[m.panelTab] = numOpts - 1
+				m.ensureAskPanelCursorVisible()
 				return true, m, nil
 			}
 			if cursor > 0 {
 				m.panelOptCursor[m.panelTab] = cursor - 1
 			}
+			m.ensureAskPanelCursorVisible()
 			return true, m, nil
 		}
 		m.autoExpandAskTA()
@@ -921,11 +939,13 @@ func (m *cliModel) updateAskUserPanel(msg tea.KeyPressMsg) (bool, tea.Model, tea
 				if isLastTab {
 					m.panelOptCursor[m.panelTab] = numOpts + 1
 				}
+				m.ensureAskPanelCursorVisible()
 				return true, m, nil
 			}
 			if cursor < maxCursor {
 				m.panelOptCursor[m.panelTab] = cursor + 1
 			}
+			m.ensureAskPanelCursorVisible()
 			return true, m, nil
 		}
 		m.autoExpandAskTA()

--- a/channel/cli_panel_test.go
+++ b/channel/cli_panel_test.go
@@ -150,6 +150,86 @@ func TestApplyQuickSwitch(t *testing.T) {
 	}
 }
 
+// TestSubscriptionGenerationGuard tests that stale per-subscription LLM values
+// are NEVER written back after a subscription switch. This is the structural guarantee
+// against the subscription overwrite bug.
+func TestSubscriptionGenerationGuard(t *testing.T) {
+	model := newCLIModel()
+	model.subGeneration = 5
+
+	// Simulate: settings panel opens with generation 5
+	model.panelSubGeneration = model.subGeneration
+
+	// Simulate: user edits some values
+	values := map[string]string{
+		"llm_provider":   "openai",
+		"llm_api_key":    "old-key-123",
+		"llm_model":      "gpt-4o",
+		"llm_base_url":   "https://api.openai.com/v1",
+		"vanguard_model": "claude-opus-4",
+		"balance_model":  "claude-sonnet-4",
+		"max_tokens":     "4096",
+	}
+
+	// Simulate: subscription switch happens (generation increments)
+	model.subGeneration = 6
+
+	// Simulate: the onSubmit callback runs (this is what the guard checks)
+	// After switch, stale LLM fields should be stripped
+	if model.panelSubGeneration != model.subGeneration {
+		for _, k := range []string{"llm_provider", "llm_model", "llm_base_url", "llm_api_key"} {
+			delete(values, k)
+		}
+	}
+
+	// Verify: per-subscription LLM fields are GONE
+	for _, k := range []string{"llm_provider", "llm_api_key", "llm_model", "llm_base_url"} {
+		if _, exists := values[k]; exists {
+			t.Errorf("BUG: stale LLM field %q should have been deleted after subscription switch", k)
+		}
+	}
+
+	// Verify: global/tier settings are PRESERVED
+	if values["vanguard_model"] != "claude-opus-4" {
+		t.Errorf("global setting vanguard_model should be preserved, got %q", values["vanguard_model"])
+	}
+	if values["balance_model"] != "claude-sonnet-4" {
+		t.Errorf("global setting balance_model should be preserved, got %q", values["balance_model"])
+	}
+	if values["max_tokens"] != "4096" {
+		t.Errorf("global setting max_tokens should be preserved, got %q", values["max_tokens"])
+	}
+}
+
+// TestSubscriptionGenerationGuardNoSwitch tests that when subscription does NOT change,
+// all LLM fields are preserved (no false positives).
+func TestSubscriptionGenerationGuardNoSwitch(t *testing.T) {
+	model := newCLIModel()
+	model.subGeneration = 5
+	model.panelSubGeneration = 5 // same generation = no switch
+
+	values := map[string]string{
+		"llm_provider": "anthropic",
+		"llm_api_key":  "key-456",
+		"llm_model":    "claude-sonnet-4",
+		"llm_base_url": "https://api.anthropic.com",
+	}
+
+	// Guard should NOT strip anything
+	if model.panelSubGeneration != model.subGeneration {
+		for _, k := range []string{"llm_provider", "llm_model", "llm_base_url", "llm_api_key"} {
+			delete(values, k)
+		}
+	}
+
+	// All fields should still be present
+	for _, k := range []string{"llm_provider", "llm_api_key", "llm_model", "llm_base_url"} {
+		if _, exists := values[k]; !exists {
+			t.Errorf("LLM field %q should NOT be deleted when subscription hasn't changed", k)
+		}
+	}
+}
+
 // TestApplyQuickSwitchNilChannel tests that nil channel doesn't crash.
 func TestApplyQuickSwitchNilChannel(t *testing.T) {
 	mgr := &mockSubscriptionManager{

--- a/channel/cli_theme.go
+++ b/channel/cli_theme.go
@@ -562,9 +562,14 @@ func (m *cliModel) newPanelTextArea(value string, width, height int) textarea.Mo
 	return ta
 }
 
-// ApplyTheme 切换当前配色方案。支持: midnight, ocean, forest, sunset, rose, mono。
-// 无效名称回退到 midnight。变更后通过 themeChangeCh 通知运行中的 model。
+// themeChangeCh signals the running model to rebuild styles after a theme change.
 var themeChangeCh = make(chan struct{}, 1)
+
+// modelsLoadErrorCh carries model list API load errors from LLM goroutines to the tea Update loop.
+var modelsLoadErrorCh = make(chan error, 1)
+
+// ModelsLoadErrorCh returns the channel for model list load errors.
+func ModelsLoadErrorCh() chan<- error { return modelsLoadErrorCh }
 
 // currentThemeName tracks the active theme name for themeChangeCh handler.
 var currentThemeName string

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -497,6 +497,8 @@ type SettingsService interface {
 // ModelLister provides available model names for the settings combo box.
 type ModelLister interface {
 	ListModels() []string
+	// ListAllModels returns models across all subscriptions (for global tier settings).
+	ListAllModels() []string
 }
 
 // Subscription represents a LLM subscription for display/selection.

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -448,8 +448,29 @@ func (m *cliModel) layoutViewportHeight() int {
 	fixedLines := 3 // titleBar + status + footer
 
 	if m.panelMode != "" {
-		// Panel 模式：viewport 缩到最小，给 panel 尽可能多的空间
-		// 用户在操作 panel 时 viewport 只是背景参考
+		if m.panelMode == "askuser" {
+			// AskUser split layout: viewport stays visible above the panel.
+			// Calculate panel content height, cap it, let viewport take the rest.
+			askContent := m.viewAskUserPanel()
+			askLines := strings.Count(askContent, "\n") + 1
+			panelBorder := 2                // PanelBox top + bottom border
+			fixedLines := 3                 // titleBar + footer + toast
+			maxPanelH := (m.height / 2) + 2 // panel gets at most ~half the screen
+			minPanelH := askLines + panelBorder
+			if minPanelH < 8 {
+				minPanelH = 8
+			}
+			if minPanelH > maxPanelH {
+				minPanelH = maxPanelH
+			}
+			viewportH := m.height - fixedLines - minPanelH
+			if viewportH < 5 {
+				viewportH = 5
+				_ = m.height - fixedLines - viewportH // panel gets the rest
+			}
+			return viewportH
+		}
+		// Other panels: viewport shrinks to minimum, panel takes all space
 		return 3
 	}
 

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -454,7 +454,7 @@ func (m *cliModel) layoutViewportHeight() int {
 			askContent := m.viewAskUserPanel()
 			askLines := strings.Count(askContent, "\n") + 1
 			panelBorder := 2                // PanelBox top + bottom border
-			fixedLines := 3                 // titleBar + footer + toast
+			fixedLines := 2                 // titleBar + toast (no separate footer — hints are in-panel)
 			maxPanelH := (m.height / 2) + 2 // panel gets at most ~half the screen
 			minPanelH := askLines + panelBorder
 			if minPanelH < 8 {

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -31,15 +31,22 @@ func (m *cliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Async subscription switch completed
 	if done, ok := msg.(cliSwitchLLMDoneMsg); ok {
+		returnToSettings := m.quickSwitchReturnToPanel
+		m.quickSwitchReturnToPanel = false
 		if done.err != nil {
 			m.showTempStatus(fmt.Sprintf("Failed to switch LLM: %v", done.err))
 		} else if done.mgr != nil {
 			if err := done.mgr.SetDefault(done.subID); err != nil {
 				m.showTempStatus(fmt.Sprintf("LLM switched but failed to save: %v", err))
 			} else {
+				m.subGeneration++ // subscription actually changed
 				m.showTempStatus(fmt.Sprintf("Switched to: %s (%s)", done.subName, done.subModel))
 			}
 			m.refreshCachedModelName()
+		}
+		// If we came from the settings panel, re-open it so the user can continue editing
+		if returnToSettings {
+			m.openSettingsFromQuickSwitch()
 		}
 		return m, nil
 	}
@@ -55,6 +62,14 @@ func (m *cliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case <-themeChangeCh:
 		m.applyThemeAndRebuild(currentThemeName)
 		m.updateViewportContent()
+	default:
+	}
+
+	// Model list load error notification from LLM goroutines
+	select {
+	case err := <-modelsLoadErrorCh:
+		m.showTempStatus(fmt.Sprintf("Model list load failed: %v", err))
+		_ = m.clearTempStatusCmd()
 	default:
 	}
 

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -157,6 +157,46 @@ func (m *cliModel) View() tea.View {
 			warningText,
 			input,
 		)
+	} else if m.panelMode == "askuser" {
+		// §12b AskUser split layout: viewport visible above, panel at bottom
+		panelFooter := m.renderFooter()
+		askRaw := m.viewAskUserPanel()
+		m.clampAskUserPanelScroll(askRaw)
+		askLines := strings.Split(askRaw, "\n")
+		// Calculate available height for the ask panel
+		fixedLines := 3 // titleBar + footer + toast
+		panelBorder := 2
+		viewportH := m.layoutViewportHeight()
+		askVisibleH := m.height - fixedLines - viewportH - panelBorder
+		if askVisibleH < 3 {
+			askVisibleH = 3
+		}
+		if m.askPanelScrollY+askVisibleH > len(askLines) {
+			m.askPanelScrollY = max(0, len(askLines)-askVisibleH)
+		}
+		end := m.askPanelScrollY + askVisibleH
+		if end > len(askLines) {
+			end = len(askLines)
+		}
+		visibleAsk := askLines[m.askPanelScrollY:end]
+		askContent := strings.Join(visibleAsk, "\n")
+		boxedAsk := m.styles.PanelBox.Render(askContent)
+		// Scroll indicator
+		totalAskLines := len(askLines)
+		scrollHint := ""
+		if totalAskLines > askVisibleH {
+			pct := (m.askPanelScrollY + askVisibleH) * 100 / totalAskLines
+			scrollHint = m.styles.PanelDesc.Render(fmt.Sprintf(" [%d%%] ↑↓PgUp/PgDn scroll", pct))
+		}
+		content = fmt.Sprintf(
+			"%s\n%s\n%s%s%s%s",
+			titleBar,
+			m.viewport.View(),
+			boxedAsk,
+			scrollHint,
+			panelFooter,
+			toastStr,
+		)
 	} else if m.panelMode != "" {
 		// §12 Panel mode: 手动切片 + PanelBox 包裹（边框永远在屏幕内）
 		panelFooter := m.renderFooter()

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -159,12 +159,12 @@ func (m *cliModel) View() tea.View {
 		)
 	} else if m.panelMode == "askuser" {
 		// §12b AskUser split layout: viewport visible above, panel at bottom
-		panelFooter := m.renderFooter()
+		// Note: no panelFooter here — hints are inside the panel (viewAskUserPanel)
 		askRaw := m.viewAskUserPanel()
 		m.clampAskUserPanelScroll(askRaw)
 		askLines := strings.Split(askRaw, "\n")
 		// Calculate available height for the ask panel
-		fixedLines := 3 // titleBar + footer + toast
+		fixedLines := 2 // titleBar + toast (no separate footer — hints are in-panel)
 		panelBorder := 2
 		viewportH := m.layoutViewportHeight()
 		askVisibleH := m.height - fixedLines - viewportH - panelBorder
@@ -189,12 +189,11 @@ func (m *cliModel) View() tea.View {
 			scrollHint = m.styles.PanelDesc.Render(fmt.Sprintf(" [%d%%] ↑↓PgUp/PgDn scroll", pct))
 		}
 		content = fmt.Sprintf(
-			"%s\n%s\n%s%s%s%s",
+			"%s\n%s\n%s%s%s",
 			titleBar,
 			m.viewport.View(),
 			boxedAsk,
 			scrollHint,
-			panelFooter,
 			toastStr,
 		)
 	} else if m.panelMode != "" {

--- a/channel/feishu.go
+++ b/channel/feishu.go
@@ -91,6 +91,14 @@ type SettingsCallbacks struct {
 	// LLMSetPersonalConcurrency 设置用户个人 LLM 并发上限
 	LLMSetPersonalConcurrency func(senderID string, personal int) error
 
+	// Model tier get/set (global config, not per-user)
+	// LLMGetModelTier returns the current model mapping for a tier ("vanguard"/"balance"/"swift").
+	LLMGetModelTier func(tier string) string
+	// LLMSetModelTier sets the model mapping for a tier and persists to config.
+	LLMSetModelTier func(tier, model string) error
+	// LLMListAllModels returns models from all subscriptions (for tier selectors).
+	LLMListAllModels func() []string
+
 	// RunnerConnectCmdGet 返回远程 Runner 连接命令（空字符串表示未启用）
 	// Deprecated: replaced by per-user token callbacks below.
 	RunnerConnectCmdGet func(senderID string) string

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -206,6 +206,24 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 		}
 		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
 
+	case "settings_set_model_tier":
+		tier := parsed["tier"]
+		if tier == "" {
+			return nil, fmt.Errorf("missing tier")
+		}
+		model := parsed["model"]
+		if model == "" {
+			if opt, ok := actionData["selected_option"].(string); ok {
+				model = opt
+			}
+		}
+		if f.settingsCallbacks.LLMSetModelTier != nil {
+			if err := f.settingsCallbacks.LLMSetModelTier(tier, model); err != nil {
+				return nil, fmt.Errorf("设置 %s 模型失败: %v", tier, err)
+			}
+		}
+		return f.BuildSettingsCard(ctx, senderID, chatID, "model")
+
 	case "settings_activate_subscription":
 		subID := parsed["subscription_id"]
 		if subID == "" {
@@ -1237,6 +1255,66 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 			},
 		},
 	))
+
+	// --- Model tier section ---
+	elements = append(elements, map[string]any{"tag": "hr"})
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": "**模型等级 (SubAgent)** — 全局设置，跨订阅生效",
+	})
+	// Collect models from ALL subscriptions (not just active one) for tier selectors.
+	var allModels []string
+	if f.settingsCallbacks.LLMListAllModels != nil {
+		allModels = f.settingsCallbacks.LLMListAllModels()
+	}
+	maxTierModels := 50
+	if len(allModels) > maxTierModels {
+		allModels = allModels[:maxTierModels]
+	}
+	for _, tier := range []struct {
+		key, label string
+	}{
+		{"vanguard", "Vanguard（强）"},
+		{"balance", "Balance（中）"},
+		{"swift", "Swift（弱）"},
+	} {
+		currentTierModel := ""
+		if f.settingsCallbacks.LLMGetModelTier != nil {
+			currentTierModel = f.settingsCallbacks.LLMGetModelTier(tier.key)
+		}
+		tierDisplay := currentTierModel
+		if tierDisplay == "" {
+			tierDisplay = "未设置"
+		}
+		var tierOptions []map[string]any
+		if len(allModels) > 0 {
+			for _, m := range allModels {
+				tierOptions = append(tierOptions, map[string]any{
+					"text":  map[string]any{"tag": "plain_text", "content": m},
+					"value": m,
+				})
+			}
+		}
+		if len(tierOptions) > 0 {
+			elements = append(elements, buildSettingRow(
+				tier.label,
+				tierDisplay,
+				map[string]any{
+					"tag":            "select_static",
+					"name":           "settings_tier_" + tier.key + "_select",
+					"placeholder":    map[string]any{"tag": "plain_text", "content": "选择模型..."},
+					"initial_option": currentTierModel,
+					"options":        tierOptions,
+					"value": map[string]string{
+						"action_data": mustMapToJSON(map[string]string{
+							"action": "settings_set_model_tier",
+							"tier":   tier.key,
+						}),
+					},
+				},
+			))
+		}
+	}
 
 	// --- Subscription management section ---
 	elements = append(elements, map[string]any{"tag": "hr"})

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -462,6 +462,18 @@ func localeZH() *UILocale {
 				Key: "llm_base_url", Label: "LLM Base URL", Description: "LLM API 地址（兼容 OpenAI 格式的第三方服务可修改此项）",
 				Type: SettingTypeText, Category: "LLM",
 			},
+			{
+				Key: "vanguard_model", Label: "Vanguard 模型", Description: "SubAgent 的高强度模型等级映射",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
+			{
+				Key: "balance_model", Label: "Balance 模型", Description: "SubAgent 的均衡模型等级映射",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
+			{
+				Key: "swift_model", Label: "Swift 模型", Description: "SubAgent 的轻量模型等级映射",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
 			// Subscription management entry (display-only, triggers quick switch)
 			{Key: "subscription_manage", Label: "📦 订阅管理", Type: SettingTypeText, Category: "LLM"},
 			{
@@ -834,6 +846,18 @@ func localeEN() *UILocale {
 				Key: "llm_base_url", Label: "LLM Base URL", Description: "LLM API endpoint (modify for OpenAI-compatible third-party services)",
 				Type: SettingTypeText, Category: "LLM",
 			},
+			{
+				Key: "vanguard_model", Label: "Vanguard Model", Description: "SubAgent tier mapping for high-power tasks",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
+			{
+				Key: "balance_model", Label: "Balance Model", Description: "SubAgent tier mapping for balanced tasks",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
+			{
+				Key: "swift_model", Label: "Swift Model", Description: "SubAgent tier mapping for lightweight tasks",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
 			// Subscription management entry (display-only, triggers quick switch)
 			{Key: "subscription_manage", Label: "📦 Subscriptions", Type: SettingTypeText, Category: "LLM"},
 			{
@@ -1205,6 +1229,18 @@ func localeJA() *UILocale {
 			{
 				Key: "llm_base_url", Label: "LLM Base URL", Description: "LLM API エンドポイント（OpenAI 互換のサードパーティサービス用に変更可）",
 				Type: SettingTypeText, Category: "LLM",
+			},
+			{
+				Key: "vanguard_model", Label: "Vanguard モデル", Description: "SubAgent の高強度タスク向けモデル階層マッピング",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
+			{
+				Key: "balance_model", Label: "Balance モデル", Description: "SubAgent のバランスタスク向けモデル階層マッピング",
+				Type: SettingTypeCombo, Category: "LLM",
+			},
+			{
+				Key: "swift_model", Label: "Swift モデル", Description: "SubAgent の軽量タスク向けモデル階層マッピング",
+				Type: SettingTypeCombo, Category: "LLM",
 			},
 			// Subscription management entry (display-only, triggers quick switch)
 			{Key: "subscription_manage", Label: "📦 サブスクリプション管理", Type: SettingTypeText, Category: "LLM"},

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -155,6 +155,7 @@ func newCLIApp() *cliApp {
 	})
 	agentLoop.RegisterCoreTool(tools.NewWebSearchTool(cfg.TavilyAPIKey))
 	agentLoop.IndexGlobalTools()
+	agentLoop.LLMFactory().SetModelTiers(cfg.LLM)
 
 	return &cliApp{
 		cfg:       cfg,
@@ -255,10 +256,13 @@ func main() {
 		IsFirstRun: firstRun,
 		GetCurrentValues: func() map[string]string {
 			return map[string]string{
-				"llm_provider": app.cfg.LLM.Provider,
-				"llm_api_key":  app.cfg.LLM.APIKey,
-				"llm_model":    app.cfg.LLM.Model,
-				"llm_base_url": app.cfg.LLM.BaseURL,
+				"llm_provider":   app.cfg.LLM.Provider,
+				"llm_api_key":    app.cfg.LLM.APIKey,
+				"llm_model":      app.cfg.LLM.Model,
+				"llm_base_url":   app.cfg.LLM.BaseURL,
+				"vanguard_model": app.cfg.LLM.VanguardModel,
+				"balance_model":  app.cfg.LLM.BalanceModel,
+				"swift_model":    app.cfg.LLM.SwiftModel,
 				"sandbox_mode": func() string {
 					if app.cfg.Sandbox.Mode != "" {
 						return app.cfg.Sandbox.Mode
@@ -329,6 +333,9 @@ func main() {
 			_, keyChanged := values["llm_api_key"]
 			_, modelChanged := values["llm_model"]
 			_, urlChanged := values["llm_base_url"]
+			_, vanguardChanged := values["vanguard_model"]
+			_, balanceChanged := values["balance_model"]
+			_, swiftChanged := values["swift_model"]
 			if llmChanged || keyChanged || modelChanged || urlChanged {
 				// Write to active subscription
 				for i := range app.cfg.Subscriptions {
@@ -373,6 +380,18 @@ func main() {
 				}
 				// Derive cfg.LLM from active subscription
 				syncLLMFromActiveSub(app.cfg)
+			}
+			if v, ok := values["vanguard_model"]; ok {
+				app.cfg.LLM.VanguardModel = strings.TrimSpace(v)
+			}
+			if v, ok := values["balance_model"]; ok {
+				app.cfg.LLM.BalanceModel = strings.TrimSpace(v)
+			}
+			if v, ok := values["swift_model"]; ok {
+				app.cfg.LLM.SwiftModel = strings.TrimSpace(v)
+			}
+			if app.agentLoop != nil && (vanguardChanged || balanceChanged || swiftChanged) {
+				app.agentLoop.LLMFactory().SetModelTiers(app.cfg.LLM)
 			}
 			// Apply Sandbox settings
 			if v, ok := values["sandbox_mode"]; ok && v != "" {
@@ -424,6 +443,7 @@ func main() {
 						app.llmClient = newClient
 						if app.agentLoop != nil {
 							app.agentLoop.LLMFactory().SetDefaults(newClient, app.cfg.LLM.Model)
+							app.agentLoop.LLMFactory().SetModelTiers(app.cfg.LLM)
 						}
 					} else {
 						log.Warnf("Failed to rebuild LLM client: %v", err)
@@ -462,6 +482,7 @@ func main() {
 					app.llmClient = newClient
 					if app.agentLoop != nil {
 						app.agentLoop.LLMFactory().SetDefaults(newClient, app.cfg.LLM.Model)
+						app.agentLoop.LLMFactory().SetModelTiers(app.cfg.LLM)
 					}
 				} else {
 					log.Warnf("Failed to rebuild LLM client: %v", err)
@@ -523,6 +544,7 @@ func main() {
 			app.llmClient = client
 			if app.agentLoop != nil {
 				app.agentLoop.LLMFactory().SetDefaults(client, model)
+				app.agentLoop.LLMFactory().SetModelTiers(app.cfg.LLM)
 			}
 			return nil
 		},
@@ -611,7 +633,10 @@ func main() {
 		if ss := app.agentLoop.GetSettingsService(); ss != nil {
 			cliCh.SetSettingsService(ss)
 		}
-		cliCh.SetModelLister(app.agentLoop.LLMFactory())
+		cliCh.SetModelLister(&cliModelLister{
+			factory: app.agentLoop.LLMFactory(),
+			cfg:     app.cfg,
+		})
 		// Inject BgTaskManager for background task display
 		bgSessionKey := "cli:" + cliCfg.ChatID
 		cliCh.SetBgTaskManager(app.agentLoop.BgTaskManager(), bgSessionKey)
@@ -706,7 +731,11 @@ func main() {
 		defer saveWg.Done()
 		return config.SaveToFile(config.ConfigFilePath(), app.cfg)
 	}
-	cliCh.SetSubscriptionManager(newConfigSubscriptionManager(app.cfg, saveConfig))
+	cliCh.SetSubscriptionManager(newConfigSubscriptionManager(app.cfg, saveConfig, func(llmCfg config.LLMConfig) {
+		if app.agentLoop != nil {
+			app.agentLoop.LLMFactory().SetModelTiers(llmCfg)
+		}
+	}))
 	cliCh.SetLLMSubscriber(newConfigLLMSubscriber(app.cfg, app.agentLoop.LLMFactory(), saveConfig))
 
 	// --share flag: auto-connect as runner after TUI starts
@@ -731,14 +760,44 @@ func main() {
 // Adapters: bridge config/types to CLI interfaces
 // ---------------------------------------------------------------------------
 
-// configSubscriptionManager manages CLI subscriptions in config.json (no database).
-type configSubscriptionManager struct {
-	cfg    *config.Config
-	saveFn func() error // persists config to disk
+// cliModelLister wraps LLMFactory + config to implement channel.ModelLister.
+// ListAllModels collects models from default LLM + all config subscriptions.
+type cliModelLister struct {
+	factory *agent.LLMFactory
+	cfg     *config.Config
 }
 
-func newConfigSubscriptionManager(cfg *config.Config, saveFn func() error) *configSubscriptionManager {
-	return &configSubscriptionManager{cfg: cfg, saveFn: saveFn}
+func (l *cliModelLister) ListModels() []string {
+	return l.factory.ListModels()
+}
+
+func (l *cliModelLister) ListAllModels() []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, m := range l.factory.ListModels() {
+		if !seen[m] {
+			seen[m] = true
+			result = append(result, m)
+		}
+	}
+	for _, sub := range l.cfg.Subscriptions {
+		if sub.Model != "" && !seen[sub.Model] {
+			seen[sub.Model] = true
+			result = append(result, sub.Model)
+		}
+	}
+	return result
+}
+
+// configSubscriptionManager manages CLI subscriptions in config.json (no database).
+type configSubscriptionManager struct {
+	cfg      *config.Config
+	saveFn   func() error           // persists config to disk
+	tierSync func(config.LLMConfig) // called after subscription switch to re-sync tier models
+}
+
+func newConfigSubscriptionManager(cfg *config.Config, saveFn func() error, tierSync func(config.LLMConfig)) *configSubscriptionManager {
+	return &configSubscriptionManager{cfg: cfg, saveFn: saveFn, tierSync: tierSync}
 }
 
 func (m *configSubscriptionManager) List(_ string) ([]channel.Subscription, error) {
@@ -814,6 +873,10 @@ func (m *configSubscriptionManager) SetDefault(id string) error {
 	}
 	// Derive cfg.LLM from new active subscription
 	syncLLMFromActiveSub(m.cfg)
+	// Re-sync model tiers (tier fields are global, not per-subscription)
+	if m.tierSync != nil {
+		m.tierSync(m.cfg.LLM)
+	}
 	return m.saveFn()
 }
 
@@ -824,6 +887,9 @@ func (m *configSubscriptionManager) SetModel(id, model string) error {
 			// If modifying active subscription, sync cfg.LLM
 			if m.cfg.Subscriptions[i].Active {
 				syncLLMFromActiveSub(m.cfg)
+				if m.tierSync != nil {
+					m.tierSync(m.cfg.LLM)
+				}
 			}
 			return m.saveFn()
 		}
@@ -857,7 +923,8 @@ func newConfigLLMSubscriber(cfg *config.Config, factory *agent.LLMFactory, saveF
 }
 
 // syncLLMFromActiveSub derives cfg.LLM.* from the active subscription.
-// This is the ONLY place that writes cfg.LLM fields.
+// It only writes the 6 subscription-derived fields; tier fields (VanguardModel/BalanceModel/SwiftModel)
+// are global and NOT touched here.
 func syncLLMFromActiveSub(cfg *config.Config) {
 	for _, sc := range cfg.Subscriptions {
 		if sc.Active {
@@ -904,6 +971,7 @@ func (s *configLLMSubscriber) SwitchSubscription(senderID string, sub *channel.S
 			}
 			s.factory.SetDefaults(client, sc.Model)
 			s.factory.SetDefaultThinkingMode(sc.ThinkingMode)
+			s.factory.SetModelTiers(s.cfg.LLM)
 			// Set active flag + derive cfg.LLM + save (all in one place)
 			for j := range s.cfg.Subscriptions {
 				s.cfg.Subscriptions[j].Active = (s.cfg.Subscriptions[j].ID == sub.ID)
@@ -925,6 +993,7 @@ func (s *configLLMSubscriber) SwitchModel(senderID, model string) {
 		}
 	}
 	syncLLMFromActiveSub(s.cfg)
+	s.factory.SetModelTiers(s.cfg.LLM)
 	if err := s.saveFn(); err != nil {
 		log.WithError(err).Warn("Failed to persist model switch")
 	}
@@ -987,6 +1056,12 @@ func createLLM(cfg config.LLMConfig, retryCfg llm.RetryConfig) (llm.LLM, error) 
 			APIKey:       cfg.APIKey,
 			DefaultModel: cfg.Model,
 			MaxTokens:    cfg.MaxOutputTokens,
+			OnModelsLoadError: func(err error) {
+				select {
+				case channel.ModelsLoadErrorCh() <- err:
+				default:
+				}
+			},
 		})
 	case "anthropic":
 		inner = llm.NewAnthropicLLM(llm.AnthropicConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -182,6 +182,9 @@ type LLMConfig struct {
 	BaseURL         string `json:"base_url"`
 	APIKey          string `json:"api_key"`
 	Model           string `json:"model"`
+	VanguardModel   string `json:"vanguard_model,omitempty"`
+	BalanceModel    string `json:"balance_model,omitempty"`
+	SwiftModel      string `json:"swift_model,omitempty"`
 	MaxOutputTokens int    `json:"max_output_tokens,omitempty"` // 0 = use default (8192)
 	ThinkingMode    string `json:"thinking_mode,omitempty"`
 }

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -37,6 +37,10 @@ type OpenAIConfig struct {
 	DefaultModel string // 默认模型（API 获取失败时的回退模型）
 	MaxTokens    int    // 最大生成 token 数（默认 8192）
 	UserAgent    string // 自定义 User-Agent（留空使用默认值）
+
+	// OnModelsLoadError is called when the async model list API call fails.
+	// Used by CLI to show a toast notification.
+	OnModelsLoadError func(err error)
 }
 
 // defaultMaxTokens 默认最大生成 token 数
@@ -78,11 +82,15 @@ func NewOpenAILLM(cfg OpenAIConfig) *OpenAILLM {
 
 	// Load model list asynchronously to avoid blocking startup.
 	// The fallback model above ensures ListModels() works before API responds.
+	onError := cfg.OnModelsLoadError
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := o.LoadModelsFromAPI(ctx); err != nil {
 			log.WithError(err).Warn("[LLM] Failed to load models from OpenAI API")
+			if onError != nil {
+				onError(err)
+			}
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -577,6 +577,7 @@ func main() {
 
 	// 所有工具注册完成，索引全局工具（用于 search_tools 语义搜索）
 	agentLoop.IndexGlobalTools()
+	agentLoop.LLMFactory().SetModelTiers(cfg.LLM)
 
 	tokenDB, err := sqlite.Open(dbPath)
 	if err != nil {
@@ -642,6 +643,35 @@ func main() {
 			},
 			LLMSetThinkingMode: func(senderID string, mode string) error {
 				return agentLoop.SetUserThinkingMode(senderID, mode)
+			},
+			LLMGetModelTier: func(tier string) string {
+				switch tier {
+				case "vanguard":
+					return cfg.LLM.VanguardModel
+				case "balance":
+					return cfg.LLM.BalanceModel
+				case "swift":
+					return cfg.LLM.SwiftModel
+				default:
+					return ""
+				}
+			},
+			LLMSetModelTier: func(tier, model string) error {
+				switch tier {
+				case "vanguard":
+					cfg.LLM.VanguardModel = model
+				case "balance":
+					cfg.LLM.BalanceModel = model
+				case "swift":
+					cfg.LLM.SwiftModel = model
+				default:
+					return fmt.Errorf("unknown tier: %s", tier)
+				}
+				agentLoop.LLMFactory().SetModelTiers(cfg.LLM)
+				return config.SaveToFile(config.ConfigFilePath(), cfg)
+			},
+			LLMListAllModels: func() []string {
+				return agentLoop.LLMFactory().ListAllModelsForUser("")
 			},
 			LLMListSubscriptions: func(senderID string) ([]channel.Subscription, error) {
 				subs, err := agentLoop.LLMFactory().GetSubscriptionSvc().List(senderID)

--- a/tools/subagent_roles.go
+++ b/tools/subagent_roles.go
@@ -14,7 +14,7 @@ type SubAgentRole struct {
 	Description  string
 	SystemPrompt string
 	AllowedTools []string
-	Model        string // 可选：指定使用的 LLM 模型（如 "claude-sonnet-4-20250514"）。为空时继承主 Agent 模型。
+	Model        string // 可选：指定使用的 LLM 模型或模型等级（vanguard/balance/swift）。为空时继承主 Agent 模型。
 
 	Capabilities SubAgentCapabilities
 }


### PR DESCRIPTION
## Summary

Three-tier model system for subagent model selection + CLI AskUser panel UX fixes.

### Model Tier System
- **Vanguard / Balance / Swift** tiers stored in `config.json` `LLMConfig` (global, not per-subscription)
- `llm_factory`: `SetModelTiers()`, `resolveTierModel()`, `normalizeModelTier()`, `ListAllModelsForUser()`, tier-aware `GetLLMForModel()`
- Agent `.md` `model:` field supports tier keywords directly; frontmatter wins over config
- Model list for tiers uses `ListAllModels()` (all subscriptions), not just active
- CLI settings UI: tier combo boxes with all-model lists, subscription generation guard
- Feishu settings: tier selectors in model tab
- `OnModelsLoadError` callback for graceful model load failure handling

### AskUser Panel Fixes
- **Ctrl+O** works in AskUser mode to expand/collapse tool summary
- **Shift+↑/↓** scrolls viewport (iteration history) line-by-line
- **Home/End** jumps to top/bottom of viewport
- **Ctrl+O scroll anchor**: uses `msgLineOffsets` to keep same first visible message after toggle
- All keyboard hints moved inside the panel box (were invisible due to layout overflow)
- Fixed `fixedLines` inconsistency (3 vs 2) across layout functions
- Panel auto-scrolls to bottom on overflow so hints are visible

### Files Changed (19 files, +965 −88)
- `agent/llm_factory.go` — tier resolution, normalization, cross-subscription model lookup
- `channel/cli_panel.go` — askuser keyboard handlers, viewport scroll, panel hints
- `channel/cli_view.go` — askuser split layout rendering
- `channel/cli_helpers.go` — toggleToolSummary anchor, panel scroll clamp
- `channel/cli_update.go` — layout viewport height, models load error drain
- `cmd/xbot-cli/main.go` — cliModelLister, tierSync, SetModelTiers wiring
- `config/config.go` — VanguardModel/BalanceModel/SwiftModel fields
- `channel/feishu.go`, `channel/feishu_settings.go` — Feishu tier UI
- Tests: `agent/llm_factory_test.go`, `channel/cli_panel_test.go`
