### PR TITLE
feat: Ctrl+K rewind with file rollback

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -431,6 +431,45 @@ func Run(ctx context.Context, cfg RunConfig) *RunOutput {
 	return s.buildMaxIterOutput()
 }
 
+// executeWithHooks wraps tool execution with pre/post hook calls.
+// Both defaultToolExecutor (SubAgents) and buildToolExecutor (main Agent)
+// MUST use this function to ensure hooks are called identically.
+//
+// The function:
+//  1. Runs pre-tool hooks with WorkingDir injected into context
+//  2. Executes the tool
+//  3. Runs post-tool hooks (always, even on error)
+//
+// toolExecCtx is the base context (with perm users etc. injected).
+// toolCtx is the ToolContext (with WorkingDir resolved).
+// workingDir is toolCtx.WorkingDir, extracted for convenience.
+func executeWithHooks(
+	hookChain *tools.HookChain,
+	toolExecCtx context.Context,
+	toolCtx *tools.ToolContext,
+	toolName, toolArgs string,
+	tool tools.Tool,
+) (*tools.ToolResult, error) {
+	// Pre-tool hooks: inject WorkingDir so hooks can resolve paths
+	if hookChain != nil {
+		hookCtx := tools.WithWorkingDir(toolExecCtx, toolCtx.WorkingDir)
+		if err := hookChain.RunPre(hookCtx, toolName, toolArgs); err != nil {
+			return nil, fmt.Errorf("pre-tool hook blocked %q: %w", toolName, err)
+		}
+	}
+
+	start := time.Now()
+	result, err := tool.Execute(toolCtx, toolArgs)
+	elapsed := time.Since(start)
+
+	// Post-tool hooks (always, even on error)
+	if hookChain != nil {
+		hookChain.RunPost(toolExecCtx, toolName, toolArgs, result, err, elapsed)
+	}
+
+	return result, err
+}
+
 // defaultToolExecutor creates the default tool executor (looks up from Registry and executes).
 // Used for SubAgent and other scenarios that don't need session MCP / activation checks.
 func defaultToolExecutor(cfg *RunConfig) func(ctx context.Context, tc llm.ToolCall) (*tools.ToolResult, error) {
@@ -449,25 +488,7 @@ func defaultToolExecutor(cfg *RunConfig) func(ctx context.Context, tc llm.ToolCa
 		}
 		toolCtx := buildToolContext(toolExecCtx, cfg)
 
-		// Run pre-tool hooks after ToolContext is built so hooks can access
-		// working directory and other context for path resolution etc.
-		if cfg.HookChain != nil {
-			hookCtx := tools.WithWorkingDir(toolExecCtx, toolCtx.WorkingDir)
-			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
-				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
-			}
-		}
-
-		start := time.Now()
-		result, err := tool.Execute(toolCtx, tc.Arguments)
-		elapsed := time.Since(start)
-
-		// Run post-tool hooks (always, even on error)
-		if cfg.HookChain != nil {
-			cfg.HookChain.RunPost(ctx, tc.Name, tc.Arguments, result, err, elapsed)
-		}
-
-		return result, err
+		return executeWithHooks(cfg.HookChain, toolExecCtx, toolCtx, tc.Name, tc.Arguments, tool)
 	}
 }
 

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -449,9 +449,10 @@ func defaultToolExecutor(cfg *RunConfig) func(ctx context.Context, tc llm.ToolCa
 		}
 		toolCtx := buildToolContext(toolExecCtx, cfg)
 
-		// Run pre-tool hooks (inject perm users into context for ApprovalHook)
+		// Run pre-tool hooks after ToolContext is built so hooks can access
+		// working directory and other context for path resolution etc.
 		if cfg.HookChain != nil {
-			hookCtx := toolExecCtx
+			hookCtx := tools.WithWorkingDir(toolExecCtx, toolCtx.WorkingDir)
 			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
 				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
 			}

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -863,16 +863,18 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 			}
 		}
 
-		// 5. Run pre-tool hooks (inject perm users into context for ApprovalHook)
+		// 5. 构建 ToolContext（统一路径，只有 ctx 变化）
+		toolCtx := buildToolContext(toolExecCtx, cfg)
+
+		// 6. Run pre-tool hooks after ToolContext is built so hooks
+		//    can access WorkingDir via context (e.g. checkpoint hook
+		//    needs WorkingDir to resolve relative file paths).
 		if cfg.HookChain != nil {
-			hookCtx := toolExecCtx
+			hookCtx := tools.WithWorkingDir(toolExecCtx, toolCtx.WorkingDir)
 			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
 				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
 			}
 		}
