### PR TITLE
fix: MCP global config should use xbotHome directly, not resolveDataPath

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -60,27 +60,6 @@ func formatErrorForUser(err error) string {
 	return fmt.Sprintf("处理消息时发生错误: %v", err)
 }
 
-// resolveDataPath 解析数据文件路径，优先使用 .xbot/ 目录，向后兼容工作目录根路径
-// 读取时：优先新路径，不存在则回退旧路径
-// 写入时：始终使用新路径
-func resolveDataPath(workDir, filename string) string {
-	// NOTE: .xbot is the server-side config directory; not accessible in user sandbox
-	xbotDir := filepath.Join(workDir, ".xbot")
-	newPath := filepath.Join(xbotDir, filename)
-	oldPath := filepath.Join(workDir, filename)
-
-	// 优先使用新路径
-	if _, err := os.Stat(newPath); err == nil {
-		return newPath
-	}
-	// 新路径不存在，检查旧路径
-	if _, err := os.Stat(oldPath); err == nil {
-		return oldPath
-	}
-	// 都不存在，返回新路径（用于创建新文件）
-	return newPath
-}
-
 func resolveGlobalSkillsDirs(legacySkillsDir string) []string {
 	if legacySkillsDir == "" {
 		return nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -106,7 +106,7 @@ var metaTools = map[string]bool{
 func (a *Agent) IndexGlobalTools() {
 	registry := a.tools
 	multiSession := a.multiSession
-	globalMCPConfigPath := resolveDataPath(a.workDir, "mcp.json")
+	globalMCPConfigPath := filepath.Join(a.xbotHome, "mcp.json")
 
 	ctx := context.Background()
 	var toolEntries []memory.ToolIndexEntry
@@ -511,8 +511,13 @@ func initStores(cfg Config) (*SkillStore, *AgentStore, *tools.ChatHistoryStore, 
 	chatHistory := tools.NewChatHistoryStore(200) // 每个群组保留最近 200 条
 	registry.Register(tools.NewChatHistoryTool(chatHistory))
 
-	// MCP config path must align with ManageTools.resolveWritableMCPConfigPath (uses workDir).
-	mcpConfigPath := resolveDataPath(cfg.WorkDir, "mcp.json")
+	// MCP global config: use xbotHome directly (~/.xbot/mcp.json).
+	// resolveDataPath would double-nest to ~/.xbot/.xbot/mcp.json.
+	xbotHome := cfg.XbotHome
+	if xbotHome == "" {
+		xbotHome = cfg.WorkDir
+	}
+	mcpConfigPath := filepath.Join(xbotHome, "mcp.json")
 
 	// 注册 ManageTools tool（需要 skillStore 和 mcpConfigPath）
 	registry.RegisterCore(tools.NewManageTools(cfg.WorkDir, mcpConfigPath))
@@ -563,9 +568,8 @@ func initSession(cfg Config) (*session.MultiTenantSession, error) {
 // initServices 注册工具、初始化 cron/LLM/offload/registry/settings 等服务。
 // 此方法直接修改 Agent 指针。
 func initServices(a *Agent, cfg Config, multiSession *session.MultiTenantSession, registry *tools.Registry) {
-	// MCP config must use workDir to align with ManageTools.resolveWritableMCPConfigPath.
-	// Using xbotHome (~/.xbot) causes resolveDataPath to produce ~/.xbot/.xbot/mcp.json.
-	mcpConfigPath := resolveDataPath(cfg.WorkDir, "mcp.json")
+	// MCP config must use xbotHome directly (not resolveDataPath which double-nests).
+	mcpConfigPath := filepath.Join(a.xbotHome, "mcp.json")
 	contextMode := resolveContextMode(cfg)
 
 	memoryProvider := cfg.MemoryProvider

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -94,7 +95,7 @@ func (a *Agent) buildBaseRunConfig(
 		SkillsDirs:       a.globalSkillDirs,
 		AgentsDir:        a.agentsDir,
 		MCPConfigPath:    tools.UserMCPConfigPath(a.workDir, sandboxUserID),
-		GlobalMCPConfig:  resolveDataPath(a.workDir, "mcp.json"),
+		GlobalMCPConfig:  filepath.Join(a.xbotHome, "mcp.json"),
 		DataDir:          a.workDir,
 		SandboxEnabled:   a.sandboxMode != "none",
 		PreferredSandbox: a.sandboxMode,
@@ -772,7 +773,7 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 		SkillsDirs:       a.globalSkillDirs,
 		AgentsDir:        a.agentsDir,
 		MCPConfigPath:    tools.UserMCPConfigPath(a.workDir, sandboxUserID),
-		GlobalMCPConfig:  resolveDataPath(a.workDir, "mcp.json"),
+		GlobalMCPConfig:  filepath.Join(a.xbotHome, "mcp.json"),
 		DataDir:          a.workDir,
 		SandboxEnabled:   a.sandboxMode != "none",
 		PreferredSandbox: a.sandboxMode,

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -751,7 +752,7 @@ func (a *Agent) buildParentToolContext(ctx context.Context, channel, chatID, sen
 		SkillsDirs:          a.globalSkillDirs,
 		AgentsDir:           a.agentsDir,
 		MCPConfigPath:       tools.UserMCPConfigPath(a.workDir, senderID),
-		GlobalMCPConfigPath: resolveDataPath(a.workDir, "mcp.json"),
+		GlobalMCPConfigPath: filepath.Join(a.xbotHome, "mcp.json"),
 		DataDir:             a.workDir,
 		SandboxEnabled:      a.sandboxMode != "none",
 		PreferredSandbox:    a.sandboxMode,

--- a/tools/manage_tools_test.go
+++ b/tools/manage_tools_test.go
@@ -20,6 +20,174 @@ func TestManageTools_Name(t *testing.T) {
 	}
 }
 
+// TestManageTools_WritePathByChannel verifies that add_mcp writes to the correct
+// config file for each channel/sandbox mode:
+//   - CLI (none sandbox): writes to GlobalMCPConfigPath (xbotHome/mcp.json)
+//   - Feishu (remote sandbox): writes to per-user MCPConfigPath
+//   - CLI (docker sandbox): writes to per-user MCPConfigPath (sandbox has own dir)
+func TestManageTools_WritePathByChannel(t *testing.T) {
+	t.Run("cli_none_sandbox_writes_global", func(t *testing.T) {
+		tempDir := t.TempDir()
+		globalPath := filepath.Join(tempDir, "xbotHome", "mcp.json")
+		userPath := filepath.Join(tempDir, "users", "cli_user", "mcp.json")
+
+		tool := NewManageTools(tempDir, globalPath)
+		ctx := &ToolContext{
+			Registry:            NewRegistry(),
+			Channel:             "cli",
+			MCPConfigPath:       userPath,
+			GlobalMCPConfigPath: globalPath,
+		}
+
+		input, _ := json.Marshal(manageToolsArgs{
+			Action:       "add_mcp",
+			Name:         "cli-test",
+			MCPConfig:    `{"url":"http://example.com/mcp"}`,
+			Instructions: "test",
+		})
+		if _, err := tool.Execute(ctx, string(input)); err != nil {
+			t.Fatalf("add_mcp failed: %v", err)
+		}
+
+		// Must be in global path
+		if _, err := os.Stat(globalPath); err != nil {
+			t.Fatalf("expected global config at %s: %v", globalPath, err)
+		}
+		// User path must NOT exist
+		if _, err := os.Stat(userPath); !os.IsNotExist(err) {
+			t.Fatalf("user config should not exist at %s", userPath)
+		}
+
+		// Verify content
+		data, _ := os.ReadFile(globalPath)
+		var cfg MCPConfig
+		json.Unmarshal(data, &cfg)
+		if _, ok := cfg.MCPServers["cli-test"]; !ok {
+			t.Fatal("cli-test not found in global config")
+		}
+	})
+
+	t.Run("feishu_sandbox_writes_user_path", func(t *testing.T) {
+		tempDir := t.TempDir()
+		globalPath := filepath.Join(tempDir, "xbotHome", "mcp.json")
+		userPath := filepath.Join(tempDir, "users", "feishu_user", "mcp.json")
+
+		// Pre-create global config with a shared server
+		globalCfg := MCPConfig{MCPServers: map[string]MCPServerConfig{
+			"shared-server": {URL: "http://shared.example.com/mcp"},
+		}}
+		globalData, _ := json.MarshalIndent(globalCfg, "", "  ")
+		os.MkdirAll(filepath.Dir(globalPath), 0o755)
+		os.WriteFile(globalPath, globalData, 0o644)
+
+		tool := NewManageTools(tempDir, globalPath)
+		ctx := &ToolContext{
+			Registry:            NewRegistry(),
+			Channel:             "feishu",
+			MCPConfigPath:       userPath,
+			GlobalMCPConfigPath: globalPath,
+		}
+
+		input, _ := json.Marshal(manageToolsArgs{
+			Action:       "add_mcp",
+			Name:         "feishu-private",
+			MCPConfig:    `{"url":"http://example.com/mcp"}`,
+			Instructions: "feishu private tool",
+		})
+		if _, err := tool.Execute(ctx, string(input)); err != nil {
+			t.Fatalf("add_mcp failed: %v", err)
+		}
+
+		// Must be in user path, NOT in global
+		if _, err := os.Stat(userPath); err != nil {
+			t.Fatalf("expected user config at %s: %v", userPath, err)
+		}
+		data, _ := os.ReadFile(userPath)
+		var userCfg MCPConfig
+		json.Unmarshal(data, &userCfg)
+		if _, ok := userCfg.MCPServers["feishu-private"]; !ok {
+			t.Fatal("feishu-private not found in user config")
+		}
+
+		// Global config should NOT be modified
+		globalData2, _ := os.ReadFile(globalPath)
+		var globalCfg2 MCPConfig
+		json.Unmarshal(globalData2, &globalCfg2)
+		if _, ok := globalCfg2.MCPServers["feishu-private"]; ok {
+			t.Fatal("feishu-private should NOT be in global config")
+		}
+		if _, ok := globalCfg2.MCPServers["shared-server"]; !ok {
+			t.Fatal("shared-server should still exist in global config")
+		}
+	})
+
+	t.Run("cli_docker_sandbox_writes_user_path", func(t *testing.T) {
+		tempDir := t.TempDir()
+		globalPath := filepath.Join(tempDir, "xbotHome", "mcp.json")
+		userPath := filepath.Join(tempDir, "users", "cli_user", "mcp.json")
+
+		tool := NewManageTools(tempDir, globalPath)
+		// Docker sandbox: CLI channel but sandbox is enabled, so should still
+		// write to global (CLI always writes to global regardless of sandbox)
+		ctx := &ToolContext{
+			Registry:            NewRegistry(),
+			Channel:             "cli",
+			MCPConfigPath:       userPath,
+			GlobalMCPConfigPath: globalPath,
+			SandboxEnabled:      true,
+		}
+
+		input, _ := json.Marshal(manageToolsArgs{
+			Action:       "add_mcp",
+			Name:         "cli-docker",
+			MCPConfig:    `{"url":"http://example.com/mcp"}`,
+			Instructions: "docker sandbox test",
+		})
+		if _, err := tool.Execute(ctx, string(input)); err != nil {
+			t.Fatalf("add_mcp failed: %v", err)
+		}
+
+		// CLI always writes to global regardless of sandbox
+		if _, err := os.Stat(globalPath); err != nil {
+			t.Fatalf("expected global config at %s: %v", globalPath, err)
+		}
+		data, _ := os.ReadFile(globalPath)
+		var cfg MCPConfig
+		json.Unmarshal(data, &cfg)
+		if _, ok := cfg.MCPServers["cli-docker"]; !ok {
+			t.Fatal("cli-docker not found in global config")
+		}
+	})
+
+	t.Run("no_context_falls_back_to_anonymous", func(t *testing.T) {
+		tempDir := t.TempDir()
+		globalPath := filepath.Join(tempDir, "global-mcp.json")
+		anonymousPath := filepath.Join(tempDir, ".xbot", "users", "anonymous", "mcp.json")
+
+		tool := NewManageTools(tempDir, globalPath)
+		// Nil context → falls back to workDir/.xbot/users/anonymous/mcp.json
+		input, _ := json.Marshal(manageToolsArgs{
+			Action:       "add_mcp",
+			Name:         "anonymous-srv",
+			MCPConfig:    `{"url":"http://example.com/mcp"}`,
+			Instructions: "fallback test",
+		})
+		if _, err := tool.Execute(nil, string(input)); err != nil {
+			t.Fatalf("add_mcp with nil ctx failed: %v", err)
+		}
+
+		if _, err := os.Stat(anonymousPath); err != nil {
+			t.Fatalf("expected anonymous config at %s: %v", anonymousPath, err)
+		}
+		data, _ := os.ReadFile(anonymousPath)
+		var cfg MCPConfig
+		json.Unmarshal(data, &cfg)
+		if _, ok := cfg.MCPServers["anonymous-srv"]; !ok {
+			t.Fatal("anonymous-srv not found in anonymous config")
+		}
+	})
+}
+
 func TestManageTools_Description(t *testing.T) {
 	tool := NewManageTools("/tmp", "/tmp/mcp.json")
 	desc := tool.Description()

--- a/tools/session_mcp.go
+++ b/tools/session_mcp.go
@@ -17,6 +17,10 @@ import (
 
 const maxMCPConnections = 20
 
+// errNotInitialized indicates MCP config files don't exist yet.
+// The caller should NOT set initialized=true so that the next access retries.
+var errNotInitialized = fmt.Errorf("MCP config not found, will retry on next access")
+
 // SessionMCPManager 管理单个会话的 MCP 连接
 type SessionMCPManager struct {
 	mu                sync.RWMutex
@@ -75,8 +79,10 @@ func (sm *SessionMCPManager) GetCatalog() []MCPServerCatalogEntry {
 	// 首次调用时确保配置已加载
 	if !sm.initialized {
 		if err := sm.loadAndConnect(context.Background()); err != nil {
-			log.WithError(err).WithField("session", sm.sessionKey).Warn("Failed to load MCP servers for catalog")
-			sm.initialized = true
+			if err != errNotInitialized {
+				log.WithError(err).WithField("session", sm.sessionKey).Warn("Failed to load MCP servers for catalog")
+				sm.initialized = true
+			}
 			return nil
 		}
 		sm.initialized = true
@@ -108,8 +114,11 @@ func (sm *SessionMCPManager) GetSessionTools() []Tool {
 	// 首次调用时加载配置
 	if !sm.initialized {
 		if err := sm.loadAndConnect(context.Background()); err != nil {
-			log.WithError(err).WithField("session", sm.sessionKey).Warn("Failed to load MCP servers for session")
-			sm.initialized = true // 标记为已尝试，避免重复尝试
+			if err != errNotInitialized {
+				log.WithError(err).WithField("session", sm.sessionKey).Warn("Failed to load MCP servers for session")
+				sm.initialized = true // 真正的错误，标记为已尝试，避免重复
+			}
+			// errNotInitialized: 配置文件暂不存在，不设 initialized，下次重试
 			return nil
 		}
 		sm.initialized = true
@@ -209,12 +218,9 @@ func (sm *SessionMCPManager) loadAndConnect(ctx context.Context) error {
 	config, err := sm.loadConfig()
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.WithFields(log.Fields{
-				"session":    sm.sessionKey,
-				"globalPath": sm.globalConfigPath,
-				"userPath":   sm.userConfigPath,
-			}).Debug("No MCP config found (not an error)")
-			return nil // 没有 mcp.json 不是错误
+			// 配置文件暂不存在，返回 errNotInitialized 让调用方不标记 initialized=true，
+			// 以便下次调用时重试（配置可能稍后被 ManageTools 创建）。
+			return errNotInitialized
 		}
 		return fmt.Errorf("load mcp config: %w", err)
 	}


### PR DESCRIPTION
## Problem

PR #461 fixed the `~/.xbot/.xbot/mcp.json` double-nest but used `workDir` instead of `xbotHome`. In CLI none sandbox, MCP config is global (`~/.xbot/mcp.json`), not per-workspace. Using `workDir` means each project directory gets its own MCP config, which breaks the "add once, use everywhere" expectation for CLI.

The underlying issue remains: `resolveDataPath()` unconditionally appends `.xbot/` to any input, so passing `xbotHome` (`~/.xbot`) produces `~/.xbot/.xbot/mcp.json`.

## Fix

Replace `resolveDataPath(xbotHome, "mcp.json")` with `filepath.Join(xbotHome, "mcp.json")` in all 4 call sites:

- `IndexGlobalTools()` — global MCP tool indexing
- `initStores()` — ManageTools globalMCPConfigPath
- `initServices()` — SetMCPConfigPath for session lazy loading
- `buildParentToolContext()` — CLI tool context GlobalMCPConfigPath
