### PR TITLE
chore: bump go.mod to 1.26 to match local toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module xbot
 
-go 1.25.3
+go 1.26
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
CI uses `go-version-file: go.mod` which was `go 1.25.3`, but local toolchain is Go 1.26.1. gofmt behavior differs between versions, causing CI lint failures on correctly-formatted code (e.g. tab width alignment in struct fields and nested if-blocks).

This bumps go.mod to `go 1.26` so CI installs the same major version as local.