-
-		// 6. 构建 ToolContext（统一路径，只有 ctx 变化）
-		toolCtx := buildToolContext(toolExecCtx, cfg)
 
 		// 7. Execute tool with timing
 		start := time.Now()

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -866,27 +866,8 @@ func (a *Agent) buildToolExecutor(channel, chatID, senderID, senderName, sandbox
 		// 5. 构建 ToolContext（统一路径，只有 ctx 变化）
 		toolCtx := buildToolContext(toolExecCtx, cfg)
 
-		// 6. Run pre-tool hooks after ToolContext is built so hooks
-		//    can access WorkingDir via context (e.g. checkpoint hook
-		//    needs WorkingDir to resolve relative file paths).
-		if cfg.HookChain != nil {
-			hookCtx := tools.WithWorkingDir(toolExecCtx, toolCtx.WorkingDir)
-			if err := cfg.HookChain.RunPre(hookCtx, tc.Name, tc.Arguments); err != nil {
-				return nil, fmt.Errorf("pre-tool hook blocked %q: %w", tc.Name, err)
-			}
-		}
-
-		// 7. Execute tool with timing
-		start := time.Now()
-		result, err := tool.Execute(toolCtx, tc.Arguments)
-		elapsed := time.Since(start)
-
-		// 8. Run post-tool hooks (always, even on error)
-		if cfg.HookChain != nil {
-			cfg.HookChain.RunPost(ctx, tc.Name, tc.Arguments, result, err, elapsed)
-		}
-
-		return result, err
+		// 6-8. Execute with hooks (shared implementation — same as defaultToolExecutor)
+		return executeWithHooks(cfg.HookChain, toolExecCtx, toolCtx, tc.Name, tc.Arguments, tool)
 	}
 }
 

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -70,6 +70,14 @@ func (c *CLIChannel) Start() error {
 	c.model.SetMsgBus(c.msgBus)
 	c.model.workDir = c.workDir
 	c.model.senderID = "cli_user"
+
+	// Apply pending injections that were set before model existed
+	if c.pendingTrimHistoryFn != nil {
+		c.model.trimHistoryFn = c.pendingTrimHistoryFn
+	}
+	if c.pendingCheckpointHook != nil {
+		c.model.checkpointHook = c.pendingCheckpointHook
+	}
 	c.model.channelName = "cli"
 	c.model.defaultChatID = c.config.ChatID
 	c.model.chatID = c.config.ChatID
@@ -245,21 +253,25 @@ func (c *CLIChannel) SetBgTaskManager(mgr *tools.BackgroundTaskManager, sessionK
 
 // SetTrimHistoryFn sets the callback for Ctrl+K rewind DB truncation.
 // cutoff is the timestamp threshold — all DB messages with created_at < cutoff will be deleted.
+// If the model hasn't been created yet, the callback is cached and applied later.
 func (c *CLIChannel) SetTrimHistoryFn(fn func(cutoff time.Time) error) {
 	c.programMu.Lock()
 	defer c.programMu.Unlock()
 	if c.model != nil {
 		c.model.trimHistoryFn = fn
 	}
+	c.pendingTrimHistoryFn = fn
 }
 
 // SetCheckpointHook sets the file checkpoint hook for Ctrl+K rewind file rollback.
+// If the model hasn't been created yet, the hook is cached and applied later.
 func (c *CLIChannel) SetCheckpointHook(hook *tools.CheckpointHook) {
 	c.programMu.Lock()
 	defer c.programMu.Unlock()
 	if c.model != nil {
 		c.model.checkpointHook = hook
 	}
+	c.pendingCheckpointHook = hook
 }
 
 // InjectUserMessage 通知 CLI 有 user 消息被 agent 注入（如 bg task 完成通知）。

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -243,9 +243,9 @@ func (c *CLIChannel) SetBgTaskManager(mgr *tools.BackgroundTaskManager, sessionK
 	c.updateBgTaskCountFn()
 }
 
-// SetTrimHistoryFn 设置 Ctrl+K 截断历史后的数据库同步回调。
-// keepCount 为保留的消息数，实现方应删除数据库中更早的消息。
-func (c *CLIChannel) SetTrimHistoryFn(fn func(keepCount int) error) {
+// SetTrimHistoryFn sets the callback for Ctrl+K rewind DB truncation.
+// cutoff is the timestamp threshold — all DB messages with created_at < cutoff will be deleted.
+func (c *CLIChannel) SetTrimHistoryFn(fn func(cutoff time.Time) error) {
 	c.programMu.Lock()
 	defer c.programMu.Unlock()
 	if c.model != nil {

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -253,6 +253,15 @@ func (c *CLIChannel) SetTrimHistoryFn(fn func(keepCount int) error) {
 	}
 }
 
+// SetCheckpointHook sets the file checkpoint hook for Ctrl+K rewind file rollback.
+func (c *CLIChannel) SetCheckpointHook(hook *tools.CheckpointHook) {
+	c.programMu.Lock()
+	defer c.programMu.Unlock()
+	if c.model != nil {
+		c.model.checkpointHook = hook
+	}
+}
+
 // InjectUserMessage 通知 CLI 有 user 消息被 agent 注入（如 bg task 完成通知）。
 // 在 CLI 界面上显示为一条 user 消息，和用户手动输入的效果一致。
 func (c *CLIChannel) InjectUserMessage(content string) {

--- a/channel/cli.go
+++ b/channel/cli.go
@@ -6,7 +6,7 @@
 //   - Tool call visualization with live status indicators
 //   - Built-in slash commands: /model, /models, /context, /new
 //   - Tab completion for commands and input history
-//   - Ctrl+K line deletion with confirmation
+//   - /rewind conversation rewind
 //   - Non-interactive (pipe) mode with streaming output
 //   - Session restore via --new/--resume flags
 
@@ -251,7 +251,7 @@ func (c *CLIChannel) SetBgTaskManager(mgr *tools.BackgroundTaskManager, sessionK
 	c.updateBgTaskCountFn()
 }
 
-// SetTrimHistoryFn sets the callback for Ctrl+K rewind DB truncation.
+// SetTrimHistoryFn sets the callback for /rewind DB truncation.
 // cutoff is the timestamp threshold — all DB messages with created_at < cutoff will be deleted.
 // If the model hasn't been created yet, the callback is cached and applied later.
 func (c *CLIChannel) SetTrimHistoryFn(fn func(cutoff time.Time) error) {
@@ -263,7 +263,7 @@ func (c *CLIChannel) SetTrimHistoryFn(fn func(cutoff time.Time) error) {
 	c.pendingTrimHistoryFn = fn
 }
 
-// SetCheckpointHook sets the file checkpoint hook for Ctrl+K rewind file rollback.
+// SetCheckpointHook sets the file checkpoint hook for /rewind file rollback.
 // If the model hasn't been created yet, the hook is cached and applied later.
 func (c *CLIChannel) SetCheckpointHook(hook *tools.CheckpointHook) {
 	c.programMu.Lock()

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -125,6 +125,12 @@ func (m *cliModel) openSettingsFromQuickSwitch() {
 func (m *cliModel) startAgentTurn() {
 	m.agentTurnID++
 	m.typing = true
+	// Sync checkpoint hook turn index
+	if m.checkpointHook != nil {
+		m.checkpointHook.SetTurnIdx(int(m.agentTurnID))
+	}
+	// Clear rewind result when new turn starts
+	m.rewindResult = nil
 	m.updatePlaceholder()
 	m.inputReady = false
 	m.resetProgressState()

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1525,8 +1525,6 @@ func (m *cliModel) fullRebuild() {
 	// §19 重置消息行号偏移（基于折行后的 viewport 行号）
 	m.msgLineOffsets = m.msgLineOffsets[:0]
 	runningLines := 0
-	// §9 Ctrl+K 红线：记录红线在折行后的 viewport 行号
-	var redLineWrappedPos = -1
 	for i := range m.messages[:splitIdx] {
 		// §19 记录消息在 viewport 折行后内容中的起始行号
 		m.msgLineOffsets = append(m.msgLineOffsets, runningLines)
@@ -1551,10 +1549,6 @@ func (m *cliModel) fullRebuild() {
 		// §9 Ctrl+K 红线：在删除边界处插入红线指示器
 		if redLineInsertIdx >= 0 && i == redLineInsertIdx {
 			boundary := m.renderDeleteBoundaryLine()
-			// boundaryStartLine: the viewport line where the boundary begins (the leading \n)
-			// This is right after the current chunk (runningLines + chunk lines)
-			chunkLines := wrappedLineCount(chunk, m.width)
-			redLineWrappedPos = runningLines + chunkLines
 			historyBuf.WriteString(boundary)
 		}
 		// 累加本消息（含搜索指示条/红线）在折行后占用的行数
@@ -1574,35 +1568,42 @@ func (m *cliModel) fullRebuild() {
 	sb.WriteString(m.renderProgressBlock())
 	sb.WriteString(m.renderRewindResultBlock())
 
-	// §9 Ctrl+K 红线：设置内容时禁止 GotoBottom，以便随后精确定位红线
+	// §9 Ctrl+K 红线：设置内容后定位到红线
 	if m.confirmDelete > 0 {
 		m.setViewportContentForScroll(sb.String())
+		m.scrollToRedLine()
 	} else {
 		m.setViewportContent(sb.String())
 	}
-
-	// §9 Ctrl+K 红线：自动滚动到红线位置（使用折行后的精确行号）
-	if m.confirmDelete > 0 && redLineWrappedPos >= 0 {
-		m.scrollViewportToRedLine(redLineWrappedPos)
-	}
 }
 
-// scrollViewportToRedLine scrolls the viewport so the red line boundary is visible
-// near the top. Used by all viewport update paths during confirmDelete mode.
-func (m *cliModel) scrollViewportToRedLine(redLinePos int) {
-	if redLinePos < 0 {
+// scrollToRedLine finds the red line boundary in the viewport content and scrolls to it.
+// Uses viewport's GetContent() to find the boundary, guaranteeing line number matches.
+func (m *cliModel) scrollToRedLine() {
+	if m.confirmDelete <= 0 {
 		return
+	}
+	content := m.viewport.GetContent()
+	idx := strings.Index(content, "━")
+	if idx < 0 {
+		return
+	}
+	// Count newlines before the red line to get the viewport line number
+	lineNum := strings.Count(content[:idx], "\n")
+	// Scroll so the red line appears a few lines from the top
+	scrollTarget := lineNum - 2
+	if scrollTarget < 0 {
+		scrollTarget = 0
 	}
 	maxOff := m.viewport.TotalLineCount() - m.viewport.Height()
 	if maxOff < 0 {
 		maxOff = 0
 	}
-	target := redLinePos
-	if target > maxOff {
-		target = maxOff
+	if scrollTarget > maxOff {
+		scrollTarget = maxOff
 	}
-	m.viewport.SetYOffset(target)
-	m.redLineTargetYOff = target
+	m.viewport.SetYOffset(scrollTarget)
+	m.redLineTargetYOff = scrollTarget
 }
 
 // scrollToRedLineIfNeeded restores the viewport to the cached red line position.

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1545,7 +1545,10 @@ func (m *cliModel) fullRebuild() {
 		// §9 Ctrl+K 红线：在删除边界处插入红线指示器
 		if redLineInsertIdx >= 0 && i == redLineInsertIdx {
 			boundary := m.renderDeleteBoundaryLine()
-			redLineWrappedPos = runningLines + wrappedLineCount(chunk+"\n"+boundary, m.width)
+			// boundaryStartLine: the viewport line where the boundary begins (the leading \n)
+			// This is right after the current chunk (runningLines + chunk lines)
+			chunkLines := wrappedLineCount(chunk, m.width)
+			redLineWrappedPos = runningLines + chunkLines
 			historyBuf.WriteString(boundary)
 		}
 		// 累加本消息（含搜索指示条/红线）在折行后占用的行数
@@ -1576,23 +1579,17 @@ func (m *cliModel) fullRebuild() {
 	if m.confirmDelete > 0 && redLineWrappedPos >= 0 {
 		vpHeight := m.viewport.Height()
 		totalLines := m.viewport.TotalLineCount()
-		// redLineWrappedPos points to the line after the boundary.
-		// We want to show the boundary near the top of the viewport (line 3).
-		// The boundary itself spans a few lines, so target just before it.
-		boundaryStart := redLineWrappedPos - 2 // approximate boundary start (2 lines for boundary content)
-		if boundaryStart < 0 {
-			boundaryStart = 0
-		}
-		targetY := boundaryStart
-		// Ensure boundary is visible: don't scroll past the point where boundary goes off-screen
+		// redLineWrappedPos points to the start of the boundary block
+		// (the leading "\n" before "━━━ rewind below ━━━").
+		// Scroll so the red line appears near the top of the viewport.
 		maxOff := totalLines - vpHeight
 		if maxOff < 0 {
 			maxOff = 0
 		}
-		if targetY > maxOff {
-			targetY = maxOff
+		if redLineWrappedPos > maxOff {
+			redLineWrappedPos = maxOff
 		}
-		m.viewport.SetYOffset(targetY)
+		m.viewport.SetYOffset(redLineWrappedPos)
 	}
 }
 

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1549,6 +1549,8 @@ func (m *cliModel) fullRebuild() {
 		// §9 Ctrl+K 红线：在删除边界处插入红线指示器
 		if redLineInsertIdx >= 0 && i == redLineInsertIdx {
 			boundary := m.renderDeleteBoundaryLine()
+			// 记录红线在 viewport 中的行号：当前消息结束后的下一行
+			m.redLineWrappedPos = runningLines + wrappedLineCount(chunk, m.width)
 			historyBuf.WriteString(boundary)
 		}
 		// 累加本消息（含搜索指示条/红线）在折行后占用的行数
@@ -1571,39 +1573,28 @@ func (m *cliModel) fullRebuild() {
 	// §9 Ctrl+K 红线：设置内容后定位到红线
 	if m.confirmDelete > 0 {
 		m.setViewportContentForScroll(sb.String())
-		m.scrollToRedLine()
+		m.applyRedLineScroll()
 	} else {
 		m.setViewportContent(sb.String())
 	}
 }
 
-// scrollToRedLine finds the red line boundary in the viewport content and scrolls to it.
-// Uses viewport's GetContent() to find the boundary, guaranteeing line number matches.
-func (m *cliModel) scrollToRedLine() {
-	if m.confirmDelete <= 0 {
+// applyRedLineScroll scrolls the viewport to the cached red line position.
+// Called after setViewportContentForScroll in fullRebuild.
+func (m *cliModel) applyRedLineScroll() {
+	if m.confirmDelete <= 0 || m.redLineWrappedPos < 0 {
 		return
-	}
-	content := m.viewport.GetContent()
-	idx := strings.Index(content, "rewind below")
-	if idx < 0 {
-		return
-	}
-	// Count newlines before the red line to get the viewport line number
-	lineNum := strings.Count(content[:idx], "\n")
-	// Scroll so the red line appears a few lines from the top
-	scrollTarget := lineNum - 2
-	if scrollTarget < 0 {
-		scrollTarget = 0
 	}
 	maxOff := m.viewport.TotalLineCount() - m.viewport.Height()
 	if maxOff < 0 {
 		maxOff = 0
 	}
-	if scrollTarget > maxOff {
-		scrollTarget = maxOff
+	target := m.redLineWrappedPos
+	if target > maxOff {
+		target = maxOff
 	}
-	m.viewport.SetYOffset(scrollTarget)
-	m.redLineTargetYOff = scrollTarget
+	m.viewport.SetYOffset(target)
+	m.redLineTargetYOff = target
 }
 
 // scrollToRedLineIfNeeded restores the viewport to the cached red line position.

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1422,6 +1422,7 @@ func (m *cliModel) updateViewportContent() {
 		if m.confirmDelete > 0 {
 			// Don't auto-scroll during rewind confirmation — keep red line visible
 			m.setViewportContentForScroll(sb.String())
+			m.scrollToRedLineIfNeeded()
 		} else {
 			m.setViewportContent(sb.String())
 		}
@@ -1494,7 +1495,12 @@ func (m *cliModel) appendNewMessagesToCache() {
 	vp.WriteString(m.cachedHistory)
 	vp.WriteString(m.renderProgressBlock())
 	vp.WriteString(m.renderRewindResultBlock())
-	m.setViewportContent(vp.String())
+	if m.confirmDelete > 0 {
+		m.setViewportContentForScroll(vp.String())
+		m.scrollToRedLineIfNeeded()
+	} else {
+		m.setViewportContent(vp.String())
+	}
 }
 
 // fullRebuild 全量重建渲染缓存（慢速路径）
@@ -1577,19 +1583,33 @@ func (m *cliModel) fullRebuild() {
 
 	// §9 Ctrl+K 红线：自动滚动到红线位置（使用折行后的精确行号）
 	if m.confirmDelete > 0 && redLineWrappedPos >= 0 {
-		vpHeight := m.viewport.Height()
-		totalLines := m.viewport.TotalLineCount()
-		// redLineWrappedPos points to the start of the boundary block
-		// (the leading "\n" before "━━━ rewind below ━━━").
-		// Scroll so the red line appears near the top of the viewport.
-		maxOff := totalLines - vpHeight
-		if maxOff < 0 {
-			maxOff = 0
-		}
-		if redLineWrappedPos > maxOff {
-			redLineWrappedPos = maxOff
-		}
-		m.viewport.SetYOffset(redLineWrappedPos)
+		m.scrollViewportToRedLine(redLineWrappedPos)
+	}
+}
+
+// scrollViewportToRedLine scrolls the viewport so the red line boundary is visible
+// near the top. Used by all viewport update paths during confirmDelete mode.
+func (m *cliModel) scrollViewportToRedLine(redLinePos int) {
+	if redLinePos < 0 {
+		return
+	}
+	maxOff := m.viewport.TotalLineCount() - m.viewport.Height()
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	target := redLinePos
+	if target > maxOff {
+		target = maxOff
+	}
+	m.viewport.SetYOffset(target)
+	m.redLineTargetYOff = target
+}
+
+// scrollToRedLineIfNeeded restores the viewport to the cached red line position.
+// Called by fast-path viewport updates (tick, append) during confirmDelete mode.
+func (m *cliModel) scrollToRedLineIfNeeded() {
+	if m.confirmDelete > 0 && m.redLineTargetYOff >= 0 {
+		m.viewport.SetYOffset(m.redLineTargetYOff)
 	}
 }
 

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1584,7 +1584,7 @@ func (m *cliModel) scrollToRedLine() {
 		return
 	}
 	content := m.viewport.GetContent()
-	idx := strings.Index(content, "━")
+	idx := strings.Index(content, "rewind below")
 	if idx < 0 {
 		return
 	}

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1419,7 +1419,12 @@ func (m *cliModel) updateViewportContent() {
 		sb.WriteString(m.cachedHistory)
 		sb.WriteString(m.renderProgressBlock())
 		sb.WriteString(m.renderRewindResultBlock())
-		m.setViewportContent(sb.String())
+		if m.confirmDelete > 0 {
+			// Don't auto-scroll during rewind confirmation — keep red line visible
+			m.setViewportContentForScroll(sb.String())
+		} else {
+			m.setViewportContent(sb.String())
+		}
 		return
 	}
 
@@ -1571,11 +1576,15 @@ func (m *cliModel) fullRebuild() {
 	if m.confirmDelete > 0 && redLineWrappedPos >= 0 {
 		vpHeight := m.viewport.Height()
 		totalLines := m.viewport.TotalLineCount()
-		// 将红线定位到视口中央偏上（留 3 行上方边距）
-		targetY := redLineWrappedPos - 3
-		if targetY < 0 {
-			targetY = 0
+		// redLineWrappedPos points to the line after the boundary.
+		// We want to show the boundary near the top of the viewport (line 3).
+		// The boundary itself spans a few lines, so target just before it.
+		boundaryStart := redLineWrappedPos - 2 // approximate boundary start (2 lines for boundary content)
+		if boundaryStart < 0 {
+			boundaryStart = 0
 		}
+		targetY := boundaryStart
+		// Ensure boundary is visible: don't scroll past the point where boundary goes off-screen
 		maxOff := totalLines - vpHeight
 		if maxOff < 0 {
 			maxOff = 0

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -312,6 +312,9 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 		m.cachedHistory = ""
 		m.exitSearch()
 
+	case "/rewind":
+		m.openRewindPanel()
+
 	case "/settings":
 		// Open interactive settings panel locally
 		if m.channel != nil {
@@ -1273,22 +1276,6 @@ func (m *cliModel) renderMessage(msg *cliMessage) string {
 	return sb.String()
 }
 
-// setViewportContentForScroll is like setViewportContent but skips GotoBottom(),
-// allowing the caller to set a precise YOffset afterwards (e.g. for Ctrl+K red line).
-func (m *cliModel) setViewportContentForScroll(content string) {
-	if m.width > 0 {
-		lines := strings.Split(content, "\n")
-		var wrapped []string
-		for _, line := range lines {
-			line = strings.TrimRight(line, " \t")
-			wrapped = append(wrapped, strings.Split(hardWrapRunes(line, m.width), "\n")...)
-		}
-		content = strings.Join(wrapped, "\n")
-	}
-	m.viewport.SetContent(content)
-	m.newContentHint = false
-}
-
 // setViewportContent sets viewport content while preserving scroll position.
 // If the user was at the bottom before the update, keep them at the bottom.
 // Lines wider than the viewport are truncated to prevent layout breakage.
@@ -1333,53 +1320,6 @@ func wrappedLineCount(content string, width int) int {
 	return count
 }
 
-// renderDeleteBoundaryLine renders the Ctrl+K rewind boundary line.
-func (m *cliModel) renderDeleteBoundaryLine() string {
-	w := m.width
-	if w <= 0 {
-		w = 80
-	}
-	accentStyle := m.styles.ProgressError // §20
-	label := " rewind below "
-	labelWidth := lipgloss.Width(accentStyle.Bold(true).Render(label))
-	totalPad := w - labelWidth
-	if totalPad < 0 {
-		totalPad = 0
-	}
-	leftPad := totalPad / 2
-	rightPad := totalPad - leftPad
-	line := accentStyle.Bold(true).Render(
-		strings.Repeat("━", leftPad) + label + strings.Repeat("━", rightPad),
-	)
-
-	// Build action hints
-	var hints []string
-	hints = append(hints, "[Y] rewind all")
-	hints = append(hints, "[K] conversation only")
-	hints = append(hints, "[N] cancel")
-
-	// Show file change count if checkpoint hook is available
-	if m.checkpointHook != nil && m.checkpointHook.Store() != nil {
-		groups := visibleMsgGroupIndices(m.messages)
-		turnsBefore := groups[:len(groups)-m.confirmDelete]
-		rewindFromTurn := len(turnsBefore)
-		fileCount := m.checkpointHook.Store().CountChanges(rewindFromTurn)
-		if fileCount > 0 {
-			hints = append([]string{fmt.Sprintf("%d file(s) affected", fileCount)}, hints...)
-		} else {
-			hints = append([]string{"no file changes to rollback"}, hints...)
-		}
-	}
-
-	hintLine := strings.Join(hints, "  ")
-	// Wrap hint if too long
-	if lipgloss.Width(hintLine) > w {
-		hintLine = strings.Join(hints, "\n")
-	}
-
-	return "\n" + line + "\n" + hintLine + "\n"
-}
-
 // visibleTurnIndices 返回每个"对话轮次"的起始 slice 索引。
 // 每个 turn 以 user 消息开头，包含之后所有的 assistant/tool_summary 消息
 // 直到下一个 user 消息为止。tool_summary 自动归属其前面最近的 user 所在的 turn。
@@ -1419,19 +1359,13 @@ func (m *cliModel) updateViewportContent() {
 		sb.WriteString(m.cachedHistory)
 		sb.WriteString(m.renderProgressBlock())
 		sb.WriteString(m.renderRewindResultBlock())
-		if m.confirmDelete > 0 {
-			// Don't auto-scroll during rewind confirmation — keep red line visible
-			m.setViewportContentForScroll(sb.String())
-			m.scrollToRedLineIfNeeded()
-		} else {
-			m.setViewportContent(sb.String())
-		}
+		m.setViewportContent(sb.String())
 		return
 	}
 
-	// 快速路径：缓存有效 + 仅追加了新消息（无流式、无搜索、无删除确认）
+	// 快速路径：缓存有效 + 仅追加了新消息（无流式、无搜索）
 	// 只渲染新增的 dirty 消息并追加到 cachedHistory，跳过全量重建。
-	if m.renderCacheValid && m.streamingMsgIdx < 0 && !m.searchMode && m.confirmDelete == 0 &&
+	if m.renderCacheValid && m.streamingMsgIdx < 0 && !m.searchMode &&
 		len(m.messages) > m.cachedMsgCount {
 		m.appendNewMessagesToCache()
 		return
@@ -1495,12 +1429,7 @@ func (m *cliModel) appendNewMessagesToCache() {
 	vp.WriteString(m.cachedHistory)
 	vp.WriteString(m.renderProgressBlock())
 	vp.WriteString(m.renderRewindResultBlock())
-	if m.confirmDelete > 0 {
-		m.setViewportContentForScroll(vp.String())
-		m.scrollToRedLineIfNeeded()
-	} else {
-		m.setViewportContent(vp.String())
-	}
+	m.setViewportContent(vp.String())
 }
 
 // fullRebuild 全量重建渲染缓存（慢速路径）
@@ -1511,15 +1440,6 @@ func (m *cliModel) fullRebuild() {
 	splitIdx := len(m.messages)
 	if m.streamingMsgIdx >= 0 {
 		splitIdx = m.streamingMsgIdx
-	}
-
-	// §9 Ctrl+K 红线：根据可见消息组计算删除边界 slice 索引
-	var redLineInsertIdx = -1
-	if m.confirmDelete > 0 {
-		groups := visibleMsgGroupIndices(m.messages)
-		if m.confirmDelete <= len(groups) {
-			redLineInsertIdx = groups[len(groups)-m.confirmDelete] - 1
-		}
 	}
 
 	// §19 重置消息行号偏移（基于折行后的 viewport 行号）
@@ -1546,14 +1466,7 @@ func (m *cliModel) fullRebuild() {
 			chunk = indicator + chunk
 		}
 		historyBuf.WriteString(m.messages[i].rendered)
-		// §9 Ctrl+K 红线：在删除边界处插入红线指示器
-		if redLineInsertIdx >= 0 && i == redLineInsertIdx {
-			boundary := m.renderDeleteBoundaryLine()
-			// 记录红线在 viewport 中的行号：当前消息结束后的下一行
-			m.redLineWrappedPos = runningLines + wrappedLineCount(chunk, m.width)
-			historyBuf.WriteString(boundary)
-		}
-		// 累加本消息（含搜索指示条/红线）在折行后占用的行数
+		// 累加本消息（含搜索指示条）在折行后占用的行数
 		runningLines += wrappedLineCount(chunk, m.width)
 	}
 
@@ -1570,39 +1483,7 @@ func (m *cliModel) fullRebuild() {
 	sb.WriteString(m.renderProgressBlock())
 	sb.WriteString(m.renderRewindResultBlock())
 
-	// §9 Ctrl+K 红线：设置内容后定位到红线
-	if m.confirmDelete > 0 {
-		m.setViewportContentForScroll(sb.String())
-		m.applyRedLineScroll()
-	} else {
-		m.setViewportContent(sb.String())
-	}
-}
-
-// applyRedLineScroll scrolls the viewport to the cached red line position.
-// Called after setViewportContentForScroll in fullRebuild.
-func (m *cliModel) applyRedLineScroll() {
-	if m.confirmDelete <= 0 || m.redLineWrappedPos < 0 {
-		return
-	}
-	maxOff := m.viewport.TotalLineCount() - m.viewport.Height()
-	if maxOff < 0 {
-		maxOff = 0
-	}
-	target := m.redLineWrappedPos
-	if target > maxOff {
-		target = maxOff
-	}
-	m.viewport.SetYOffset(target)
-	m.redLineTargetYOff = target
-}
-
-// scrollToRedLineIfNeeded restores the viewport to the cached red line position.
-// Called by fast-path viewport updates (tick, append) during confirmDelete mode.
-func (m *cliModel) scrollToRedLineIfNeeded() {
-	if m.confirmDelete > 0 && m.redLineTargetYOff >= 0 {
-		m.viewport.SetYOffset(m.redLineTargetYOff)
-	}
+	m.setViewportContent(sb.String())
 }
 
 // isSearchMatch 检查消息是否匹配当前搜索（§21）
@@ -1765,7 +1646,7 @@ func idleTickCmd() tea.Cmd {
 	})
 }
 
-// renderRewindResultBlock renders the rewind result summary after a Ctrl+K rewind.
+// renderRewindResultBlock renders the rewind result summary after a /rewind operation.
 // NOTE: This is a pure render function — it does NOT modify m.rewindResult.
 // The result is cleared when a new agent turn starts (in startAgentTurn).
 func (m *cliModel) renderRewindResultBlock() string {

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -1333,26 +1333,51 @@ func wrappedLineCount(content string, width int) int {
 	return count
 }
 
-// renderDeleteBoundaryLine 渲染 Ctrl+K 删除边界红线。
+// renderDeleteBoundaryLine renders the Ctrl+K rewind boundary line.
 func (m *cliModel) renderDeleteBoundaryLine() string {
 	w := m.width
 	if w <= 0 {
 		w = 80
 	}
-	redStyle := m.styles.ProgressError // §20
-	label := " ✂ delete below "
-	// label 的可见宽度（不含 ANSI 转义）
-	labelWidth := lipgloss.Width(redStyle.Bold(true).Render(label))
+	accentStyle := m.styles.ProgressError // §20
+	label := " rewind below "
+	labelWidth := lipgloss.Width(accentStyle.Bold(true).Render(label))
 	totalPad := w - labelWidth
 	if totalPad < 0 {
 		totalPad = 0
 	}
 	leftPad := totalPad / 2
 	rightPad := totalPad - leftPad
-	line := redStyle.Bold(true).Render(
+	line := accentStyle.Bold(true).Render(
 		strings.Repeat("━", leftPad) + label + strings.Repeat("━", rightPad),
 	)
-	return "\n" + line + "\n"
+
+	// Build action hints
+	var hints []string
+	hints = append(hints, "[Y] rewind all")
+	hints = append(hints, "[K] conversation only")
+	hints = append(hints, "[N] cancel")
+
+	// Show file change count if checkpoint hook is available
+	if m.checkpointHook != nil && m.checkpointHook.Store() != nil {
+		groups := visibleMsgGroupIndices(m.messages)
+		turnsBefore := groups[:len(groups)-m.confirmDelete]
+		rewindFromTurn := len(turnsBefore)
+		fileCount := m.checkpointHook.Store().CountChanges(rewindFromTurn)
+		if fileCount > 0 {
+			hints = append([]string{fmt.Sprintf("%d file(s) affected", fileCount)}, hints...)
+		} else {
+			hints = append([]string{"no file changes to rollback"}, hints...)
+		}
+	}
+
+	hintLine := strings.Join(hints, "  ")
+	// Wrap hint if too long
+	if lipgloss.Width(hintLine) > w {
+		hintLine = strings.Join(hints, "\n")
+	}
+
+	return "\n" + line + "\n" + hintLine + "\n"
 }
 
 // visibleTurnIndices 返回每个"对话轮次"的起始 slice 索引。
@@ -1393,6 +1418,7 @@ func (m *cliModel) updateViewportContent() {
 		var sb strings.Builder
 		sb.WriteString(m.cachedHistory)
 		sb.WriteString(m.renderProgressBlock())
+		sb.WriteString(m.renderRewindResultBlock())
 		m.setViewportContent(sb.String())
 		return
 	}
@@ -1422,10 +1448,12 @@ func (m *cliModel) updateStreamingOnly() {
 	// Append progress block
 	sb.WriteString(m.renderProgressBlock())
 
+	// Append rewind result block
+	sb.WriteString(m.renderRewindResultBlock())
+
 	m.setViewportContent(sb.String())
 }
 
-// appendNewMessagesToCache incrementally renders and appends only the new messages
 // since cachedMsgCount, updating cachedHistory and msgLineOffsets without rebuilding
 // old messages. This is O(new_messages) instead of O(all_messages).
 func (m *cliModel) appendNewMessagesToCache() {
@@ -1460,6 +1488,7 @@ func (m *cliModel) appendNewMessagesToCache() {
 	var vp strings.Builder
 	vp.WriteString(m.cachedHistory)
 	vp.WriteString(m.renderProgressBlock())
+	vp.WriteString(m.renderRewindResultBlock())
 	m.setViewportContent(vp.String())
 }
 
@@ -1522,13 +1551,14 @@ func (m *cliModel) fullRebuild() {
 	m.renderCacheValid = true
 	m.cachedMsgCount = len(m.messages)
 
-	// 拼接最终内容：历史 + 当前流式消息（如有） + progress block
+	// 拼接最终内容：历史 + 当前流式消息（如有） + progress block + rewind result
 	var sb strings.Builder
 	sb.WriteString(m.cachedHistory)
 	if m.streamingMsgIdx >= 0 {
 		sb.WriteString(m.renderMessage(&m.messages[m.streamingMsgIdx]))
 	}
 	sb.WriteString(m.renderProgressBlock())
+	sb.WriteString(m.renderRewindResultBlock())
 
 	// §9 Ctrl+K 红线：设置内容时禁止 GotoBottom，以便随后精确定位红线
 	if m.confirmDelete > 0 {
@@ -1715,6 +1745,41 @@ func idleTickCmd() tea.Cmd {
 	return tea.Tick(3*time.Second, func(time.Time) tea.Msg {
 		return idleTickMsg{}
 	})
+}
+
+// renderRewindResultBlock renders the rewind result summary after a Ctrl+K rewind.
+// NOTE: This is a pure render function — it does NOT modify m.rewindResult.
+// The result is cleared when a new agent turn starts (in startAgentTurn).
+func (m *cliModel) renderRewindResultBlock() string {
+	if m.rewindResult == nil {
+		return ""
+	}
+	r := m.rewindResult
+
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString(m.styles.ProgressDone.Bold(true).Render("  Rewind complete"))
+	sb.WriteString("\n")
+
+	if len(r.Restored) > 0 {
+		fmt.Fprintf(&sb, "  Files restored: %d\n", len(r.Restored))
+		for _, f := range r.Restored {
+			sb.WriteString(m.styles.TextMutedSt.Render(fmt.Sprintf("    %s\n", f)))
+		}
+	}
+	if len(r.CreatedDel) > 0 {
+		fmt.Fprintf(&sb, "  Files deleted: %d\n", len(r.CreatedDel))
+		for _, f := range r.CreatedDel {
+			sb.WriteString(m.styles.TextMutedSt.Render(fmt.Sprintf("    %s\n", f)))
+		}
+	}
+	if len(r.Errors) > 0 {
+		for _, e := range r.Errors {
+			sb.WriteString(m.styles.ProgressError.Render(fmt.Sprintf("  Error: %s\n", e)))
+		}
+	}
+
+	return sb.String()
 }
 
 // tickerCmd is deprecated — ticker is now driven by cliTickMsg.

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -257,6 +257,7 @@ type cliModel struct {
 	confirmDelete     int                   // >0 = in rewind confirmation mode, value = turns to rewind
 	checkpointHook    *tools.CheckpointHook // file checkpoint hook for rewind file rollback (nil = no file tracking)
 	rewindResult      *tools.RewindResult   // result of the last rewind operation (for display)
+	redLineWrappedPos int                   // viewport line number where red line starts (set by fullRebuild)
 	redLineTargetYOff int                   // cached YOffset to keep red line visible during confirmDelete mode
 
 	// --- §10 TODO 进度条 ---

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -253,8 +253,10 @@ type cliModel struct {
 	fileCompIdx     int      // 当前选中的文件补全索引
 	fileCompActive  bool     // true = Tab 循环中，阻止重新 glob
 
-	// --- §9 Ctrl+K 上下文编辑 ---
-	confirmDelete int // >0 时处于删除确认状态，值为待删除消息数
+	// --- §9 Ctrl+K Rewind ---
+	confirmDelete  int                   // >0 = in rewind confirmation mode, value = turns to rewind
+	checkpointHook *tools.CheckpointHook // file checkpoint hook for rewind file rollback (nil = no file tracking)
+	rewindResult   *tools.RewindResult   // result of the last rewind operation (for display)
 
 	// --- §10 TODO 进度条 ---
 	todos            []CLITodoItem // 从 progress 事件同步的 TODO 列表

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -201,7 +201,7 @@ type cliModel struct {
 	tempStatus      string                       // 临时状态提示（自动过期）
 	pendingCmds     []tea.Cmd                    // commands queued by helpers (auto-drained in Update)
 	shouldQuit      bool                         // Smart quit: quit after current operation completes
-	trimHistoryFn   func(cutoff time.Time) error // Ctrl+K rewind: delete DB messages older than cutoff timestamp
+	trimHistoryFn   func(cutoff time.Time) error // /rewind: delete DB messages at or after cutoff timestamp
 
 	// --- Message queue (typing 期间排队的消息) ---
 	messageQueue   []string // 排队等待发送的消息
@@ -253,12 +253,12 @@ type cliModel struct {
 	fileCompIdx     int      // 当前选中的文件补全索引
 	fileCompActive  bool     // true = Tab 循环中，阻止重新 glob
 
-	// --- §9 Ctrl+K Rewind ---
-	confirmDelete     int                   // >0 = in rewind confirmation mode, value = turns to rewind
-	checkpointHook    *tools.CheckpointHook // file checkpoint hook for rewind file rollback (nil = no file tracking)
-	rewindResult      *tools.RewindResult   // result of the last rewind operation (for display)
-	redLineWrappedPos int                   // viewport line number where red line starts (set by fullRebuild)
-	redLineTargetYOff int                   // cached YOffset to keep red line visible during confirmDelete mode
+	// --- §9 Rewind (/rewind command) ---
+	rewindMode     bool                  // true = rewind overlay active
+	rewindItems    []rewindItem          // candidate user messages for rewind selection
+	rewindCursor   int                   // selected index in rewindItems
+	rewindResult   *tools.RewindResult   // result of the last rewind operation (for display)
+	checkpointHook *tools.CheckpointHook // file checkpoint hook for rewind file rollback (nil = no file tracking)
 
 	// --- §10 TODO 进度条 ---
 	todos            []CLITodoItem // 从 progress 事件同步的 TODO 列表

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -193,15 +193,15 @@ type cliModel struct {
 	ready           bool                  // 是否已初始化
 
 	// --- Agent state ---
-	agentTurnID     uint64                    // monotonically increasing turn counter
-	typing          bool                      // agent 是否正在回复
-	typingStartTime time.Time                 // 本次处理开始时间
-	inputReady      bool                      // 输入就绪状态（agent 回复期间禁止发送）
-	msgBus          *bus.MessageBus           // 消息总线引用
-	tempStatus      string                    // 临时状态提示（自动过期）
-	pendingCmds     []tea.Cmd                 // commands queued by helpers (auto-drained in Update)
-	shouldQuit      bool                      // Smart quit: quit after current operation completes
-	trimHistoryFn   func(keepCount int) error // Ctrl+K 确认删除后回调：截断数据库中的 session messages
+	agentTurnID     uint64                       // monotonically increasing turn counter
+	typing          bool                         // agent 是否正在回复
+	typingStartTime time.Time                    // 本次处理开始时间
+	inputReady      bool                         // 输入就绪状态（agent 回复期间禁止发送）
+	msgBus          *bus.MessageBus              // 消息总线引用
+	tempStatus      string                       // 临时状态提示（自动过期）
+	pendingCmds     []tea.Cmd                    // commands queued by helpers (auto-drained in Update)
+	shouldQuit      bool                         // Smart quit: quit after current operation completes
+	trimHistoryFn   func(cutoff time.Time) error // Ctrl+K rewind: delete DB messages older than cutoff timestamp
 
 	// --- Message queue (typing 期间排队的消息) ---
 	messageQueue   []string // 排队等待发送的消息

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -254,9 +254,10 @@ type cliModel struct {
 	fileCompActive  bool     // true = Tab 循环中，阻止重新 glob
 
 	// --- §9 Ctrl+K Rewind ---
-	confirmDelete  int                   // >0 = in rewind confirmation mode, value = turns to rewind
-	checkpointHook *tools.CheckpointHook // file checkpoint hook for rewind file rollback (nil = no file tracking)
-	rewindResult   *tools.RewindResult   // result of the last rewind operation (for display)
+	confirmDelete     int                   // >0 = in rewind confirmation mode, value = turns to rewind
+	checkpointHook    *tools.CheckpointHook // file checkpoint hook for rewind file rollback (nil = no file tracking)
+	rewindResult      *tools.RewindResult   // result of the last rewind operation (for display)
+	redLineTargetYOff int                   // cached YOffset to keep red line visible during confirmDelete mode
 
 	// --- §10 TODO 进度条 ---
 	todos            []CLITodoItem // 从 progress 事件同步的 TODO 列表

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 	"xbot/llm"
+	log "xbot/logger"
 	"xbot/tools"
 )
 
@@ -88,6 +89,14 @@ type askItem struct {
 type askQItem struct {
 	Question string   `json:"question"`
 	Options  []string `json:"options,omitempty"`
+}
+
+// rewindItem represents a candidate user message in the rewind selection list.
+type rewindItem struct {
+	MsgIndex int       // index in m.messages
+	Preview  string    // first line of the message content (for display)
+	Content  string    // full message content (for input box on select)
+	Time     time.Time // message timestamp (for DB truncation cutoff)
 }
 
 // dangerItem represents a single clearable memory target in the danger zone panel.
@@ -178,6 +187,218 @@ func (m *cliModel) closePanel() {
 	// 恢复 viewport 到正常模式高度
 	m.panelScrollY = 0
 	m.relayoutViewport()
+}
+
+// ---------------------------------------------------------------------------
+// §9 Rewind Panel (/rewind command)
+// ---------------------------------------------------------------------------
+
+// openRewindPanel collects user messages from history and opens the rewind overlay.
+func (m *cliModel) openRewindPanel() {
+	var items []rewindItem
+	for i, msg := range m.messages {
+		if msg.role != "user" {
+			continue
+		}
+		content := msg.content
+		// Build preview: first line, truncated
+		preview := content
+		if idx := strings.Index(preview, "\n"); idx >= 0 {
+			preview = preview[:idx]
+		}
+		if runes := []rune(preview); len(runes) > 60 {
+			preview = string(runes[:57]) + "..."
+		}
+		items = append(items, rewindItem{
+			MsgIndex: i,
+			Preview:  preview,
+			Content:  content,
+			Time:     msg.timestamp,
+		})
+	}
+	if len(items) == 0 {
+		m.showTempStatus(m.locale.NoMessagesToDelete)
+		return
+	}
+	m.rewindItems = items
+	m.rewindCursor = len(items) - 1 // default to most recent
+	m.rewindMode = true
+	m.renderCacheValid = false
+}
+
+// closeRewindPanel deactivates the rewind overlay.
+func (m *cliModel) closeRewindPanel() {
+	m.rewindMode = false
+	m.rewindItems = nil
+	m.rewindCursor = 0
+}
+
+// viewRewindPanel renders the rewind selection overlay (centered panel).
+func (m *cliModel) viewRewindPanel(width, height int) string {
+	if !m.rewindMode || len(m.rewindItems) == 0 {
+		return ""
+	}
+
+	var lines []string
+
+	// Header
+	lines = append(lines, m.styles.PanelHeader.Render(m.locale.RewindTitle))
+	lines = append(lines, m.styles.PanelDesc.Render(m.locale.RewindHint))
+	lines = append(lines, "") // spacer
+
+	// Items (newest first for natural selection)
+	total := len(m.rewindItems)
+	maxVisible := height - 10 // leave room for header + hints + borders
+	if maxVisible < 3 {
+		maxVisible = 3
+	}
+
+	// Calculate scroll offset to keep cursor visible
+	scrollStart := 0
+	scrollEnd := total
+	if total > maxVisible {
+		scrollStart = m.rewindCursor - maxVisible/2
+		if scrollStart < 0 {
+			scrollStart = 0
+		}
+		scrollEnd = scrollStart + maxVisible
+		if scrollEnd > total {
+			scrollEnd = total
+			scrollStart = scrollEnd - maxVisible
+		}
+	}
+
+	for i := scrollStart; i < scrollEnd; i++ {
+		item := m.rewindItems[i]
+		cursor := " "
+		style := m.styles.TextMutedSt
+		if i == m.rewindCursor {
+			cursor = "▸"
+			style = m.styles.Accent
+		}
+		// Show turn number (newest = 1)
+		turnNum := total - i
+		line := style.Render(fmt.Sprintf(" %s #%d  %s", cursor, turnNum, item.Preview))
+		lines = append(lines, line)
+	}
+
+	// Scroll indicator
+	if total > maxVisible {
+		if scrollStart > 0 {
+			lines = append(lines, m.styles.TextMutedSt.Render("  ↑ more"))
+		}
+		if scrollEnd < total {
+			lines = append(lines, m.styles.TextMutedSt.Render("  ↓ more"))
+		}
+	}
+
+	// Build panel with border
+	panelContent := strings.Join(lines, "\n")
+	box := m.styles.PanelBox.Render(panelContent)
+
+	// Hint line
+	hint := m.styles.PanelHint.Render(" ↑↓ Navigate  Enter Rewind  Esc Cancel")
+
+	// Center vertically
+	listH := len(lines) + 3
+	blankLines := max(0, (height-listH)/2)
+	var b strings.Builder
+	for i := 0; i < blankLines; i++ {
+		b.WriteString("\n")
+	}
+	b.WriteString(box)
+	b.WriteString("\n")
+	b.WriteString(hint)
+
+	return b.String()
+}
+
+// handleRewindKey handles key events for the rewind overlay.
+// Returns (handled, cmd). Called from Update() at same priority as quickSwitch.
+func (m *cliModel) handleRewindKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
+	if !m.rewindMode {
+		return false, nil
+	}
+	switch msg.Code {
+	case tea.KeyEsc:
+		m.closeRewindPanel()
+		return true, nil
+	case tea.KeyUp:
+		if m.rewindCursor > 0 {
+			m.rewindCursor--
+		}
+		return true, nil
+	case tea.KeyDown:
+		if m.rewindCursor < len(m.rewindItems)-1 {
+			m.rewindCursor++
+		}
+		return true, nil
+	case tea.KeyHome:
+		m.rewindCursor = 0
+		return true, nil
+	case tea.KeyEnd:
+		m.rewindCursor = len(m.rewindItems) - 1
+		return true, nil
+	case tea.KeyEnter:
+		m.applyRewind()
+		return true, nil
+	}
+	return true, nil // block all other keys
+}
+
+// applyRewind executes the rewind: truncate history at selected message,
+// run file checkpoint rollback, and place selected message content in input box.
+func (m *cliModel) applyRewind() {
+	if m.rewindCursor < 0 || m.rewindCursor >= len(m.rewindItems) {
+		m.closeRewindPanel()
+		return
+	}
+	item := m.rewindItems[m.rewindCursor]
+	selectedContent := item.Content
+	cutoff := item.Time
+
+	// Truncate UI messages: keep everything BEFORE the selected message
+	cutIdx := item.MsgIndex
+	m.messages = m.messages[:cutIdx]
+
+	// Truncate DB session messages (async, by timestamp)
+	if m.trimHistoryFn == nil {
+		log.Warn("Rewind: trimHistoryFn is nil, DB messages will NOT be truncated")
+	} else if cutoff.IsZero() {
+		log.Warn("Rewind: cutoff timestamp is zero, DB messages will NOT be truncated")
+	} else {
+		log.WithFields(log.Fields{"cutIdx": cutIdx, "cutoff": cutoff, "totalMsgs": len(m.messages)}).Info("Rewind: truncating DB messages")
+		go func() {
+			if err := m.trimHistoryFn(cutoff); err != nil {
+				log.WithError(err).Warn("Failed to trim session history after rewind")
+			}
+		}()
+	}
+
+	// File rollback via checkpoint hook
+	if m.checkpointHook != nil && m.checkpointHook.Store() != nil {
+		// Count how many user turns are being rewound (for checkpoint lookup)
+		turnsAfter := 0
+		for _, ri := range m.rewindItems {
+			if ri.MsgIndex >= cutIdx {
+				turnsAfter++
+			}
+		}
+		m.rewindResult = m.checkpointHook.Store().Rewind(turnsAfter)
+	}
+
+	// Put selected message content into input box
+	m.textarea.SetValue(selectedContent)
+	m.textarea.CursorEnd()
+	m.textarea.Focus()
+
+	// Reset state
+	m.rewindMode = false
+	m.rewindItems = nil
+	m.rewindCursor = 0
+	m.renderCacheValid = false
+	m.cachedHistory = ""
+	m.updateViewportContent()
 }
 
 // openBgTasksPanel opens the unified tasks & agents management panel.

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -486,6 +486,9 @@ type CLIChannel struct {
 	// Permission control
 	approvalHook *tools.ApprovalHook // injected to wire CLIApprovalHandler after program creation
 
+	// Pending injections (set before model exists, applied in Start)
+	pendingTrimHistoryFn  func(time.Time) error
+	pendingCheckpointHook *tools.CheckpointHook
 }
 
 // SettingsService is the interface needed by CLIChannel for settings panel.

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -173,7 +173,7 @@ func newGlamourRenderer(wrapWidth int) *glamour.TermRenderer {
 // cliCommands 已知命令列表（用于 Tab 补全，§8）
 var cliCommands = []string{
 	"/cancel", "/clear", "/compact", "/context", "/exit", "/help",
-	"/new", "/quit", "/search", "/settings", "/setup", "/tasks", "/update",
+	"/new", "/quit", "/rewind", "/search", "/settings", "/setup", "/tasks", "/update",
 	"/usage",
 }
 

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -108,6 +108,10 @@ func (m *cliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if handled, cmd := m.handleQuickSwitchKey(key); handled {
 			return m, cmd
 		}
+		// §9 Rewind overlay: same priority as quick switch.
+		if handled, cmd := m.handleRewindKey(key); handled {
+			return m, cmd
+		}
 	}
 
 	// §12 Panel mode: intercept all key events when panel is active

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -21,14 +21,45 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 		groups := visibleMsgGroupIndices(m.messages)
 		switch msg.String() {
 		case "y", "Y":
-			// 确认删除：根据 turn 索引截断
+			// Rewind all: conversation + file rollback
+			if m.confirmDelete > len(groups) {
+				m.confirmDelete = len(groups)
+			}
+			cutIdx := groups[len(groups)-m.confirmDelete]
+			// Count turns being rewound (for file checkpoint lookup)
+			// turnsToRewind = number of user turns being removed
+			turnsBefore := groups[:len(groups)-m.confirmDelete]
+			rewindFromTurn := len(turnsBefore) // turn index where rewind starts
+
+			// Truncate UI messages
+			m.messages = m.messages[:cutIdx]
+			// Truncate DB session messages (async)
+			if m.trimHistoryFn != nil {
+				keepCount := cutIdx
+				go func() {
+					if err := m.trimHistoryFn(keepCount); err != nil {
+						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")
+					}
+				}()
+			}
+
+			// File rollback if checkpoint hook is available
+			if m.checkpointHook != nil && m.checkpointHook.Store() != nil {
+				m.rewindResult = m.checkpointHook.Store().Rewind(rewindFromTurn)
+			}
+
+			m.confirmDelete = 0
+			m.renderCacheValid = false
+			m.cachedHistory = ""
+			m.updateViewportContent()
+			return m, nil, true
+		case "k", "K":
+			// Rewind conversation only (no file rollback)
 			if m.confirmDelete > len(groups) {
 				m.confirmDelete = len(groups)
 			}
 			cutIdx := groups[len(groups)-m.confirmDelete]
 			m.messages = m.messages[:cutIdx]
-			// 同步截断数据库中的 session messages（异步避免阻塞 UI）
-			// safe: 此时 typing=false，输入被 confirmDelete 拦截，不会有并发写入
 			if m.trimHistoryFn != nil {
 				keepCount := cutIdx
 				go func() {
@@ -38,18 +69,19 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				}()
 			}
 			m.confirmDelete = 0
+			m.rewindResult = nil
 			m.renderCacheValid = false
 			m.cachedHistory = ""
 			m.updateViewportContent()
 			return m, nil, true
 		case "n", "N":
-			// 取消删除
+			// Cancel rewind
 			m.confirmDelete = 0
 			m.renderCacheValid = false
 			m.updateViewportContent()
 			return m, nil, true
 		default:
-			// 检查数字键（调整删除数量）
+			// Check number keys (adjust rewind count)
 			if len(msg.Text) > 0 {
 				if len(msg.Text) == 1 && msg.Text[0] >= '1' && msg.Text[0] <= '9' {
 					newDel := int(msg.Text[0] - '0')
@@ -62,7 +94,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 					return m, nil, true
 				}
 			}
-			// 其他键也取消（包括 Esc）
+			// Other keys also cancel (including Esc)
 			m.confirmDelete = 0
 			m.renderCacheValid = false
 			m.updateViewportContent()
@@ -326,7 +358,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 		return m, nil, true
 
 	case msg.String() == "ctrl+k":
-		// §9 Ctrl+K 上下文编辑（按可见消息组计数，tool_summary 合并到 assistant）
+		// §9 Ctrl+K Rewind mode
 		if !m.typing && len(m.messages) > 0 {
 			groups := visibleMsgGroupIndices(m.messages)
 			defaultDel := 1

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -51,6 +51,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			}
 
 			m.confirmDelete = 0
+			m.redLineTargetYOff = 0
 			m.renderCacheValid = false
 			m.cachedHistory = ""
 			m.updateViewportContent()
@@ -74,6 +75,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				}()
 			}
 			m.confirmDelete = 0
+			m.redLineTargetYOff = 0
 			m.rewindResult = nil
 			m.renderCacheValid = false
 			m.cachedHistory = ""
@@ -82,6 +84,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 		case "n", "N":
 			// Cancel rewind
 			m.confirmDelete = 0
+			m.redLineTargetYOff = 0
 			m.renderCacheValid = false
 			m.updateViewportContent()
 			return m, nil, true
@@ -101,6 +104,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			}
 			// Other keys also cancel (including Esc)
 			m.confirmDelete = 0
+			m.redLineTargetYOff = 0
 			m.renderCacheValid = false
 			m.updateViewportContent()
 			return m, nil, true

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -57,6 +57,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 
 			m.confirmDelete = 0
 			m.redLineTargetYOff = 0
+			m.redLineWrappedPos = 0
 			m.renderCacheValid = false
 			m.cachedHistory = ""
 			m.updateViewportContent()
@@ -86,6 +87,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			}
 			m.confirmDelete = 0
 			m.redLineTargetYOff = 0
+			m.redLineWrappedPos = 0
 			m.rewindResult = nil
 			m.renderCacheValid = false
 			m.cachedHistory = ""
@@ -95,6 +97,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			// Cancel rewind
 			m.confirmDelete = 0
 			m.redLineTargetYOff = 0
+			m.redLineWrappedPos = 0
 			m.renderCacheValid = false
 			m.updateViewportContent()
 			return m, nil, true
@@ -115,6 +118,7 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			// Other keys also cancel (including Esc)
 			m.confirmDelete = 0
 			m.redLineTargetYOff = 0
+			m.redLineWrappedPos = 0
 			m.renderCacheValid = false
 			m.updateViewportContent()
 			return m, nil, true

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -26,18 +26,20 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				m.confirmDelete = len(groups)
 			}
 			cutIdx := groups[len(groups)-m.confirmDelete]
+			// Get timestamp of the first message being removed (for DB truncation)
+			var cutoff time.Time
+			if cutIdx < len(m.messages) {
+				cutoff = m.messages[cutIdx].timestamp
+			}
 			// Count turns being rewound (for file checkpoint lookup)
-			// turnsToRewind = number of user turns being removed
-			turnsBefore := groups[:len(groups)-m.confirmDelete]
-			rewindFromTurn := len(turnsBefore) // turn index where rewind starts
+			rewindFromTurn := len(groups) - m.confirmDelete
 
 			// Truncate UI messages
 			m.messages = m.messages[:cutIdx]
-			// Truncate DB session messages (async)
-			if m.trimHistoryFn != nil {
-				keepCount := cutIdx
+			// Truncate DB session messages (async, by timestamp)
+			if m.trimHistoryFn != nil && !cutoff.IsZero() {
 				go func() {
-					if err := m.trimHistoryFn(keepCount); err != nil {
+					if err := m.trimHistoryFn(cutoff); err != nil {
 						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")
 					}
 				}()
@@ -59,11 +61,14 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				m.confirmDelete = len(groups)
 			}
 			cutIdx := groups[len(groups)-m.confirmDelete]
+			var cutoff time.Time
+			if cutIdx < len(m.messages) {
+				cutoff = m.messages[cutIdx].timestamp
+			}
 			m.messages = m.messages[:cutIdx]
-			if m.trimHistoryFn != nil {
-				keepCount := cutIdx
+			if m.trimHistoryFn != nil && !cutoff.IsZero() {
 				go func() {
-					if err := m.trimHistoryFn(keepCount); err != nil {
+					if err := m.trimHistoryFn(cutoff); err != nil {
 						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")
 					}
 				}()

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-
-	log "xbot/logger"
 )
 
 // handleKeyPress processes key press events in the main update loop.
@@ -15,115 +13,6 @@ import (
 // immediately; otherwise, post-switch processing (viewport/textarea update) should continue.
 func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Model, []tea.Cmd, bool) {
 	var cmds []tea.Cmd
-
-	// §9 Ctrl+K 确认模式：必须在 switch msg.Code 之前拦截所有按键
-	if m.confirmDelete > 0 {
-		groups := visibleMsgGroupIndices(m.messages)
-		switch msg.String() {
-		case "y", "Y":
-			// Rewind all: conversation + file rollback
-			if m.confirmDelete > len(groups) {
-				m.confirmDelete = len(groups)
-			}
-			cutIdx := groups[len(groups)-m.confirmDelete]
-			// Get timestamp of the first message being removed (for DB truncation)
-			var cutoff time.Time
-			if cutIdx < len(m.messages) {
-				cutoff = m.messages[cutIdx].timestamp
-			}
-			// Count turns being rewound (for file checkpoint lookup)
-			rewindFromTurn := len(groups) - m.confirmDelete
-
-			// Truncate UI messages
-			m.messages = m.messages[:cutIdx]
-			// Truncate DB session messages (async, by timestamp)
-			if m.trimHistoryFn == nil {
-				log.Warn("Ctrl+K rewind: trimHistoryFn is nil, DB messages will NOT be truncated")
-			} else if cutoff.IsZero() {
-				log.Warn("Ctrl+K rewind: cutoff timestamp is zero, DB messages will NOT be truncated")
-			} else {
-				log.WithFields(log.Fields{"cutIdx": cutIdx, "cutoff": cutoff, "totalMsgs": len(m.messages)}).Info("Ctrl+K rewind: truncating DB messages")
-				go func() {
-					if err := m.trimHistoryFn(cutoff); err != nil {
-						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")
-					}
-				}()
-			}
-
-			// File rollback if checkpoint hook is available
-			if m.checkpointHook != nil && m.checkpointHook.Store() != nil {
-				m.rewindResult = m.checkpointHook.Store().Rewind(rewindFromTurn)
-			}
-
-			m.confirmDelete = 0
-			m.redLineTargetYOff = 0
-			m.redLineWrappedPos = 0
-			m.renderCacheValid = false
-			m.cachedHistory = ""
-			m.updateViewportContent()
-			return m, nil, true
-		case "k", "K":
-			// Rewind conversation only (no file rollback)
-			if m.confirmDelete > len(groups) {
-				m.confirmDelete = len(groups)
-			}
-			cutIdx := groups[len(groups)-m.confirmDelete]
-			var cutoff time.Time
-			if cutIdx < len(m.messages) {
-				cutoff = m.messages[cutIdx].timestamp
-			}
-			m.messages = m.messages[:cutIdx]
-			if m.trimHistoryFn == nil {
-				log.Warn("Ctrl+K rewind (K): trimHistoryFn is nil, DB messages will NOT be truncated")
-			} else if cutoff.IsZero() {
-				log.Warn("Ctrl+K rewind (K): cutoff timestamp is zero, DB messages will NOT be truncated")
-			} else {
-				log.WithFields(log.Fields{"cutIdx": cutIdx, "cutoff": cutoff}).Info("Ctrl+K rewind (K): truncating DB messages")
-				go func() {
-					if err := m.trimHistoryFn(cutoff); err != nil {
-						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")
-					}
-				}()
-			}
-			m.confirmDelete = 0
-			m.redLineTargetYOff = 0
-			m.redLineWrappedPos = 0
-			m.rewindResult = nil
-			m.renderCacheValid = false
-			m.cachedHistory = ""
-			m.updateViewportContent()
-			return m, nil, true
-		case "n", "N":
-			// Cancel rewind
-			m.confirmDelete = 0
-			m.redLineTargetYOff = 0
-			m.redLineWrappedPos = 0
-			m.renderCacheValid = false
-			m.updateViewportContent()
-			return m, nil, true
-		default:
-			// Check number keys (adjust rewind count)
-			if len(msg.Text) > 0 {
-				if len(msg.Text) == 1 && msg.Text[0] >= '1' && msg.Text[0] <= '9' {
-					newDel := int(msg.Text[0] - '0')
-					if newDel > len(groups) {
-						newDel = len(groups)
-					}
-					m.confirmDelete = newDel
-					m.renderCacheValid = false
-					m.updateViewportContent()
-					return m, nil, true
-				}
-			}
-			// Other keys also cancel (including Esc)
-			m.confirmDelete = 0
-			m.redLineTargetYOff = 0
-			m.redLineWrappedPos = 0
-			m.renderCacheValid = false
-			m.updateViewportContent()
-			return m, nil, true
-		}
-	}
 
 	// 🥚 彩蛋覆盖层激活时，按任意键退出（Ctrl+C 除外，已在上面处理）
 	if m.easterEgg != easterEggNone {
@@ -378,23 +267,6 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 	case msg.Code == tea.KeyTab:
 		// §8 Tab 命令补全
 		m.handleTabComplete()
-		return m, nil, true
-
-	case msg.String() == "ctrl+k":
-		// §9 Ctrl+K Rewind mode
-		if !m.typing && len(m.messages) > 0 {
-			groups := visibleMsgGroupIndices(m.messages)
-			defaultDel := 1
-			if defaultDel > len(groups) {
-				defaultDel = len(groups)
-			}
-			m.confirmDelete = defaultDel
-			m.renderCacheValid = false
-			m.updateViewportContent()
-		} else if !m.typing {
-			m.showTempStatus(m.locale.NoMessagesToDelete)
-			return m, nil, true
-		}
 		return m, nil, true
 
 	case msg.String() == "ctrl+o":

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -37,7 +37,12 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			// Truncate UI messages
 			m.messages = m.messages[:cutIdx]
 			// Truncate DB session messages (async, by timestamp)
-			if m.trimHistoryFn != nil && !cutoff.IsZero() {
+			if m.trimHistoryFn == nil {
+				log.Warn("Ctrl+K rewind: trimHistoryFn is nil, DB messages will NOT be truncated")
+			} else if cutoff.IsZero() {
+				log.Warn("Ctrl+K rewind: cutoff timestamp is zero, DB messages will NOT be truncated")
+			} else {
+				log.WithFields(log.Fields{"cutIdx": cutIdx, "cutoff": cutoff, "totalMsgs": len(m.messages)}).Info("Ctrl+K rewind: truncating DB messages")
 				go func() {
 					if err := m.trimHistoryFn(cutoff); err != nil {
 						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")
@@ -67,7 +72,12 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				cutoff = m.messages[cutIdx].timestamp
 			}
 			m.messages = m.messages[:cutIdx]
-			if m.trimHistoryFn != nil && !cutoff.IsZero() {
+			if m.trimHistoryFn == nil {
+				log.Warn("Ctrl+K rewind (K): trimHistoryFn is nil, DB messages will NOT be truncated")
+			} else if cutoff.IsZero() {
+				log.Warn("Ctrl+K rewind (K): cutoff timestamp is zero, DB messages will NOT be truncated")
+			} else {
+				log.WithFields(log.Fields{"cutIdx": cutIdx, "cutoff": cutoff}).Info("Ctrl+K rewind (K): truncating DB messages")
 				go func() {
 					if err := m.trimHistoryFn(cutoff); err != nil {
 						log.WithError(err).Warn("Failed to trim session history after Ctrl+K")

--- a/channel/cli_view.go
+++ b/channel/cli_view.go
@@ -148,15 +148,6 @@ func (m *cliModel) View() tea.View {
 			input,
 			toastStr,
 		)
-	} else if m.confirmDelete > 0 {
-		warningText := m.styles.WarningBold.Render(fmt.Sprintf(m.locale.ConfirmDelete, m.confirmDelete))
-		content = fmt.Sprintf(
-			"%s\n%s\n%s\n%s",
-			titleBar,
-			m.viewport.View(),
-			warningText,
-			input,
-		)
 	} else if m.panelMode == "askuser" {
 		// §12b AskUser split layout: viewport visible above, panel at bottom
 		// Note: no panelFooter here — hints are inside the panel (viewAskUserPanel)
@@ -340,6 +331,14 @@ func (m *cliModel) View() tea.View {
 	// Rendered as a centered panel replacing the entire view.
 	if m.quickSwitchMode != "" {
 		overlay := m.viewQuickSwitch(m.width, m.height)
+		if overlay != "" {
+			v.Content = overlay
+		}
+	}
+
+	// §9 Rewind overlay (/rewind command)
+	if m.rewindMode {
+		overlay := m.viewRewindPanel(m.width, m.height)
 		if overlay != "" {
 			v.Content = overlay
 		}

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -82,8 +82,9 @@ type UILocale struct {
 	SearchNoResults   string
 	SearchNavFormat   string
 
-	// --- F. Confirm dialog ---
-	ConfirmDelete string // "[!] Ctrl+K: delete last %d messages? (y/N, number to adjust)"
+	// --- F. Rewind ---
+	RewindTitle string // "Rewind"
+	RewindHint  string // "Select a message to rewind to. Content will be placed in input box."
 
 	// --- G. Splash ---
 	SplashDesc    string // "AI-powered terminal agent"
@@ -264,6 +265,7 @@ func localeZH() *UILocale {
 			{Cmd: "/context", Desc: "查看上下文信息"},
 			{Cmd: "/new", Desc: "开始新会话"},
 			{Cmd: "/quit", Desc: "退出程序"},
+			{Cmd: "/rewind", Desc: "回退对话"},
 			{Cmd: "/settings", Desc: "打开设置面板"},
 			{Cmd: "/setup", Desc: "重新运行配置引导"},
 			{Cmd: "/tasks", Desc: "查看任务和代理"},
@@ -274,7 +276,6 @@ func localeZH() *UILocale {
 			{Key: "Enter", Desc: "发送消息"},
 			{Key: "Ctrl+C/Esc", Desc: "中止/清空"},
 			{Key: "Ctrl+J", Desc: "输入框换行"},
-			{Key: "Ctrl+K", Desc: "上下文删除"},
 			{Key: "Ctrl+O", Desc: "展开/折叠工具"},
 			{Key: "Tab", Desc: "命令/路径补全"},
 			{Key: "Home/End", Desc: "跳到顶/底部"},
@@ -293,7 +294,8 @@ func localeZH() *UILocale {
 		SearchNavFormat:   "/ %s  [%d/%d]  n next · N prev · Esc",
 
 		// --- F. Confirm dialog ---
-		ConfirmDelete: "[!] Ctrl+K: 删除最后 %d 轮对话？(y/N, 数字调整)",
+		RewindTitle: "Rewind",
+		RewindHint:  "选择要回退到的消息，内容将放入输入框",
 
 		// --- G. Splash ---
 		SplashDesc:    "AI 驱动的终端助手",
@@ -375,7 +377,7 @@ func localeZH() *UILocale {
 		IdlePlaceholders: []string{
 			"Enter 发送 · Ctrl+J 换行 · /help",
 			"/model 切换模型",
-			"Ctrl+K 删除 · Ctrl+O 工具",
+			"Ctrl+O 工具",
 			"@filepath 附加文件",
 			"^ 打开后台任务面板",
 			"/compact 压缩上下文",
@@ -648,6 +650,7 @@ func localeEN() *UILocale {
 			{Cmd: "/context", Desc: "View context info"},
 			{Cmd: "/new", Desc: "Start new session"},
 			{Cmd: "/quit", Desc: "Quit"},
+			{Cmd: "/rewind", Desc: "Rewind conversation"},
 			{Cmd: "/settings", Desc: "Open settings panel"},
 			{Cmd: "/setup", Desc: "Re-run setup wizard"},
 			{Cmd: "/tasks", Desc: "View tasks & agents"},
@@ -658,7 +661,6 @@ func localeEN() *UILocale {
 			{Key: "Enter", Desc: "Send message"},
 			{Key: "Ctrl+C/Esc", Desc: "Abort/clear"},
 			{Key: "Ctrl+J", Desc: "Newline in input"},
-			{Key: "Ctrl+K", Desc: "Context delete"},
 			{Key: "Ctrl+O", Desc: "Expand/collapse tools"},
 			{Key: "Tab", Desc: "Command/path completion"},
 			{Key: "Home/End", Desc: "Jump to top/bottom"},
@@ -677,7 +679,8 @@ func localeEN() *UILocale {
 		SearchNavFormat:   "/ %s  [%d/%d]  n next · N prev · Esc",
 
 		// --- F. Confirm dialog ---
-		ConfirmDelete: "[!] Ctrl+K: delete last %d turns? (y/N, number to adjust)",
+		RewindTitle: "Rewind",
+		RewindHint:  "Select a message to rewind to. Content will be placed in input box.",
 
 		// --- G. Splash ---
 		SplashDesc:    "AI-powered terminal agent",
@@ -759,7 +762,7 @@ func localeEN() *UILocale {
 		IdlePlaceholders: []string{
 			"Enter send · Ctrl+J newline · /help",
 			"Type /model to switch model",
-			"Ctrl+K delete | Ctrl+O tools",
+			"Ctrl+O tools",
 			"@filepath to attach files",
 			"^ open background tasks panel",
 			"Type /compact to compress context",
@@ -1032,6 +1035,7 @@ func localeJA() *UILocale {
 			{Cmd: "/context", Desc: "コンテキスト情報表示"},
 			{Cmd: "/new", Desc: "新規セッション開始"},
 			{Cmd: "/quit", Desc: "終了"},
+			{Cmd: "/rewind", Desc: "会話を巻き戻す"},
 			{Cmd: "/settings", Desc: "設定パネルを開く"},
 			{Cmd: "/setup", Desc: "セットアップウィザード再実行"},
 			{Cmd: "/tasks", Desc: "タスクとエージェント表示"},
@@ -1042,7 +1046,6 @@ func localeJA() *UILocale {
 			{Key: "Enter", Desc: "メッセージ送信"},
 			{Key: "Ctrl+C/Esc", Desc: "中止/クリア"},
 			{Key: "Ctrl+J", Desc: "入力欄で改行"},
-			{Key: "Ctrl+K", Desc: "コンテキスト削除"},
 			{Key: "Ctrl+O", Desc: "ツール展開/折りたたみ"},
 			{Key: "Tab", Desc: "コマンド/パス補完"},
 			{Key: "Home/End", Desc: "先頭/末尾へ移動"},
@@ -1061,7 +1064,8 @@ func localeJA() *UILocale {
 		SearchNavFormat:   "/ %s  [%d/%d]  n 次 · N 前 · Esc",
 
 		// --- F. Confirm dialog ---
-		ConfirmDelete: "[!] Ctrl+K: 最後の %d ターンを削除しますか？(y/N, 数字で調整)",
+		RewindTitle: "Rewind",
+		RewindHint:  "巻き戻すメッセージを選択してください。内容が入力欄に配置されます。",
 
 		// --- G. Splash ---
 		SplashDesc:    "AI駆動のターミナルエージェント",
@@ -1143,7 +1147,7 @@ func localeJA() *UILocale {
 		IdlePlaceholders: []string{
 			"Enter 送信 · Ctrl+J 改行 · /help",
 			"/model でモデル切替",
-			"Ctrl+K 削除 · Ctrl+O ツール",
+			"Ctrl+O ツール",
 			"@filepath でファイル添付",
 			"^ バックグラウンドタスクパネル",
 			"/compact でコンテキスト圧縮",

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -655,7 +655,6 @@ func main() {
 			} else {
 				cliCh.SetCheckpointHook(cpHook)
 				defer cpStore.Cleanup()
-				log.WithField("dir", checkpointDir).Info("Checkpoint hook registered for Ctrl+K rewind")
 			}
 		} else {
 			log.WithError(err).Warn("Failed to create checkpoint store")
@@ -669,7 +668,6 @@ func main() {
 				_, err := cliSessionSvc.PurgeNewerThan(cliTenantID, cutoff)
 				return err
 			})
-			log.WithField("tenantID", cliTenantID).Info("TrimHistoryFn registered for Ctrl+K rewind")
 		} else {
 			log.WithFields(log.Fields{"tenantID": cliTenantID, "hasSessionSvc": cliSessionSvc != nil, "hasDB": app.db != nil}).Warn("TrimHistoryFn NOT registered — DB truncation will not work")
 		}

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -648,11 +648,11 @@ func main() {
 		}
 		// Inject TrimHistoryFn for Ctrl+K session truncation
 		if cliTenantID != 0 && cliSessionSvc != nil {
-			cliCh.SetTrimHistoryFn(func(keepCount int) error {
-				if keepCount <= 0 {
+			cliCh.SetTrimHistoryFn(func(cutoff time.Time) error {
+				if cutoff.IsZero() {
 					return nil
 				}
-				_, err := cliSessionSvc.PurgeOldMessages(cliTenantID, keepCount)
+				_, err := cliSessionSvc.PurgeOlderThan(cliTenantID, cutoff)
 				return err
 			})
 		}

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -652,7 +652,7 @@ func main() {
 				if cutoff.IsZero() {
 					return nil
 				}
-				_, err := cliSessionSvc.PurgeOlderThan(cliTenantID, cutoff)
+				_, err := cliSessionSvc.PurgeNewerThan(cliTenantID, cutoff)
 				return err
 			})
 		}

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -656,6 +656,19 @@ func main() {
 				return err
 			})
 		}
+		// Inject CheckpointHook for Ctrl+K rewind file rollback
+		checkpointDir := filepath.Join(os.Getenv("HOME"), ".xbot", "checkpoints", "cli-default")
+		if cpStore, err := tools.NewCheckpointStore(checkpointDir); err == nil {
+			cpHook := tools.NewCheckpointHook(cpStore)
+			if err := app.agentLoop.ToolHookChain().Use(cpHook); err != nil {
+				log.WithError(err).Warn("Failed to register checkpoint hook")
+			} else {
+				cliCh.SetCheckpointHook(cpHook)
+				defer cpStore.Cleanup()
+			}
+		} else {
+			log.WithError(err).Warn("Failed to create checkpoint store")
+		}
 	}
 
 	// Apply saved theme at startup

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -646,16 +646,6 @@ func main() {
 				cliCh.SetApprovalHook(ah)
 			}
 		}
-		// Inject TrimHistoryFn for Ctrl+K session truncation
-		if cliTenantID != 0 && cliSessionSvc != nil {
-			cliCh.SetTrimHistoryFn(func(cutoff time.Time) error {
-				if cutoff.IsZero() {
-					return nil
-				}
-				_, err := cliSessionSvc.PurgeNewerThan(cliTenantID, cutoff)
-				return err
-			})
-		}
 		// Inject CheckpointHook for Ctrl+K rewind file rollback
 		checkpointDir := filepath.Join(os.Getenv("HOME"), ".xbot", "checkpoints", "cli-default")
 		if cpStore, err := tools.NewCheckpointStore(checkpointDir); err == nil {
@@ -665,9 +655,23 @@ func main() {
 			} else {
 				cliCh.SetCheckpointHook(cpHook)
 				defer cpStore.Cleanup()
+				log.WithField("dir", checkpointDir).Info("Checkpoint hook registered for Ctrl+K rewind")
 			}
 		} else {
 			log.WithError(err).Warn("Failed to create checkpoint store")
+		}
+		// Inject TrimHistoryFn for Ctrl+K session truncation
+		if cliTenantID != 0 && cliSessionSvc != nil {
+			cliCh.SetTrimHistoryFn(func(cutoff time.Time) error {
+				if cutoff.IsZero() {
+					return nil
+				}
+				_, err := cliSessionSvc.PurgeNewerThan(cliTenantID, cutoff)
+				return err
+			})
+			log.WithField("tenantID", cliTenantID).Info("TrimHistoryFn registered for Ctrl+K rewind")
+		} else {
+			log.WithFields(log.Fields{"tenantID": cliTenantID, "hasSessionSvc": cliSessionSvc != nil, "hasDB": app.db != nil}).Warn("TrimHistoryFn NOT registered — DB truncation will not work")
 		}
 	}
 

--- a/docs/agent/tools.md
+++ b/docs/agent/tools.md
@@ -30,6 +30,7 @@
 | `context_edit.go` | ContextEdit tool (conversation history surgery) |
 | `cron.go` | Cron tool (scheduled tasks) |
 | `task_manager.go` | Background task management |
+| `checkpoint.go` | CheckpointHook + CheckpointStore (Ctrl+K rewind file rollback) |
 
 ## Tool Schema Rule
 
@@ -41,6 +42,7 @@ Items: &llm.ToolParamItems{Type: "string"}
 ## Hook Chain
 
 Three built-in hooks: LoggingHook, TimingHook, ApprovalHook.
+Fourth hook: CheckpointHook (file snapshot for Ctrl+K rewind, CLI-only).
 Chain is shared across main Agent and all SubAgents (same instance pointer).
 Max 20 hooks (`MaxHookChainLen` in `hook.go`).
 

--- a/storage/sqlite/session.go
+++ b/storage/sqlite/session.go
@@ -270,13 +270,11 @@ func (s *SessionService) PurgeNewerThan(tenantID int64, cutoff time.Time) (int64
 		return 0, fmt.Errorf("purge newer than: %w", err)
 	}
 	rows, _ := result.RowsAffected()
-	if rows > 0 {
-		log.WithFields(log.Fields{
-			"tenant_id": tenantID,
-			"purged":    rows,
-			"cutoff":    cutoff,
-		}).Debug("Session messages purged (newer than)")
-	}
+	log.WithFields(log.Fields{
+		"tenant_id": tenantID,
+		"purged":    rows,
+		"cutoff":    cutoff.Format(time.RFC3339),
+	}).Info("Session messages purged (newer than or equal)")
 	return rows, nil
 }
 

--- a/storage/sqlite/session.go
+++ b/storage/sqlite/session.go
@@ -255,6 +255,31 @@ func (s *SessionService) PurgeOldMessages(tenantID int64, keepCount int) (int64,
 	return rows, nil
 }
 
+// PurgeOlderThan deletes all messages for a tenant with created_at strictly before the given timestamp.
+// Used by Ctrl+K rewind to truncate DB history to match UI truncation.
+func (s *SessionService) PurgeOlderThan(tenantID int64, cutoff time.Time) (int64, error) {
+	if cutoff.IsZero() {
+		return 0, nil
+	}
+	conn := s.db.Conn()
+	result, err := conn.Exec(
+		"DELETE FROM session_messages WHERE tenant_id = ? AND created_at < ?",
+		tenantID, cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("purge older than: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows > 0 {
+		log.WithFields(log.Fields{
+			"tenant_id": tenantID,
+			"purged":    rows,
+			"cutoff":    cutoff,
+		}).Debug("Session messages purged (older than)")
+	}
+	return rows, nil
+}
+
 // UpdateMessageContent updates the content of the Nth message (0-indexed) for a tenant.
 // Used by observation masking to persist masked content back to session.
 func (s *SessionService) UpdateMessageContent(tenantID int64, messageIndex int, content string) error {

--- a/storage/sqlite/session.go
+++ b/storage/sqlite/session.go
@@ -255,19 +255,19 @@ func (s *SessionService) PurgeOldMessages(tenantID int64, keepCount int) (int64,
 	return rows, nil
 }
 
-// PurgeOlderThan deletes all messages for a tenant with created_at strictly before the given timestamp.
+// PurgeNewerThan deletes all messages for a tenant with created_at at or after the given timestamp.
 // Used by Ctrl+K rewind to truncate DB history to match UI truncation.
-func (s *SessionService) PurgeOlderThan(tenantID int64, cutoff time.Time) (int64, error) {
+func (s *SessionService) PurgeNewerThan(tenantID int64, cutoff time.Time) (int64, error) {
 	if cutoff.IsZero() {
 		return 0, nil
 	}
 	conn := s.db.Conn()
 	result, err := conn.Exec(
-		"DELETE FROM session_messages WHERE tenant_id = ? AND created_at < ?",
+		"DELETE FROM session_messages WHERE tenant_id = ? AND created_at >= ?",
 		tenantID, cutoff,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("purge older than: %w", err)
+		return 0, fmt.Errorf("purge newer than: %w", err)
 	}
 	rows, _ := result.RowsAffected()
 	if rows > 0 {
@@ -275,7 +275,7 @@ func (s *SessionService) PurgeOlderThan(tenantID int64, cutoff time.Time) (int64
 			"tenant_id": tenantID,
 			"purged":    rows,
 			"cutoff":    cutoff,
-		}).Debug("Session messages purged (older than)")
+		}).Debug("Session messages purged (newer than)")
 	}
 	return rows, nil
 }

--- a/tools/approval.go
+++ b/tools/approval.go
@@ -12,6 +12,7 @@ import (
 type contextKey string
 
 const permUsersKey contextKey = "perm_users"
+const workingDirKey contextKey = "working_dir"
 
 // PermUsersFromContext retrieves the permission control user config from context.
 func PermUsersFromContext(ctx context.Context) (defaultUser, privilegedUser string) {
@@ -41,6 +42,20 @@ func WithPermUsers(ctx context.Context, defaultUser, privilegedUser string) cont
 		DefaultUser:    defaultUser,
 		PrivilegedUser: privilegedUser,
 	})
+}
+
+// WithWorkingDir injects the agent's working directory into context.
+// Used by checkpoint hook to resolve relative file paths to absolute.
+func WithWorkingDir(ctx context.Context, dir string) context.Context {
+	return context.WithValue(ctx, workingDirKey, dir)
+}
+
+// WorkingDirFromContext retrieves the working directory from context.
+func WorkingDirFromContext(ctx context.Context) string {
+	if dir, ok := ctx.Value(workingDirKey).(string); ok {
+		return dir
+	}
+	return ""
 }
 
 // ApprovalRequest represents a pending user approval for a tool execution.

--- a/tools/checkpoint.go
+++ b/tools/checkpoint.go
@@ -1,0 +1,409 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	log "xbot/logger"
+)
+
+// maxCheckpointFileSize is the maximum file size (in bytes) to snapshot.
+// Files larger than this are skipped (1 MB).
+const maxCheckpointFileSize = 1 << 20
+
+// FileSnapshot records the state of a file before an agent edit.
+type FileSnapshot struct {
+	TurnIdx  int    `json:"turn_idx"`
+	ToolName string `json:"tool_name"`
+	FilePath string `json:"file_path"`
+	Existed  bool   `json:"existed"`
+	// Base64-encoded file content before the edit. Nil/empty if file didn't exist.
+	ContentB64 string `json:"content_b64,omitempty"`
+}
+
+// RewindResult summarizes the outcome of a rewind operation.
+type RewindResult struct {
+	Restored   []string // files restored to pre-edit state
+	CreatedDel []string // agent-created files that were deleted
+	Skipped    []string // files skipped (too large, sandbox, etc.)
+	Errors     []string // files that failed to restore
+}
+
+// CheckpointStore persists file snapshots as JSONL.
+// Thread-safe: all access is protected by a mutex.
+type CheckpointStore struct {
+	mu      sync.Mutex
+	baseDir string // directory containing changes.jsonl
+	file    *os.File
+	dirty   bool
+}
+
+// NewCheckpointStore creates (or reopens) a checkpoint store for the given session.
+// baseDir is typically ~/.xbot/checkpoints/{sessionKey}/
+func NewCheckpointStore(baseDir string) (*CheckpointStore, error) {
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return nil, fmt.Errorf("checkpoint store mkdir: %w", err)
+	}
+	f, err := os.OpenFile(filepath.Join(baseDir, "changes.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint store open: %w", err)
+	}
+	return &CheckpointStore{baseDir: baseDir, file: f}, nil
+}
+
+// Write appends a snapshot to the JSONL file.
+func (s *CheckpointStore) Write(snap FileSnapshot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("checkpoint marshal: %w", err)
+	}
+	if _, err := s.file.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("checkpoint write: %w", err)
+	}
+	s.dirty = true
+	return nil
+}
+
+// ReadAll reads all snapshots from the JSONL file.
+func (s *CheckpointStore) ReadAll() ([]FileSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(filepath.Join(s.baseDir, "changes.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("checkpoint read: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var snapshots []FileSnapshot
+	for _, line := range splitJSONLLines(data) {
+		if len(line) == 0 {
+			continue
+		}
+		var snap FileSnapshot
+		if err := json.Unmarshal(line, &snap); err != nil {
+			log.WithError(err).Warn("checkpoint store: skipping malformed line")
+			continue
+		}
+		snapshots = append(snapshots, snap)
+	}
+	return snapshots, nil
+}
+
+// Rewind restores files to their state before the given turn index.
+// All file edits from turnIdx onwards are reverted.
+func (s *CheckpointStore) Rewind(turnIdx int) *RewindResult {
+	snapshots, err := s.ReadAll()
+	if err != nil {
+		return &RewindResult{Errors: []string{fmt.Sprintf("read checkpoints: %v", err)}}
+	}
+
+	// Filter snapshots from the target turn onwards
+	var affected []FileSnapshot
+	for _, snap := range snapshots {
+		if snap.TurnIdx >= turnIdx {
+			affected = append(affected, snap)
+		}
+	}
+	if len(affected) == 0 {
+		return &RewindResult{}
+	}
+
+	// Group by file path, keep the earliest snapshot per file (pre-turn state)
+	earliestPerFile := make(map[string]FileSnapshot)
+	for _, snap := range affected {
+		if existing, ok := earliestPerFile[snap.FilePath]; !ok || snap.TurnIdx < existing.TurnIdx {
+			earliestPerFile[snap.FilePath] = snap
+		}
+	}
+
+	result := &RewindResult{}
+
+	for filePath, snap := range earliestPerFile {
+		if snap.Existed {
+			// Restore file to pre-edit content
+			content, err := base64.StdEncoding.DecodeString(snap.ContentB64)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: decode error: %v", filePath, err))
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: mkdir: %v", filePath, err))
+				continue
+			}
+			if err := os.WriteFile(filePath, content, 0644); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: write: %v", filePath, err))
+				continue
+			}
+			result.Restored = append(result.Restored, filePath)
+		} else {
+			// Agent created this file — delete it
+			if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: delete: %v", filePath, err))
+				continue
+			}
+			result.CreatedDel = append(result.CreatedDel, filePath)
+		}
+	}
+
+	// After rewind, truncate the JSONL to only keep pre-turnIdx snapshots
+	s.truncateTo(turnIdx)
+
+	return result
+}
+
+// truncateTo removes all snapshots with turnIdx >= cutoff from the JSONL file.
+func (s *CheckpointStore) truncateTo(cutoff int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	snapshots, err := s.readAllInternal()
+	if err != nil {
+		log.WithError(err).Warn("checkpoint truncate: failed to read")
+		return
+	}
+
+	// Close current file
+	s.file.Close()
+
+	// Rewrite with only pre-cutoff snapshots
+	f, err := os.Create(filepath.Join(s.baseDir, "changes.jsonl"))
+	if err != nil {
+		log.WithError(err).Warn("checkpoint truncate: failed to recreate file")
+		return
+	}
+
+	for _, snap := range snapshots {
+		if snap.TurnIdx < cutoff {
+			data, err := json.Marshal(snap)
+			if err != nil {
+				continue
+			}
+			f.Write(append(data, '\n'))
+		}
+	}
+	s.file = f
+}
+
+func (s *CheckpointStore) readAllInternal() ([]FileSnapshot, error) {
+	data, err := os.ReadFile(filepath.Join(s.baseDir, "changes.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var snapshots []FileSnapshot
+	for _, line := range splitJSONLLines(data) {
+		if len(line) == 0 {
+			continue
+		}
+		var snap FileSnapshot
+		if err := json.Unmarshal(line, &snap); err != nil {
+			continue
+		}
+		snapshots = append(snapshots, snap)
+	}
+	return snapshots, nil
+}
+
+// Close flushes and closes the checkpoint store.
+func (s *CheckpointStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.file.Close()
+}
+
+// Cleanup removes the entire checkpoint directory.
+func (s *CheckpointStore) Cleanup() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.file.Close()
+	return os.RemoveAll(s.baseDir)
+}
+
+// HasChanges returns true if there are any recorded file changes for the given turn or later.
+func (s *CheckpointStore) HasChanges(turnIdx int) bool {
+	snapshots, err := s.ReadAll()
+	if err != nil {
+		return false
+	}
+	for _, snap := range snapshots {
+		if snap.TurnIdx >= turnIdx {
+			return true
+		}
+	}
+	return false
+}
+
+// CountChanges returns the number of distinct files affected from turnIdx onwards.
+func (s *CheckpointStore) CountChanges(turnIdx int) int {
+	snapshots, err := s.ReadAll()
+	if err != nil {
+		return 0
+	}
+	seen := make(map[string]bool)
+	for _, snap := range snapshots {
+		if snap.TurnIdx >= turnIdx {
+			seen[snap.FilePath] = true
+		}
+	}
+	return len(seen)
+}
+
+// CheckpointHook is a ToolHook that snapshots files before FileCreate/FileReplace operations.
+type CheckpointHook struct {
+	mu      sync.Mutex
+	store   *CheckpointStore
+	turnIdx int
+	// pending stores snapshots that haven't been confirmed yet (pre-tool, waiting for post-tool)
+	pending map[string]FileSnapshot // keyed by file path
+}
+
+// NewCheckpointHook creates a new checkpoint hook with the given store.
+func NewCheckpointHook(store *CheckpointStore) *CheckpointHook {
+	return &CheckpointHook{
+		store:   store,
+		pending: make(map[string]FileSnapshot),
+	}
+}
+
+func (h *CheckpointHook) Name() string { return "checkpoint" }
+
+// PreToolUse snapshots the file before a FileCreate/FileReplace operation.
+func (h *CheckpointHook) PreToolUse(_ context.Context, toolName string, args string) error {
+	if toolName != "FileCreate" && toolName != "FileReplace" {
+		return nil
+	}
+
+	filePath := parseFilePath(toolName, args)
+	if filePath == "" {
+		return nil
+	}
+
+	// Read current file content (if it exists)
+	var content []byte
+	existed := false
+	if info, err := os.Stat(filePath); err == nil {
+		if info.Size() > maxCheckpointFileSize {
+			return nil // skip large files
+		}
+		content, err = os.ReadFile(filePath)
+		if err != nil {
+			return nil // can't read, skip
+		}
+		existed = true
+	}
+
+	h.mu.Lock()
+	h.pending[filePath] = FileSnapshot{
+		TurnIdx:    h.turnIdx,
+		ToolName:   toolName,
+		FilePath:   filePath,
+		Existed:    existed,
+		ContentB64: base64.StdEncoding.EncodeToString(content),
+	}
+	h.mu.Unlock()
+
+	return nil
+}
+
+// PostToolUse confirms the snapshot if the tool succeeded, or discards it on failure.
+func (h *CheckpointHook) PostToolUse(_ context.Context, toolName string, _ string, _ *ToolResult, err error, _ time.Duration) {
+	if toolName != "FileCreate" && toolName != "FileReplace" {
+		return
+	}
+
+	h.mu.Lock()
+	// Find and remove the pending entry (most recent)
+	var snap FileSnapshot
+	var found bool
+	for p, s := range h.pending {
+		snap = s
+		delete(h.pending, p)
+		found = true
+		break
+	}
+	h.mu.Unlock()
+
+	if !found {
+		return
+	}
+
+	if err != nil {
+		// Tool failed — discard the snapshot
+		return
+	}
+
+	// Tool succeeded — write snapshot to store
+	if writeErr := h.store.Write(snap); writeErr != nil {
+		log.WithError(writeErr).Warn("checkpoint hook: failed to write snapshot")
+	}
+}
+
+// SetTurnIdx sets the current turn index. Should be called before each agent turn
+// (i.e., before each user message is processed by the agent).
+func (h *CheckpointHook) SetTurnIdx(idx int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.turnIdx = idx
+}
+
+// TurnIdx returns the current turn index.
+func (h *CheckpointHook) TurnIdx() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.turnIdx
+}
+
+// Store returns the underlying CheckpointStore.
+func (h *CheckpointHook) Store() *CheckpointStore {
+	return h.store
+}
+
+// parseFilePath extracts the file path from tool arguments JSON.
+func parseFilePath(toolName, args string) string {
+	if args == "" {
+		return ""
+	}
+	var params struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(args), &params); err != nil {
+		return ""
+	}
+	return params.Path
+}
+
+// splitJSONLLines splits byte data into JSONL lines.
+func splitJSONLLines(data []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			lines = append(lines, data[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		lines = append(lines, data[start:])
+	}
+	return lines
+}

--- a/tools/checkpoint.go
+++ b/tools/checkpoint.go
@@ -288,7 +288,7 @@ func NewCheckpointHook(store *CheckpointStore) *CheckpointHook {
 func (h *CheckpointHook) Name() string { return "checkpoint" }
 
 // PreToolUse snapshots the file before a FileCreate/FileReplace operation.
-func (h *CheckpointHook) PreToolUse(_ context.Context, toolName string, args string) error {
+func (h *CheckpointHook) PreToolUse(ctx context.Context, toolName string, args string) error {
 	if toolName != "FileCreate" && toolName != "FileReplace" {
 		return nil
 	}
@@ -297,6 +297,18 @@ func (h *CheckpointHook) PreToolUse(_ context.Context, toolName string, args str
 	if filePath == "" {
 		return nil
 	}
+
+	// Resolve to absolute path using working directory from context
+	if !filepath.IsAbs(filePath) {
+		wd := WorkingDirFromContext(ctx)
+		if wd == "" {
+			wd, _ = os.Getwd()
+		}
+		if wd != "" {
+			filePath = filepath.Join(wd, filePath)
+		}
+	}
+	filePath = filepath.Clean(filePath)
 
 	// Read current file content (if it exists)
 	var content []byte

--- a/tools/checkpoint.go
+++ b/tools/checkpoint.go
@@ -109,6 +109,7 @@ func (s *CheckpointStore) ReadAll() ([]FileSnapshot, error) {
 func (s *CheckpointStore) Rewind(turnIdx int) *RewindResult {
 	snapshots, err := s.ReadAll()
 	if err != nil {
+		log.WithError(err).Warn("checkpoint rewind: failed to read snapshots")
 		return &RewindResult{Errors: []string{fmt.Sprintf("read checkpoints: %v", err)}}
 	}
 
@@ -120,8 +121,11 @@ func (s *CheckpointStore) Rewind(turnIdx int) *RewindResult {
 		}
 	}
 	if len(affected) == 0 {
+		log.WithField("turnIdx", turnIdx).Debug("checkpoint rewind: no snapshots found at or after turn")
 		return &RewindResult{}
 	}
+
+	log.WithFields(log.Fields{"turnIdx": turnIdx, "snapshots": len(affected), "total": len(snapshots)}).Debug("checkpoint rewind: starting")
 
 	// Group by file path, keep the earliest snapshot per file (pre-turn state)
 	earliestPerFile := make(map[string]FileSnapshot)
@@ -295,6 +299,7 @@ func (h *CheckpointHook) PreToolUse(ctx context.Context, toolName string, args s
 
 	filePath := parseFilePath(toolName, args)
 	if filePath == "" {
+		log.WithField("tool", toolName).Warn("checkpoint hook: empty file path from args")
 		return nil
 	}
 
@@ -367,6 +372,8 @@ func (h *CheckpointHook) PostToolUse(_ context.Context, toolName string, _ strin
 	// Tool succeeded — write snapshot to store
 	if writeErr := h.store.Write(snap); writeErr != nil {
 		log.WithError(writeErr).Warn("checkpoint hook: failed to write snapshot")
+	} else {
+		log.WithFields(log.Fields{"turn": snap.TurnIdx, "tool": toolName, "file": snap.FilePath, "existed": snap.Existed}).Debug("checkpoint hook: snapshot saved")
 	}
 }
 

--- a/tools/checkpoint_test.go
+++ b/tools/checkpoint_test.go
@@ -1,0 +1,286 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckpointStore_WriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatalf("NewCheckpointStore: %v", err)
+	}
+	defer store.Close()
+
+	// Write two snapshots
+	snap1 := FileSnapshot{
+		TurnIdx:    1,
+		ToolName:   "FileReplace",
+		FilePath:   "/tmp/foo.go",
+		Existed:    true,
+		ContentB64: "c2FtcGxl", // "sample" in base64
+	}
+	snap2 := FileSnapshot{
+		TurnIdx:  2,
+		ToolName: "FileCreate",
+		FilePath: "/tmp/new.go",
+		Existed:  false,
+	}
+
+	if err := store.Write(snap1); err != nil {
+		t.Fatalf("Write snap1: %v", err)
+	}
+	if err := store.Write(snap2); err != nil {
+		t.Fatalf("Write snap2: %v", err)
+	}
+
+	// Read back
+	snaps, err := store.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snaps))
+	}
+	if snaps[0].FilePath != "/tmp/foo.go" || snaps[0].TurnIdx != 1 {
+		t.Errorf("snap1 mismatch: %+v", snaps[0])
+	}
+	if snaps[1].FilePath != "/tmp/new.go" || snaps[1].TurnIdx != 2 {
+		t.Errorf("snap2 mismatch: %+v", snaps[1])
+	}
+}
+
+func TestCheckpointStore_Rewind(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatalf("NewCheckpointStore: %v", err)
+	}
+	defer store.Close()
+
+	// Create test files
+	testDir := t.TempDir()
+	fooPath := filepath.Join(testDir, "foo.go")
+	barPath := filepath.Join(testDir, "bar.go")
+	newPath := filepath.Join(testDir, "new.go")
+
+	if err := os.WriteFile(fooPath, []byte("original foo"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(barPath, []byte("original bar"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Turn 1: modify foo.go
+	store.Write(FileSnapshot{
+		TurnIdx: 1, ToolName: "FileReplace", FilePath: fooPath,
+		Existed: true, ContentB64: encodeB64("original foo"),
+	})
+	// Turn 2: modify bar.go, create new.go
+	store.Write(FileSnapshot{
+		TurnIdx: 2, ToolName: "FileReplace", FilePath: barPath,
+		Existed: true, ContentB64: encodeB64("original bar"),
+	})
+	store.Write(FileSnapshot{
+		TurnIdx: 2, ToolName: "FileCreate", FilePath: newPath,
+		Existed: false,
+	})
+
+	// Simulate agent edits: modify files
+	os.WriteFile(fooPath, []byte("modified foo turn 1"), 0644)
+	os.WriteFile(barPath, []byte("modified bar turn 2"), 0644)
+	os.WriteFile(newPath, []byte("new file content"), 0644)
+
+	// Rewind to before turn 2
+	result := store.Rewind(2)
+
+	if len(result.Restored) != 1 {
+		t.Errorf("expected 1 restored, got %d", len(result.Restored))
+	}
+	if len(result.CreatedDel) != 1 {
+		t.Errorf("expected 1 created del, got %d", len(result.CreatedDel))
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+
+	// Verify bar.go was restored
+	content, err := os.ReadFile(barPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "original bar" {
+		t.Errorf("bar.go content = %q, want %q", string(content), "original bar")
+	}
+
+	// Verify new.go was deleted
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Error("new.go should have been deleted")
+	}
+
+	// Verify foo.go was NOT restored (it was modified in turn 1, rewind to turn 2)
+	content, err = os.ReadFile(fooPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "modified foo turn 1" {
+		t.Errorf("foo.go should not be restored: got %q", string(content))
+	}
+}
+
+func TestCheckpointStore_RewindAll(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatalf("NewCheckpointStore: %v", err)
+	}
+	defer store.Close()
+
+	testDir := t.TempDir()
+	fooPath := filepath.Join(testDir, "foo.go")
+	os.WriteFile(fooPath, []byte("original"), 0644)
+
+	// Turn 1: modify foo.go
+	store.Write(FileSnapshot{
+		TurnIdx: 1, ToolName: "FileReplace", FilePath: fooPath,
+		Existed: true, ContentB64: encodeB64("original"),
+	})
+
+	os.WriteFile(fooPath, []byte("modified"), 0644)
+
+	// Rewind everything
+	result := store.Rewind(1)
+	if len(result.Restored) != 1 {
+		t.Errorf("expected 1 restored, got %d", len(result.Restored))
+	}
+
+	content, _ := os.ReadFile(fooPath)
+	if string(content) != "original" {
+		t.Errorf("foo.go = %q, want %q", string(content), "original")
+	}
+}
+
+func TestCheckpointStore_CountChanges(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	store.Write(FileSnapshot{TurnIdx: 1, FilePath: "/a.go"})
+	store.Write(FileSnapshot{TurnIdx: 2, FilePath: "/b.go"})
+	store.Write(FileSnapshot{TurnIdx: 2, FilePath: "/c.go"})
+	store.Write(FileSnapshot{TurnIdx: 3, FilePath: "/d.go"})
+
+	if n := store.CountChanges(2); n != 3 {
+		t.Errorf("CountChanges(2) = %d, want 3 (b, c, d)", n)
+	}
+	if n := store.CountChanges(3); n != 1 {
+		t.Errorf("CountChanges(3) = %d, want 1 (d)", n)
+	}
+	if n := store.CountChanges(4); n != 0 {
+		t.Errorf("CountChanges(4) = %d, want 0", n)
+	}
+}
+
+func TestCheckpointStore_Cleanup(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.Write(FileSnapshot{TurnIdx: 1, FilePath: "/a.go"})
+	store.Close()
+
+	store2, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snaps, _ := store2.ReadAll()
+	if len(snaps) != 1 {
+		t.Errorf("expected 1 snapshot after reopen, got %d", len(snaps))
+	}
+	store2.Cleanup()
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("cleanup should remove directory")
+	}
+}
+
+// encodeB64 is a test helper for base64 encoding file content.
+func encodeB64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestCheckpointHook_PrePost(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	hook := NewCheckpointHook(store)
+	hook.SetTurnIdx(1)
+
+	testDir := t.TempDir()
+	testFile := filepath.Join(testDir, "test.go")
+	os.WriteFile(testFile, []byte("before"), 0644)
+
+	// Pre: snapshot before edit
+	args := `{"path": "` + testFile + `", "old_string": "before", "new_string": "after"}`
+	if err := hook.PreToolUse(context.TODO(), "FileReplace", args); err != nil {
+		t.Fatalf("PreToolUse: %v", err)
+	}
+
+	// Simulate the edit
+	os.WriteFile(testFile, []byte("after"), 0644)
+
+	// Post: confirm success
+	hook.PostToolUse(context.TODO(), "FileReplace", args, nil, nil, 0)
+
+	// Verify snapshot was recorded
+	snaps, _ := store.ReadAll()
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+	if snaps[0].FilePath != testFile {
+		t.Errorf("path = %q, want %q", snaps[0].FilePath, testFile)
+	}
+	if !snaps[0].Existed {
+		t.Error("file should have existed")
+	}
+}
+
+func TestCheckpointHook_PostError(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCheckpointStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	hook := NewCheckpointHook(store)
+	hook.SetTurnIdx(1)
+
+	testDir := t.TempDir()
+	testFile := filepath.Join(testDir, "test.go")
+	os.WriteFile(testFile, []byte("before"), 0644)
+
+	args := `{"path": "` + testFile + `", "old_string": "x", "new_string": "y"}`
+	hook.PreToolUse(context.TODO(), "FileReplace", args)
+
+	// Post with error — should discard snapshot
+	hook.PostToolUse(context.TODO(), "FileReplace", args, nil, os.ErrNotExist, 0)
+
+	snaps, _ := store.ReadAll()
+	if len(snaps) != 0 {
+		t.Errorf("expected 0 snapshots on error, got %d", len(snaps))
+	}
+}


### PR DESCRIPTION
Rewrite Ctrl+K from simple conversation truncation to a Claude Code-style rewind feature that also rolls back agent file modifications.

## Changes

### New: CheckpointHook + CheckpointStore (tools/checkpoint.go)
- Intercepts FileCreate/FileReplace via the existing ToolHook interface
- Snapshots file content before each edit, stores as append-only JSONL
- Rewind(turnIdx) restores files: modified files reverted, agent-created files deleted
- Session-scoped: checkpoint directory deleted on CLI exit

### Rewired: Ctrl+K UI (channel/)
- Boundary line shows action hints: [Y] rewind all, [K] conversation only, [N] cancel
- Shows file change count at rewind boundary
- After rewind: displays summary (files restored, files deleted, errors)

### Wiring (cmd/xbot-cli/main.go)
- Creates CheckpointStore, registers CheckpointHook on HookChain
- Injects hook into CLI channel, defer cpStore.Cleanup() on exit

## Design Tradeoffs

- Only track FileCreate/FileReplace (Shell file changes not tracked)
- No external modification detection (always restore to snapshot)
- Files >1MB skipped, sandbox file changes not tracked
- Session-scoped storage (deleted on exit)

## Testing

- 7 new unit tests in tools/checkpoint_test.go
- All existing tests pass
