### PR TITLE
fix: MCP config path mismatch in CLI none sandbox

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -106,7 +106,7 @@ var metaTools = map[string]bool{
 func (a *Agent) IndexGlobalTools() {
 	registry := a.tools
 	multiSession := a.multiSession
-	globalMCPConfigPath := resolveDataPath(a.xbotHome, "mcp.json")
+	globalMCPConfigPath := resolveDataPath(a.workDir, "mcp.json")
 
 	ctx := context.Background()
 	var toolEntries []memory.ToolIndexEntry
@@ -511,12 +511,8 @@ func initStores(cfg Config) (*SkillStore, *AgentStore, *tools.ChatHistoryStore, 
 	chatHistory := tools.NewChatHistoryStore(200) // 每个群组保留最近 200 条
 	registry.Register(tools.NewChatHistoryTool(chatHistory))
 
-	// MCP 配置路径：使用 xbotHome (e.g. ~/.xbot/mcp.json) 作为全局 MCP 配置位置
-	xbotHome := cfg.XbotHome
-	if xbotHome == "" {
-		xbotHome = cfg.WorkDir
-	}
-	mcpConfigPath := resolveDataPath(xbotHome, "mcp.json")
+	// MCP config path must align with ManageTools.resolveWritableMCPConfigPath (uses workDir).
+	mcpConfigPath := resolveDataPath(cfg.WorkDir, "mcp.json")
 
 	// 注册 ManageTools tool（需要 skillStore 和 mcpConfigPath）
 	registry.RegisterCore(tools.NewManageTools(cfg.WorkDir, mcpConfigPath))
@@ -567,11 +563,9 @@ func initSession(cfg Config) (*session.MultiTenantSession, error) {
 // initServices 注册工具、初始化 cron/LLM/offload/registry/settings 等服务。
 // 此方法直接修改 Agent 指针。
 func initServices(a *Agent, cfg Config, multiSession *session.MultiTenantSession, registry *tools.Registry) {
-	xbotHome := cfg.XbotHome
-	if xbotHome == "" {
-		xbotHome = cfg.WorkDir
-	}
-	mcpConfigPath := resolveDataPath(xbotHome, "mcp.json")
+	// MCP config must use workDir to align with ManageTools.resolveWritableMCPConfigPath.
+	// Using xbotHome (~/.xbot) causes resolveDataPath to produce ~/.xbot/.xbot/mcp.json.
+	mcpConfigPath := resolveDataPath(cfg.WorkDir, "mcp.json")
 	contextMode := resolveContextMode(cfg)
 
 	memoryProvider := cfg.MemoryProvider

--- a/tools/session_mcp.go
+++ b/tools/session_mcp.go
@@ -209,6 +209,11 @@ func (sm *SessionMCPManager) loadAndConnect(ctx context.Context) error {
 	config, err := sm.loadConfig()
 	if err != nil {
 		if os.IsNotExist(err) {
+			log.WithFields(log.Fields{
+				"session":    sm.sessionKey,
+				"globalPath": sm.globalConfigPath,
+				"userPath":   sm.userConfigPath,
+			}).Debug("No MCP config found (not an error)")
 			return nil // 没有 mcp.json 不是错误
 		}
 		return fmt.Errorf("load mcp config: %w", err)
@@ -326,6 +331,8 @@ func (sm *SessionMCPManager) loadConfig() (*MCPConfig, error) {
 					merged.MCPServers[name] = server
 				}
 			}
+		} else if !os.IsNotExist(err) {
+			log.WithError(err).WithField("path", sm.globalConfigPath).Warn("Failed to read global MCP config")
 		}
 	}
 


### PR DESCRIPTION
## Problem

In CLI channel with `none` sandbox, `load_tools` always returns "No tools found" for MCP tools, even after successfully adding them via `ManageTools`.

**Root cause**: `resolveDataPath()` unconditionally appends `.xbot/` to its input. Three call sites used `xbotHome` (`~/.xbot`) as input, producing the non-existent path `~/.xbot/.xbot/mcp.json`. Meanwhile, `ManageTools` correctly wrote to `{workDir}/.xbot/mcp.json`.

The entire error chain silently swallowed `os.ErrNotExist` — zero log output made this invisible.

## Changes

### `agent/agent.go` — Fix path in 3 call sites
- `initStores()`: ManageTools globalMCPConfigPath
- `initServices()`: SetMCPConfigPath for session lazy loading
- `IndexGlobalTools()`: global MCP tool indexing

All changed from `resolveDataPath(xbotHome, "mcp.json")` → `resolveDataPath(cfg.WorkDir, "mcp.json")`

### `tools/session_mcp.go` — Add debug logging
- Log actual paths when no MCP config is found (debug level)
- Log non-NotExist ReadFile errors (warn level)

This makes future path mismatches diagnosable instead of silently swallowed.
