### PR TITLE
fix: rewind duplicate user message bug

### DIFF
--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -667,7 +667,7 @@ func main() {
 				if cutoff.IsZero() {
 					return nil
 				}
-				_, err := cliSessionSvc.PurgeNewerThan(cliTenantID, cutoff)
+				_, err := cliSessionSvc.PurgeNewerThanOrEqual(cliTenantID, cutoff)
 				return err
 			})
 		} else {

--- a/storage/sqlite/session.go
+++ b/storage/sqlite/session.go
@@ -255,10 +255,40 @@ func (s *SessionService) PurgeOldMessages(tenantID int64, keepCount int) (int64,
 	return rows, nil
 }
 
+// PurgeNewerThanOrEqual deletes all messages for a tenant with created_at >= the given timestamp.
+// Used by Ctrl+K rewind to truncate DB history to match UI truncation.
+// Uses ">=" (not ">") so the selected rewind message is also removed — the UI already
+// places its content into the input box for re-editing, so keeping it in DB would cause
+// a duplicate on re-send.
+func (s *SessionService) PurgeNewerThanOrEqual(tenantID int64, cutoff time.Time) (int64, error) {
+	if cutoff.IsZero() {
+		return 0, nil
+	}
+	conn := s.db.Conn()
+	// IMPORTANT: created_at is stored as RFC3339 TEXT (e.g. "2026-04-14T20:34:25+08:00").
+	// We must compare against the same string format — passing time.Time directly causes
+	// modernc.org/sqlite to serialize it differently (e.g. "2026-04-14 20:34:25+08:00"),
+	// which breaks lexicographic comparison and deletes ALL messages.
+	cutoffStr := cutoff.Format(time.RFC3339)
+	result, err := conn.Exec(
+		"DELETE FROM session_messages WHERE tenant_id = ? AND created_at >= ?",
+		tenantID, cutoffStr,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("purge newer or equal: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	log.WithFields(log.Fields{
+		"tenant_id": tenantID,
+		"purged":    rows,
+		"cutoff":    cutoff.Format(time.RFC3339),
+	}).Info("Session messages purged (newer or equal)")
+	return rows, nil
+}
+
 // PurgeNewerThan deletes all messages for a tenant with created_at after the given timestamp.
 // Used by Ctrl+K rewind to truncate DB history to match UI truncation.
-// Uses strict ">" (not ">=") so the selected rewind message is preserved in the DB
-// as a safety net — on restart the user sees one extra message rather than a blank session.
+// NOTE: Prefer PurgeNewerThanOrEqual for rewind to avoid duplicate user messages on re-send.
 func (s *SessionService) PurgeNewerThan(tenantID int64, cutoff time.Time) (int64, error) {
 	if cutoff.IsZero() {
 		return 0, nil


### PR DESCRIPTION
## Summary

PurgeNewerThan used strict > comparison, preserving the rewound message in DB. When user re-sent the same message, it created a duplicate.

### Changes
- Add PurgeNewerThanOrEqual method (>=) to SessionService
- Switch CLI rewind trimHistoryFn to use PurgeNewerThanOrEqual
- Fix modernc.org/sqlite time.Time serialization: use cutoff.Format(time.RFC3339) string param instead of raw time.Time
- Keep original PurgeNewerThan with > for other callers

Cherry-picked from feat/agent-backend branch.