### PR TITLE
feat: per-role colors for SubAgent display

### DIFF
--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -1169,17 +1169,36 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 
 	cfg := a.buildSubAgentRunConfig(ctx, parentCtx, task, systemPrompt, allowedTools, caps, roleName, false, subModel)
 
-	// SubAgent 进度上报：优先使用父 Agent 注入的回调（避免并发 SubAgent 互相覆盖 patch），
-	// 否则 fallback 到直接发送消息（非并行场景）。
-	// 进度穿透：子 Agent 的 ProgressNotifier 不仅上报自身进度，还注入回调到 subCtx
-	// 让更深层 SubAgent 也能递归穿透进度到最顶层。
-	if cb, ok := SubAgentProgressFromContext(ctx); ok {
-		rn := roleName
-		myDepth := cc.Depth() + 1
-		myPath := cc.Spawn(rn).Chain
+	// SubAgent 进度上报：统一走穿透回调模式。
+	// 顶层 agent（无 parent callback）创建 root callback，只渲染 depth=1（直接子 agent）的进度。
+	// 深层子 agent 的进度通过穿透回调冒泡上来，但 depth>1 不发送到聊天窗口。
+	myDepth := cc.Depth() + 1
+	myPath := cc.Spawn(roleName).Chain
+
+	// 确定当前层级使用的 parent callback（可能为 nil）
+	parentCB, _ := SubAgentProgressFromContext(ctx)
+
+	// 构建 subCtx：传递 CallChain + 穿透回调
+	subCtx := WithCallChain(ctx, cc.Spawn(roleName))
+
+	// 注入穿透回调到 subCtx，让更深层 SubAgent 递归上报进度到顶层
+	// 穿透回调包装 parentCB，累加 depth 和 path
+	subCtx = WithSubAgentProgress(subCtx, func(detail SubAgentProgressDetail) {
+		detail.Depth = myDepth + detail.Depth
+		if len(detail.Path) == 0 {
+			detail.Path = myPath
+		}
+		if parentCB != nil {
+			parentCB(detail)
+		}
+	})
+
+	// 设置当前层级的 ProgressNotifier
+	if parentCB != nil {
+		// 非顶层：穿透进度到父 agent（由上面的穿透回调处理）
 		cfg.ProgressNotifier = func(lines []string) {
 			if len(lines) > 0 {
-				cb(SubAgentProgressDetail{
+				parentCB(SubAgentProgressDetail{
 					Path:  myPath,
 					Lines: lines,
 					Depth: myDepth,
@@ -1187,7 +1206,8 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 			}
 		}
 	} else if originChannel != "" && originChatID != "" {
-		rn := roleName // 闭包捕获
+		// 顶层 agent（交互式）：只发送 depth=1 的进度到聊天窗口
+		rn := roleName
 		cfg.ProgressNotifier = func(lines []string) {
 			if len(lines) > 0 {
 				last := lines[len(lines)-1]
@@ -1198,22 +1218,6 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 				_ = a.sendMessage(originChannel, originChatID, prefixed)
 			}
 		}
-	}
-
-	// 传递 CallChain 给子 Agent
-	subCtx := WithCallChain(ctx, cc.Spawn(roleName))
-
-	// 注入穿透回调到 subCtx，让子 Agent 的 execOne 能获取并递归上报进度到父 Agent
-	if cb, ok := SubAgentProgressFromContext(ctx); ok {
-		myDepth := cc.Depth() + 1
-		myPath := cc.Spawn(roleName).Chain
-		subCtx = WithSubAgentProgress(subCtx, func(detail SubAgentProgressDetail) {
-			detail.Depth = myDepth + detail.Depth
-			if len(detail.Path) == 0 {
-				detail.Path = myPath
-			}
-			cb(detail)
-		})
 	}
 
 	// Register one-shot subagent in interactiveSubAgents so it's visible
@@ -1230,15 +1234,25 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 	}
 	a.interactiveSubAgents.Store(oneshotKey, oneshotIA)
 
+	// Wire incremental snapshot callback so iteration history is available
+	// during Run() for panel preview and inspect — not only after completion.
+	cfg.OnIterationSnapshot = func(snap IterationSnapshot) {
+		oneshotIA.iterationHistory = append(oneshotIA.iterationHistory, snap)
+	}
+
 	out := Run(subCtx, cfg)
 
 	// Populate iteration history so inspect can show results after completion
 	oneshotIA.running = false
-	oneshotIA.lastReply = out.Content
-	if len(out.IterationHistory) > 0 {
-		oneshotIA.iterationHistory = append(oneshotIA.iterationHistory, out.IterationHistory...)
+	if out != nil {
+		oneshotIA.lastReply = out.Content
+		log.Ctx(ctx).WithField("iteration_count", len(oneshotIA.iterationHistory)).Info("oneshot subagent completed")
+	} else {
+		log.Ctx(ctx).Warn("oneshot subagent returned nil output")
 	}
-	// Don't delete — let inactivity cleanup remove it so user can inspect results
+	// One-shot agents are ephemeral: remove immediately after completion.
+	// Unlike interactive sessions, there's no "send more messages" use case.
+	a.interactiveSubAgents.Delete(oneshotKey)
 
 	log.Ctx(ctx).WithFields(log.Fields{
 		"parent":    parentAgentID,

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -1216,7 +1216,23 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 		})
 	}
 
+	// Register one-shot subagent in interactiveSubAgents so it's visible
+	// in the task & agents panel. Removed immediately after Run completes.
+	oneshotInstance := fmt.Sprintf("oneshot-%s-%d", roleName, time.Now().UnixNano())
+	oneshotKey := interactiveKey(originChannel, originChatID, roleName, oneshotInstance)
+	oneshotIA := &interactiveAgent{
+		roleName:   roleName,
+		instance:   oneshotInstance,
+		lastUsed:   time.Now(),
+		running:    true,
+		background: false,
+	}
+	a.interactiveSubAgents.Store(oneshotKey, oneshotIA)
+
 	out := Run(subCtx, cfg)
+
+	// Unregister one-shot subagent
+	a.interactiveSubAgents.Delete(oneshotKey)
 
 	log.Ctx(ctx).WithFields(log.Fields{
 		"parent":    parentAgentID,

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -1232,8 +1232,13 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 
 	out := Run(subCtx, cfg)
 
-	// Unregister one-shot subagent
-	a.interactiveSubAgents.Delete(oneshotKey)
+	// Populate iteration history so inspect can show results after completion
+	oneshotIA.running = false
+	oneshotIA.lastReply = out.Content
+	if len(out.IterationHistory) > 0 {
+		oneshotIA.iterationHistory = append(oneshotIA.iterationHistory, out.IterationHistory...)
+	}
+	// Don't delete — let inactivity cleanup remove it so user can inspect results
 
 	log.Ctx(ctx).WithFields(log.Fields{
 		"parent":    parentAgentID,

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -1226,6 +1226,7 @@ func (a *Agent) spawnSubAgent(ctx context.Context, msg bus.InboundMessage) (*bus
 		lastUsed:   time.Now(),
 		running:    true,
 		background: false,
+		task:       task,
 	}
 	a.interactiveSubAgents.Store(oneshotKey, oneshotIA)
 

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -602,16 +602,16 @@ func (a *Agent) InspectInteractiveSession(
 		fmt.Fprintf(&sb, "\n### Last Reply:\n%s\n", ia.lastReply)
 	}
 
-	// One-shot subagents don't have messages or iterationHistory.
-	// Show a status line instead.
+	// One-shot subagents: show status when no iterations yet (still running)
 	if ia.task != "" && len(ia.messages) == 0 && len(ia.iterationHistory) == 0 {
 		if ia.running {
 			fmt.Fprintf(&sb, "\n_One-shot subagent is executing..._\n")
-		} else {
-			fmt.Fprintf(&sb, "\n_One-shot subagent completed._\n")
 		}
 		return sb.String(), nil
 	}
+
+	// One-shot subagents have no messages, skip that section.
+	// But they do have iterationHistory (after completion).
 
 	// ── 3. Recent Messages — tail of conversation history ──
 	// Show the last tailCount messages so the parent agent can see

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -37,6 +37,7 @@ type interactiveAgent struct {
 	cancelCurrent    context.CancelFunc  // 当前运行的取消函数（nil = idle）
 	lastError        string              // 最近一次错误
 	lastReply        string              // 最近一次回复摘要
+	task             string              // one-shot subagent 的任务描述（交互式为空）
 }
 
 // interactiveSessionTTL 是 interactive SubAgent 会话的生存时间。
@@ -588,11 +589,28 @@ func (a *Agent) InspectInteractiveSession(
 	if ia.running {
 		status = "running"
 	}
-	fmt.Fprintf(&sb, "## %s/%s  (%s, %d messages)\n", roleName, instance, status, len(ia.messages))
+	if ia.task != "" {
+		// One-shot subagent: show task instead of message count
+		fmt.Fprintf(&sb, "## %s/%s  (%s)\n", roleName, instance, status)
+		fmt.Fprintf(&sb, "\n**Task**: %s\n", ia.task)
+	} else {
+		fmt.Fprintf(&sb, "## %s/%s  (%s, %d messages)\n", roleName, instance, status, len(ia.messages))
+	}
 
 	// ── 2. Last Reply (full) — most useful info first ──
 	if ia.lastReply != "" {
 		fmt.Fprintf(&sb, "\n### Last Reply:\n%s\n", ia.lastReply)
+	}
+
+	// One-shot subagents don't have messages or iterationHistory.
+	// Show a status line instead.
+	if ia.task != "" && len(ia.messages) == 0 && len(ia.iterationHistory) == 0 {
+		if ia.running {
+			fmt.Fprintf(&sb, "\n_One-shot subagent is executing..._\n")
+		} else {
+			fmt.Fprintf(&sb, "\n_One-shot subagent completed._\n")
+		}
+		return sb.String(), nil
 	}
 
 	// ── 3. Recent Messages — tail of conversation history ──
@@ -830,6 +848,7 @@ type InteractiveSessionInfo struct {
 	Instance   string
 	Running    bool
 	Background bool
+	Task       string // one-shot subagent task description (empty for interactive)
 }
 
 // ListInteractiveSessions returns info about all interactive sessions matching the given channel/chatID prefix.
@@ -856,6 +875,7 @@ func (a *Agent) ListInteractiveSessions(channel, chatID string) []InteractiveSes
 			Instance:   ia.instance,
 			Running:    ia.running,
 			Background: ia.background,
+			Task:       ia.task,
 		}
 		ia.mu.Unlock()
 		results = append(results, info)

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -849,6 +849,7 @@ type InteractiveSessionInfo struct {
 	Running    bool
 	Background bool
 	Task       string // one-shot subagent task description (empty for interactive)
+	Preview    string // latest progress/last reply summary for panel display
 }
 
 // ListInteractiveSessions returns info about all interactive sessions matching the given channel/chatID prefix.
@@ -876,6 +877,7 @@ func (a *Agent) ListInteractiveSessions(channel, chatID string) []InteractiveSes
 			Running:    ia.running,
 			Background: ia.background,
 			Task:       ia.task,
+			Preview:    summarizeInteractivePreviewLocked(ia),
 		}
 		ia.mu.Unlock()
 		results = append(results, info)
@@ -887,4 +889,28 @@ func (a *Agent) ListInteractiveSessions(channel, chatID string) []InteractiveSes
 // CountInteractiveSessions returns the number of active interactive sessions for the given channel/chatID.
 func (a *Agent) CountInteractiveSessions(channel, chatID string) int {
 	return len(a.ListInteractiveSessions(channel, chatID))
+}
+
+func summarizeInteractivePreviewLocked(ia *interactiveAgent) string {
+	if ia == nil {
+		return ""
+	}
+	if n := len(ia.iterationHistory); n > 0 {
+		snap := ia.iterationHistory[n-1]
+		if snap.Thinking != "" {
+			return snap.Thinking
+		}
+		if snap.Reasoning != "" {
+			return snap.Reasoning
+		}
+		for i := len(snap.Tools) - 1; i >= 0; i-- {
+			if snap.Tools[i].Summary != "" {
+				return snap.Tools[i].Summary
+			}
+		}
+	}
+	if ia.lastError != "" {
+		return "Error: " + ia.lastError
+	}
+	return ia.lastReply
 }

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -969,7 +969,7 @@ func (m *cliModel) renderSubAgentTree(sb *strings.Builder, agents []CLISubAgent,
 			}
 		}
 		icon := m.ticker.viewFrames(waveFrames)
-		style := m.styles.ProgressRunning
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color(RoleColor(sa.Role)))
 		switch sa.Status {
 		case "error":
 			icon = "✗"

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -21,6 +21,7 @@ type panelAgentEntry struct {
 	Instance   string // instance ID
 	Running    bool   // true = currently executing
 	Background bool   // true = background mode
+	Task       string // one-shot subagent task description
 }
 
 // openSettingsPanel activates the settings panel overlay.
@@ -426,6 +427,16 @@ func (m *cliModel) viewBgTaskList() string {
 			}
 
 			label := fmt.Sprintf("[agent] %s/%s (%s)", ag.Role, ag.Instance, mode)
+			if ag.Task != "" {
+				// One-shot subagent: show truncated task instead of instance ID
+				taskPreview := ag.Task
+				if len(taskPreview) > 45 {
+					taskPreview = taskPreview[:42] + "..."
+				}
+				// Replace newlines for single-line display
+				taskPreview = strings.ReplaceAll(taskPreview, "\n", " ")
+				label = fmt.Sprintf("[agent] %s: %s", ag.Role, taskPreview)
+			}
 			if len(label) > 55 {
 				label = label[:52] + "..."
 			}

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -22,6 +22,7 @@ type panelAgentEntry struct {
 	Running    bool   // true = currently executing
 	Background bool   // true = background mode
 	Task       string // one-shot subagent task description
+	Preview    string // latest progress/last reply summary
 }
 
 // openSettingsPanel activates the settings panel overlay.
@@ -453,6 +454,18 @@ func (m *cliModel) viewBgTaskList() string {
 			)
 			sb.WriteString(line)
 			sb.WriteString("\n")
+			if ag.Preview != "" {
+				preview := strings.ReplaceAll(ag.Preview, "\n", " ")
+				preview = strings.TrimSpace(preview)
+				if len(preview) > 64 {
+					preview = preview[:61] + "..."
+				}
+				previewStyle := s.PanelDesc
+				if !ag.Running {
+					previewStyle = previewStyle.Faint(true)
+				}
+				fmt.Fprintf(&sb, "    %s\n", previewStyle.Render(preview))
+			}
 			idx++
 		}
 	}

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -4,6 +4,7 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"context"
 	"fmt"
 	"strings"
@@ -407,10 +408,11 @@ func (m *cliModel) viewBgTaskList() string {
 		// Render agents
 		for _, ag := range m.panelBgAgents {
 			statusIcon := "●"
-			statusStyle := s.ProgressRunning
+			roleColor := lipgloss.Color(RoleColor(ag.Role))
+			statusStyle := lipgloss.NewStyle().Foreground(roleColor)
 			if !ag.Running {
 				statusIcon = "◦"
-				statusStyle = s.ProgressDone
+				statusStyle = statusStyle.Faint(true)
 			}
 
 			prefix := "  "
@@ -428,10 +430,15 @@ func (m *cliModel) viewBgTaskList() string {
 				label = label[:52] + "..."
 			}
 
+			labelStyle := lipgloss.NewStyle().Foreground(roleColor)
+			if !ag.Running {
+				labelStyle = labelStyle.Faint(true)
+			}
+
 			line := fmt.Sprintf("%s %s  %s",
 				prefix,
 				statusStyle.Render(statusIcon),
-				label,
+				labelStyle.Render(label),
 			)
 			sb.WriteString(line)
 			sb.WriteString("\n")

--- a/channel/cli_theme.go
+++ b/channel/cli_theme.go
@@ -4,8 +4,10 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/lipgloss/v2"
 	"github.com/muesli/termenv"
+	"hash/fnv"
 	"image/color"
 	"os"
+	"strings"
 )
 
 func init() {
@@ -603,4 +605,45 @@ func ThemeNames() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// roleColorPalette provides distinct hues for known SubAgent roles.
+// Roles not listed here get a deterministic color from hash.
+var roleColorPalette = map[string]string{
+	"explore":            "#8ab4f8", // blue
+	"debug":              "#f28b82", // red
+	"secretariat":        "#c58af9", // purple
+	"chancellery":        "#fdd663", // yellow
+	"department-state":   "#81c995", // green
+	"crown-prince":       "#ff8a65", // orange
+	"ministry-works":     "#4dd0e1", // cyan
+	"ministry-justice":   "#ef5350", // red-alt
+	"ministry-personnel": "#ab47bc", // purple-alt
+	"ministry-revenue":   "#66bb6a", // green-alt
+	"ministry-defense":   "#ffa726", // amber
+	"ministry-rites":     "#42a5f5", // blue-alt
+	"github":             "#f0f6fc", // white (GitHub logo)
+	"gitlab":             "#fc6d26", // GitLab orange
+	"pipeline-operator":  "#4dd0e1", // cyan
+}
+
+// fallbackRoleHues is a pool of visually distinct hues for unknown roles.
+var fallbackRoleHues = []string{
+	"#8ab4f8", "#81c995", "#c58af9", "#fdd663", "#f28b82",
+	"#4dd0e1", "#ff8a65", "#ab47bc", "#66bb6a", "#42a5f5",
+	"#ef5350", "#ffa726",
+}
+
+// RoleColor returns a lipgloss.Color for a SubAgent role name.
+// Known roles get a fixed color from roleColorPalette; unknown roles get
+// a deterministic color from hash so the same role always has the same color.
+func RoleColor(role string) string {
+	if c, ok := roleColorPalette[role]; ok {
+		return c
+	}
+	// Deterministic hash for unknown roles
+	h := fnv.New32a()
+	h.Write([]byte(strings.ToLower(role)))
+	idx := h.Sum32() % uint32(len(fallbackRoleHues))
+	return fallbackRoleHues[idx]
 }

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -441,6 +441,7 @@ type AgentPanelEntry struct {
 	Instance   string
 	Running    bool
 	Background bool
+	Task       string // one-shot subagent task (empty for interactive)
 }
 
 // ---------------------------------------------------------------------------

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -442,6 +442,7 @@ type AgentPanelEntry struct {
 	Running    bool
 	Background bool
 	Task       string // one-shot subagent task (empty for interactive)
+	Preview    string // latest progress/last reply summary for panel display
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -581,6 +581,7 @@ func main() {
 					Instance:   s.Instance,
 					Running:    s.Running,
 					Background: s.Background,
+					Task:       s.Task,
 				}
 			}
 			return entries

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -582,6 +582,7 @@ func main() {
 					Running:    s.Running,
 					Background: s.Background,
 					Task:       s.Task,
+					Preview:    s.Preview,
 				}
 			}
 			return entries

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -57,13 +57,14 @@ Persistent multi-turn session. Create once, send multiple messages, unload when 
 
 ## Background rule
 Only interactive sub-agents may run in background mode.
+Prefer foreground execution by default. Use background=true only when the sub-agent truly needs to keep running while the caller does other work; using background=true and then immediately waiting/sleeping for the result is effectively the same as foreground mode, just with more complexity.
 
 Parameters (JSON):
   - task: string (required except some control actions), the task or message for the sub-agent
   - role: string (required), predefined role name
   - instance: string (REQUIRED on every call), unique instance ID used to identify the session/run
   - interactive: boolean (optional), create or reuse an interactive session
-  - background: boolean (optional), only valid when interactive=true
+  - background: boolean (optional), only valid when interactive=true; prefer false unless there is a concrete need to let the caller continue doing other work before checking back later
   - action: string (optional), one of "send", "unload", "inspect", "interrupt"
 
 Available roles are listed in the <available_agents> section of the system prompt.`
@@ -75,7 +76,7 @@ func (t *SubAgentTool) Parameters() []llm.ToolParam {
 		{Name: "role", Type: "string", Description: "Predefined role name (for example: code-reviewer)", Required: true},
 		{Name: "instance", Type: "string", Description: `REQUIRED on every call. Stable unique ID for this sub-agent run/session. Never omit it. Examples: "review-1", "planner-main", "bugfix-login".`, Required: true},
 		{Name: "interactive", Type: "boolean", Description: "Create or reuse an interactive session for multi-turn conversation"},
-		{Name: "background", Type: "boolean", Description: "Run the interactive sub-agent in background mode. Only valid when interactive=true."},
+		{Name: "background", Type: "boolean", Description: "Run the interactive sub-agent in background mode. Only valid when interactive=true. Prefer foreground by default; use this only when the caller genuinely needs to continue other work and check back later."},
 		{Name: "action", Type: "string", Description: `Optional control action: "send", "unload", "inspect", or "interrupt".`},
 		{Name: "tail", Type: "integer", Description: "For action=\"inspect\": number of recent iterations to show (default: 5)."},
 	}


### PR DESCRIPTION
## Changes

Each SubAgent role now gets a distinct color in both the **progress tree** and the **task & agents panel**.

### Color mapping (`cli_theme.go`)
- **Known roles** get fixed, carefully chosen colors:
  - explore → blue, debug → red, secretariat → purple, chancellery → yellow
  - Six ministries → green, cyan, orange, amber, etc.
  - github → white, gitlab → GitLab orange
- **Unknown roles** get a deterministic color from FNV-32 hash, so the same role always has the same color across sessions

### Applied in
- `cli_message.go` — progress tree running icon uses per-role color
- `cli_panel.go` — task & agents panel agent icon + label use per-role color (faint when stopped)

### Foreground subagents in panel
Interactive foreground subagents were already visible in the panel (tracked by `agentCount` / `ListInteractiveSessions`). One-shot foreground subagents cannot be shown because the parent agent is blocked during their execution — this is a fundamental TUI limitation.
