### PR TITLE
fix: settings panel overflow and layout

### DIFF
--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -572,8 +572,8 @@ export default function SettingsPanel({ open, onClose, onNicknameChange, onPrese
         onClick={onClose}
       />
       {/* Panel */}
-      <div className="settings-panel" style={{ maxWidth: '520px' }}>
-        <div className="flex items-center justify-between mb-4">
+      <div className="settings-panel">
+        <div className="flex items-center justify-between">
           <h2 className="text-lg font-bold text-white">⚙️ 设置</h2>
           <div className="flex items-center gap-2">
             {saving && <span className="text-xs text-slate-500">保存中...</span>}
@@ -582,7 +582,7 @@ export default function SettingsPanel({ open, onClose, onNicknameChange, onPrese
         </div>
 
         {/* Tabs */}
-        <div className="flex gap-1 mb-4 p-1 bg-slate-700/50 rounded-lg">
+        <div className="flex gap-1 p-1 bg-slate-700/50 rounded-lg flex-shrink-0">
           {TABS.map((tab) => (
             <button
               key={tab.id}
@@ -597,6 +597,9 @@ export default function SettingsPanel({ open, onClose, onNicknameChange, onPrese
             </button>
           ))}
         </div>
+
+        {/* Scrollable content area */}
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
 
         {/* ── 外观设置 ── */}
         {activeTab === 'appearance' && (
@@ -1281,6 +1284,7 @@ export default function SettingsPanel({ open, onClose, onNicknameChange, onPrese
             )}
           </div>
         )}
+        </div>{/* end scrollable content */}
       </div>
       {/* Toast notification */}
       {toast && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -747,17 +747,18 @@ body {
   position: fixed;
   top: 0;
   right: 0;
-  width: 300px;
-  height: 100%;
+  width: min(420px, 90vw);
+  height: 100vh;
   background: #1e293b;
   border-left: 1px solid #334155;
-  padding: 24px;
+  padding: 20px 24px;
   z-index: 101;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   animation: settings-slide-in 0.25s ease-out;
   box-shadow: -4px 0 24px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
 }
 
 .settings-item {


### PR DESCRIPTION
## Summary
修复 Settings 面板内容超出屏幕无法滚动、宽度布局异常的问题。

## Changes

| 文件 | 改动 |
|------|------|
| `web/src/index.css` | 面板 width 300px→min(420px,90vw)，height 100%→100vh，加 overflow:hidden |
| `web/src/components/SettingsPanel.tsx` | tab 内容区包裹 flex-1 overflow-y:auto 可滚动容器 |

## 根因
1. `.settings-panel` 有 `height:100%` + `flex-direction:column` 但无 overflow 控制 → 内容溢出不可见
2. CSS `width:300px` 与内联 `maxWidth:520px` 冲突
3. 无可滚动内容容器，所有 tab 内容直接在 flex column 中撑满

## 修复
- 面板本身 `overflow:hidden`，标题+Tab栏固定在顶部
- 新增 `<div style={{flex:1, overflowY:'auto', minHeight:0}}>` 包裹所有 tab 内容
- 内容区超出时可正常滚动，标题和 tab 切换始终可见
