### PR TITLE
fix: one-shot cron jobs never fire + remove FileReplace 1MB param limit

### DIFF
--- a/cron/scheduler.go
+++ b/cron/scheduler.go
@@ -185,24 +185,11 @@ func (s *Scheduler) checkAndFire(now time.Time) {
 			continue
 		}
 
-		// Skip expired one-shot jobs (next_run is in the past and already triggered)
-		if job.OneShot && job.NextRun.Before(now) {
-			// Check if this was already triggered recently (within last minute)
-			// This handles the case where service was restarted after a job was due
-			if job.LastTrigger != nil && now.Sub(*job.LastTrigger) < time.Minute {
-				// Already triggered recently, skip
-				log.WithFields(log.Fields{
-					"job_id":       job.ID,
-					"last_trigger": job.LastTrigger,
-				}).Info("Cron job already triggered recently, skipping expired one-shot")
-			} else {
-				// Hasn't been triggered, remove the expired one-shot job
-				log.WithFields(log.Fields{
-					"job_id":   job.ID,
-					"next_run": job.NextRun,
-				}).Info("Removing expired one-shot cron job")
-				s.cronSvc.RemoveJob(job.ID)
-			}
+		// Skip one-shot jobs that were already fired (LastTrigger is set).
+		// One-shot jobs with NextRun in the past and no LastTrigger were never
+		// executed (e.g. missed during downtime) — they should fall through to
+		// the firing logic below, not be silently removed.
+		if job.OneShot && job.LastTrigger != nil {
 			continue
 		}
 

--- a/tools/edit.go
+++ b/tools/edit.go
@@ -196,15 +196,6 @@ func (t *FileReplaceTool) Execute(ctx *ToolContext, input string) (*ToolResult, 
 		return nil, fmt.Errorf("run_as and reason must be provided together")
 	}
 
-	// Safety: reject oversized inputs to prevent CPU/memory exhaustion
-	const maxParamLen = 1 << 20 // 1 MB
-	if len(params.OldString) > maxParamLen {
-		return nil, fmt.Errorf("old_string too large (%d bytes, max %d)", len(params.OldString), maxParamLen)
-	}
-	if len(params.NewString) > maxParamLen {
-		return nil, fmt.Errorf("new_string too large (%d bytes, max %d)", len(params.NewString), maxParamLen)
-	}
-
 	// When only end_line is specified, default start_line to 1
 	if params.EndLine > 0 && params.StartLine <= 0 {
 		params.StartLine = 1


### PR DESCRIPTION
## Problem 1: One-shot cron jobs never fire

One-shot jobs (created via `Cron` tool with `delay_seconds` or `at`) are always removed without executing.

**Root cause**: `checkAndFire` uses `job.NextRun.Before(now)` to detect "expired" one-shot jobs, but the ticker has 5-second granularity — so `now` is almost always > `NextRun`. This means every one-shot job hits the expired branch on its first due tick and gets removed before reaching `injectFunc`.

```
checkAndFire(now):
  1. now.Before(NextRun)? → false (job is due)
  2. OneShot && NextRun.Before(now)? → true (5s ticker, now > NextRun)
  3. LastTrigger == nil → "Hasn't been triggered, remove" → DELETE, continue
  → never reaches injectFunc
```

**Log evidence**:
```
09:53:04 "Removing expired one-shot cron job" job_id=job_425889e8
09:58:39 "Removing expired one-shot cron job" job_id=job_ab373727
```
No "Cron job fired" or message processing logs follow.

**Fix**: Use `LastTrigger` as the sole criterion — already fired → skip, never fired → fall through to firing logic.

## Problem 2: FileReplace 1MB parameter limit

`FileReplaceTool.Execute` rejects `old_string` or `new_string` exceeding 1MB (`const maxParamLen = 1 << 20`). This prevents LLMs with large context windows from making large replacements in a single call. No such limit exists on `FileCreate`.

**Fix**: Remove the limit entirely.
