### PR TITLE
fix: web stream rendering — wire WebChannel + fix content duplication

### DIFF
--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -468,12 +468,21 @@ func (a *Agent) buildMainRunConfig(
 					remoteCLICh = rc
 				}
 			}
+			var webCh *channelpkg.WebChannel
+			if ch, ok := a.channelFinder("web"); ok {
+				if wc, ok := ch.(*channelpkg.WebChannel); ok {
+					webCh = wc
+				}
+			}
 			cfg.StreamContentFunc = func(content string) {
 				if cliCh != nil {
 					cliCh.SendProgress(chatID, &channelpkg.CLIProgressPayload{StreamContent: content})
 				}
 				if remoteCLICh != nil {
 					remoteCLICh.SendStreamContent(chatID, content, "")
+				}
+				if webCh != nil {
+					webCh.SendStreamContent(chatID, content, "")
 				}
 			}
 			cfg.StreamReasoningFunc = func(content string) {
@@ -482,6 +491,9 @@ func (a *Agent) buildMainRunConfig(
 				}
 				if remoteCLICh != nil {
 					remoteCLICh.SendStreamContent(chatID, "", content)
+				}
+				if webCh != nil {
+					webCh.SendStreamContent(chatID, "", content)
 				}
 			}
 		}

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -637,8 +637,9 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
             if (!reasoning && !content) break
 
             // Accumulate reasoning
+            // NOTE: backend sends accumulated full text, so we REPLACE not append
             if (reasoning) {
-              reasoningRef.current += reasoning
+              reasoningRef.current = reasoning
               if (progressRef.current) {
                 progressRef.current = { ...progressRef.current, thinking: reasoningRef.current }
                 setProgress({ ...progressRef.current })
@@ -657,18 +658,19 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
             }
 
             // Accumulate content — show as streaming text in the assistant turn
+            // NOTE: backend sends accumulated full text (not delta), so we REPLACE not append
             if (content) {
-              streamingContentRef.current += content
+              streamingContentRef.current = content
               setMessages(prev => {
                 // Find or create a streaming placeholder message at the end
                 const last = prev[prev.length - 1]
                 if (last && last.id === '__streaming__') {
-                  return [...prev.slice(0, -1), { ...last, content: streamingContentRef.current }]
+                  return [...prev.slice(0, -1), { ...last, content: content }]
                 }
                 return [...prev, {
                   id: '__streaming__',
                   type: 'assistant' as const,
-                  content: streamingContentRef.current,
+                  content: content,
                 }]
               })
             }


### PR DESCRIPTION
## Summary
修复 Web 端 stream 渲染两个 bug：不逐字渲染 + 内容重复

## Root Cause

**Bug 1 — WebChannel 从未接入 stream 回调**
`engine_wire.go` 的 `StreamContentFunc` 只给 CLI 和 RemoteCLI 发 stream，WebChannel 虽有 `SendStreamContent` 方法但从未被调用。Web 前端根本收不到 `stream_content` WebSocket 消息。

**Bug 2 — 前端追加 vs 后端累积**
`CollectStreamWithCallback` 每次传的是累积全文（`content.String()`），但前端用 `streamingContentRef += content` 追加。结果：
```
收到 "现" → "现"
收到 "现在" → "现现在"
收到 "现在让我" → "现现在现在让我"
...
```

## Changes

| 文件 | 改动 |
|------|------|
| `agent/engine_wire.go` | `StreamContentFunc`/`StreamReasoningFunc` 添加 `WebChannel.SendStreamContent` 调用 |
| `web/src/ChatPage.tsx` | `streamingContentRef += content` → `= content`（替换），reasoning 同理 |

## Fix
- 后端：WebChannel 现在收到 stream content/reasoning 并推送 `stream_content` WS 消息
- 前端：直接替换累积文本而非追加，因为后端每次传的是累积全文
