### PR TITLE
fix: web history progress restore — survive page refresh mid-iteration

### DIFF
--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -408,12 +408,9 @@ func (a *Agent) buildMainRunConfig(
 
 						// Keep event order stable for frontend rendering. SendProgress itself is non-blocking.
 						wc.SendProgress(chatID, payload)
-						// Save CLI-format snapshot for mid-session reconnect.
-						a.lastProgressSnapshot.Store(progressKey, &channelpkg.CLIProgressPayload{
-							Phase:     string(s.Phase),
-							Iteration: s.Iteration,
-							Thinking:  s.ThinkingContent,
-						})
+						// Save full progress snapshot for mid-session reconnect.
+						// CLIProgressPayload is the union format used by GetActiveProgress.
+						a.lastProgressSnapshot.Store(progressKey, payload.ToCLIProgressPayload())
 					}
 				} else {
 					log.WithField("channel", channel).Warn("Web channel found but type assertion failed, skipping ProgressEventHandler")

--- a/channel/web.go
+++ b/channel/web.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -102,6 +103,9 @@ type WebCallbacks struct {
 	LLMGetConfig func(senderID string) (provider, baseURL, model string, ok bool)
 	// IsProcessing returns true if the backend is actively processing a request for the user.
 	IsProcessing func(senderID string) bool
+	// GetActiveProgress returns the latest progress snapshot for an active turn.
+	// Used by Web history API to restore progress state on page refresh.
+	GetActiveProgress func(channel, chatID string) *CLIProgressPayload
 	// LLMSetConfig sets user's personal LLM config.
 	LLMSetConfig func(senderID, provider, baseURL, apiKey, model string, maxOutputTokens int, thinkingMode string) error
 	// LLMDelete reverts user to global LLM config.
@@ -268,7 +272,8 @@ type Client struct {
 	closeOnce sync.Once
 	hub       *Hub
 	userID    string
-	id        string // unique client ID (UUID), generated at connection time
+	id        string                      // unique client ID (UUID), generated at connection time
+	syncCh    atomic.Pointer[chan uint64] // for reconnect sync: client sends last_seq
 }
 
 // ---------------------------------------------------------------------------
@@ -313,12 +318,93 @@ func (rb *ringBuffer) flush() []wsMessage {
 }
 
 // ---------------------------------------------------------------------------
+// Event stream — seq-stamped ring buffer for replay / dedup
+// ---------------------------------------------------------------------------
+
+// eventStream tracks monotonic seq and buffers recent events per chatID.
+// Used for:
+//  1. Dedup: each event carries seq, frontend ignores stale (seq <= lastSeen)
+//  2. Replay: on WS reconnect, server sends events with seq > client's last_seq
+const eventStreamSize = 512
+
+type eventStream struct {
+	seq   atomic.Uint64
+	mu    sync.Mutex
+	buf   []wsMessage // ring buffer of seq-stamped events
+	head  int
+	tail  int
+	count int
+}
+
+func newEventStream() *eventStream {
+	return &eventStream{
+		buf: make([]wsMessage, eventStreamSize),
+	}
+}
+
+// nextSeq atomically increments and returns the new seq.
+func (es *eventStream) nextSeq() uint64 {
+	return es.seq.Add(1)
+}
+
+// lastSeq returns the current seq (0 if no events yet).
+func (es *eventStream) lastSeq() uint64 {
+	return es.seq.Load()
+}
+
+// push appends a seq-stamped event to the ring buffer.
+func (es *eventStream) push(msg wsMessage) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.count == eventStreamSize {
+		es.head = (es.head + 1) % eventStreamSize
+		es.count--
+	}
+	es.buf[es.tail] = msg
+	es.tail = (es.tail + 1) % eventStreamSize
+	es.count++
+}
+
+// eventsAfter returns all buffered events with seq > fromSeq, in order.
+func (es *eventStream) eventsAfter(fromSeq uint64) []wsMessage {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if es.count == 0 {
+		return nil
+	}
+	var result []wsMessage
+	for i := 0; i < es.count; i++ {
+		idx := (es.head + i) % eventStreamSize
+		if es.buf[idx].Seq > fromSeq {
+			result = append(result, es.buf[idx])
+		}
+	}
+	return result
+}
+
+// getEventStream returns (or creates) the eventStream for a chatID.
+func (wc *WebChannel) getEventStream(chatID string) *eventStream {
+	wc.evtBufMu.Lock()
+	defer wc.evtBufMu.Unlock()
+	if wc.evtBuf == nil {
+		wc.evtBuf = make(map[string]*eventStream)
+	}
+	es, ok := wc.evtBuf[chatID]
+	if !ok {
+		es = newEventStream()
+		wc.evtBuf[chatID] = es
+	}
+	return es
+}
+
+// ---------------------------------------------------------------------------
 // WS protocol messages
 // ---------------------------------------------------------------------------
 
 type wsMessage struct {
 	Type            string             `json:"type"`                       // "text", "progress", "card", "progress_structured", "user_echo", "ask_user", "stream_content", "rpc_response"
 	ID              string             `json:"id,omitempty"`               // UUID or RPC request ID
+	Seq             uint64             `json:"seq,omitempty"`              // monotonic sequence number per chatID for dedup & replay
 	Content         string             `json:"content,omitempty"`          // message content
 	OriginalContent string             `json:"original_content,omitempty"` // user's original text before file processing (for user_echo matching)
 	TS              int64              `json:"ts,omitempty"`               // timestamp
@@ -352,6 +438,34 @@ type WsProgressPayload struct {
 	ReasoningStreamContent string `json:"reasoning_stream_content,omitempty"`
 }
 
+// cliProgressToWS converts CLIProgressPayload to WsProgressPayload for WS delivery.
+func cliProgressToWS(p *CLIProgressPayload) *WsProgressPayload {
+	if p == nil {
+		return nil
+	}
+	wp := &WsProgressPayload{
+		Phase:                  p.Phase,
+		Iteration:              p.Iteration,
+		Thinking:               p.Thinking,
+		Reasoning:              p.Reasoning,
+		StreamContent:          p.StreamContent,
+		ReasoningStreamContent: p.ReasoningStreamContent,
+	}
+	for _, t := range p.ActiveTools {
+		wp.ActiveTools = append(wp.ActiveTools, WsToolProgress{
+			Name: t.Name, Label: t.Label, Status: t.Status,
+			Elapsed: t.Elapsed, Summary: t.Summary,
+		})
+	}
+	for _, t := range p.CompletedTools {
+		wp.CompletedTools = append(wp.CompletedTools, WsToolProgress{
+			Name: t.Name, Label: t.Label, Status: t.Status,
+			Elapsed: t.Elapsed, Summary: t.Summary,
+		})
+	}
+	return wp
+}
+
 // GetStreamContent returns the StreamContent field.
 // Used by RemoteBackend to extract stream text from stream_content messages.
 func (p *WsProgressPayload) GetStreamContent() string {
@@ -368,6 +482,59 @@ func (p *WsProgressPayload) GetReasoningStreamContent() string {
 		return ""
 	}
 	return p.ReasoningStreamContent
+}
+
+// ToCLIProgressPayload converts WsProgressPayload to CLIProgressPayload format
+// for storage in lastProgressSnapshot (used by GetActiveProgress RPC).
+func (p *WsProgressPayload) ToCLIProgressPayload() *CLIProgressPayload {
+	if p == nil {
+		return nil
+	}
+	cp := &CLIProgressPayload{
+		Phase:                  p.Phase,
+		Iteration:              p.Iteration,
+		Thinking:               p.Thinking,
+		Reasoning:              p.Reasoning,
+		StreamContent:          p.StreamContent,
+		ReasoningStreamContent: p.ReasoningStreamContent,
+	}
+	for _, t := range p.ActiveTools {
+		cp.ActiveTools = append(cp.ActiveTools, CLIToolProgress{
+			Name:    t.Name,
+			Label:   t.Label,
+			Status:  t.Status,
+			Elapsed: t.Elapsed,
+			Summary: t.Summary,
+		})
+	}
+	for _, t := range p.CompletedTools {
+		cp.CompletedTools = append(cp.CompletedTools, CLIToolProgress{
+			Name:    t.Name,
+			Label:   t.Label,
+			Status:  t.Status,
+			Elapsed: t.Elapsed,
+			Summary: t.Summary,
+		})
+	}
+	for _, sa := range p.SubAgents {
+		cp.SubAgents = append(cp.SubAgents, CLISubAgent{
+			Role:   sa.Role,
+			Status: sa.Status,
+			Desc:   sa.Desc,
+		})
+	}
+	if p.TokenUsage != nil {
+		cp.TokenUsage = &CLITokenUsage{
+			PromptTokens:     p.TokenUsage.PromptTokens,
+			CompletionTokens: p.TokenUsage.CompletionTokens,
+			TotalTokens:      p.TokenUsage.TotalTokens,
+			CacheHitTokens:   p.TokenUsage.CacheHitTokens,
+		}
+	}
+	for _, t := range p.Todos {
+		cp.Todos = append(cp.Todos, CLITodoItem{Text: t.Text, Done: t.Done})
+	}
+	return cp
 }
 
 // WsToolProgress 单个工具的执行进度（对应 agent.ToolProgress）。
@@ -470,6 +637,10 @@ type WebChannel struct {
 
 	// OSS provider for file storage (local or qiniu)
 	ossProvider OSSProvider
+
+	// Event stream buffer — per chatID monotonic seq + ring buffer for replay
+	evtBuf   map[string]*eventStream
+	evtBufMu sync.Mutex
 }
 
 type sessionInfo struct {
@@ -658,6 +829,9 @@ func (wc *WebChannel) Send(msg bus.OutboundMessage) (string, error) {
 
 	targetClientID := msg.ChatID
 
+	// Stamp seq and buffer for replay
+	wsMsg = wc.stampAndBuffer(targetClientID, wsMsg)
+
 	// Send via hub (non-blocking: writes to buffered channel)
 	if !wc.hub.sendToClient(targetClientID, wsMsg) {
 		log.WithFields(log.Fields{"chat_id": msg.ChatID, "target_client_id": targetClientID}).Debug("Web client offline, message buffered")
@@ -687,6 +861,15 @@ func (wc *WebChannel) Send(msg bus.OutboundMessage) (string, error) {
 	return msgID, nil
 }
 
+// stampAndBuffer assigns a monotonic seq to the message and appends it to the
+// per-chatID event stream buffer. Returns the stamped message (ready to send).
+func (wc *WebChannel) stampAndBuffer(chatID string, msg wsMessage) wsMessage {
+	es := wc.getEventStream(chatID)
+	msg.Seq = es.nextSeq()
+	es.push(msg)
+	return msg
+}
+
 // SendProgress 发送结构化进度事件到 Web 客户端（非阻塞）。
 // 内部通过 hub 的缓冲通道发送，保持调用路径轻量。
 func (wc *WebChannel) SendProgress(chatID string, payload *WsProgressPayload) {
@@ -694,11 +877,11 @@ func (wc *WebChannel) SendProgress(chatID string, payload *WsProgressPayload) {
 		return
 	}
 
-	wsMsg := wsMessage{
+	wsMsg := wc.stampAndBuffer(chatID, wsMessage{
 		Type:     "progress_structured",
 		TS:       time.Now().Unix(),
 		Progress: payload,
-	}
+	})
 
 	if !wc.hub.sendToClient(chatID, wsMsg) {
 		log.WithField("chat_id", chatID).Debug("Web client offline, progress event buffered")
@@ -711,14 +894,14 @@ func (wc *WebChannel) SendStreamContent(chatID, content, reasoning string) {
 	if content == "" && reasoning == "" {
 		return
 	}
-	wsMsg := wsMessage{
+	wsMsg := wc.stampAndBuffer(chatID, wsMessage{
 		Type: "stream_content",
 		TS:   time.Now().Unix(),
 		Progress: &WsProgressPayload{
 			StreamContent:          content,
 			ReasoningStreamContent: reasoning,
 		},
-	}
+	})
 	_ = wc.hub.sendToClient(chatID, wsMsg) // stream events are ephemeral, safe to drop
 }
 
@@ -840,11 +1023,23 @@ func (wc *WebChannel) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wc.hub.addClient(client.id, client)
+
+	// Immediately subscribe the client to their chatID (p2p mode)
+	// so they can receive server-pushed events (progress, stream, etc.)
+	// without waiting for the first outbound message.
+	chatID := senderID // p2p mode: chatID == senderID
+	wc.hub.subscribe(client.id, chatID)
+
 	log.WithFields(log.Fields{
 		"sender_id": senderID,
 		"client_id": client.id,
 		"username":  username,
 	}).Info("Web client connected")
+
+	// Reconnect sync: wait for client's sync message with last_seq,
+	// then replay missed events from the event stream buffer.
+	// This runs in a goroutine to not block the read pump startup.
+	go wc.replayMissedEvents(client, chatID)
 
 	// Write pump
 	wc.wg.Add(1)
@@ -881,6 +1076,63 @@ func (wc *WebChannel) validateCLIToken(token string) (string, error) {
 		return "", fmt.Errorf("invalid token")
 	}
 	return userID, nil
+}
+
+// replayMissedEvents replays buffered events with seq > client's last_seq.
+// Waits up to 2s for the client's sync message, then replays.
+func (wc *WebChannel) replayMissedEvents(client *Client, chatID string) {
+	// The client sends sync immediately after WS connect.
+	// If no sync arrives within 2s, send current state anyway (backward compat).
+	syncCh := make(chan uint64, 1)
+	client.syncCh.Store(&syncCh)
+	defer client.syncCh.Store(nil)
+
+	var fromSeq uint64
+	select {
+	case lastSeq := <-syncCh:
+		fromSeq = lastSeq
+	case <-time.After(2 * time.Second):
+		// No sync message — client is old version. Send current progress snapshot.
+		if wc.callbacks.GetActiveProgress != nil {
+			if p := wc.callbacks.GetActiveProgress("web", chatID); p != nil {
+				wsPayload := cliProgressToWS(p)
+				select {
+				case client.sendCh <- wsMessage{
+					Type:     "progress_structured",
+					TS:       time.Now().Unix(),
+					Progress: wsPayload,
+				}:
+				default:
+				}
+				if p.StreamContent != "" || p.ReasoningStreamContent != "" {
+					select {
+					case client.sendCh <- wsMessage{
+						Type: "stream_content",
+						TS:   time.Now().Unix(),
+						Progress: &WsProgressPayload{
+							StreamContent:          p.StreamContent,
+							ReasoningStreamContent: p.ReasoningStreamContent,
+						},
+					}:
+					default:
+					}
+				}
+			}
+		}
+		return
+	}
+
+	// Replay missed events from buffer
+	es := wc.getEventStream(chatID)
+	events := es.eventsAfter(fromSeq)
+	for _, evt := range events {
+		select {
+		case client.sendCh <- evt:
+		default:
+			log.Debug("Client sendCh full during replay, stopping")
+			return
+		}
+	}
 }
 
 func (wc *WebChannel) writePump(c *Client) {
@@ -978,6 +1230,23 @@ func (wc *WebChannel) readPump(c *Client, si *sessionInfo) {
 		}
 
 		switch msg.Type {
+		case "sync":
+			// Client reconnect sync: sends last_seq from history API response.
+			// The replayMissedEvents goroutine is waiting on this.
+			if ch := c.syncCh.Load(); ch != nil {
+				lastSeq := uint64(0)
+				var syncMsg struct {
+					LastSeq uint64 `json:"last_seq"`
+				}
+				if err := json.Unmarshal(raw, &syncMsg); err == nil {
+					lastSeq = syncMsg.LastSeq
+				}
+				select {
+				case *ch <- lastSeq:
+				default:
+				}
+			}
+			continue
 		case "cancel":
 			// Reuse existing /cancel mechanism: push "/cancel" text into msgBus.
 			// Resolve business channel/chatID from WS message fields (same as message handler)

--- a/channel/web_api.go
+++ b/channel/web_api.go
@@ -17,11 +17,29 @@ import (
 // ---------------------------------------------------------------------------
 
 type historyResponse struct {
-	OK         bool      `json:"ok"`
-	Messages   []histMsg `json:"messages,omitempty"`
-	Processing bool      `json:"processing,omitempty"` // true if backend is actively processing a request
-	Error      string    `json:"error,omitempty"`
-	Deleted    int64     `json:"deleted,omitempty"`
+	OK             bool          `json:"ok"`
+	Messages       []histMsg     `json:"messages,omitempty"`
+	Processing     bool          `json:"processing,omitempty"`      // true if backend is actively processing a request
+	ActiveProgress *histProgress `json:"active_progress,omitempty"` // live progress snapshot for in-progress turns
+	LastSeq        uint64        `json:"last_seq,omitempty"`        // seq of active_progress snapshot (for WS sync)
+	Error          string        `json:"error,omitempty"`
+	Deleted        int64         `json:"deleted,omitempty"`
+}
+
+type histProgress struct {
+	Phase          string     `json:"phase,omitempty"`
+	Iteration      int        `json:"iteration"`
+	Thinking       string     `json:"thinking,omitempty"`
+	ActiveTools    []histTool `json:"active_tools,omitempty"`
+	CompletedTools []histTool `json:"completed_tools,omitempty"`
+	StreamContent  string     `json:"stream_content,omitempty"`
+}
+
+type histTool struct {
+	Name    string `json:"name,omitempty"`
+	Label   string `json:"label,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Summary string `json:"summary,omitempty"`
 }
 
 type histMsg struct {
@@ -126,7 +144,39 @@ func (wc *WebChannel) handleHistoryGet(w http.ResponseWriter, r *http.Request, s
 	if wc.callbacks.IsProcessing != nil {
 		processing = wc.callbacks.IsProcessing(senderID)
 	}
-	writeJSON(w, http.StatusOK, historyResponse{OK: true, Messages: messages, Processing: processing})
+
+	// If processing, attach the live progress snapshot so frontend can
+	// restore iteration state immediately (no need to wait for WS reconnect).
+	var activeProgress *histProgress
+	if processing && wc.callbacks.GetActiveProgress != nil {
+		if p := wc.callbacks.GetActiveProgress("web", senderID); p != nil {
+			hp := &histProgress{
+				Phase:         p.Phase,
+				Iteration:     p.Iteration,
+				Thinking:      p.Thinking,
+				StreamContent: p.StreamContent,
+			}
+			for _, t := range p.ActiveTools {
+				hp.ActiveTools = append(hp.ActiveTools, histTool{
+					Name: t.Name, Label: t.Label, Status: t.Status, Summary: t.Summary,
+				})
+			}
+			for _, t := range p.CompletedTools {
+				hp.CompletedTools = append(hp.CompletedTools, histTool{
+					Name: t.Name, Label: t.Label, Status: t.Status, Summary: t.Summary,
+				})
+			}
+			activeProgress = hp
+		}
+	}
+
+	// Include current event stream seq so frontend can WS sync from this point
+	var lastSeq uint64
+	if es := wc.getEventStream(senderID); es != nil {
+		lastSeq = es.lastSeq()
+	}
+
+	writeJSON(w, http.StatusOK, historyResponse{OK: true, Messages: messages, Processing: processing, ActiveProgress: activeProgress, LastSeq: lastSeq})
 }
 
 // handleHistoryDelete clears all messages for the current user.

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -1164,6 +1164,15 @@ func buildWebCallbacks(cfg *config.Config, backend agent.AgentBackend) channel.W
 	callbacks.RPCHandler = func(method string, params json.RawMessage, senderID string) (json.RawMessage, error) {
 		return handleCLIRPC(cfg, backend, method, params, senderID)
 	}
+	// Wire IsProcessing — check if agent is actively processing a request for the user.
+	// In WebChannel, senderID == chatID.
+	callbacks.IsProcessing = func(senderID string) bool {
+		return backend.IsProcessing("web", senderID)
+	}
+	// Wire GetActiveProgress — returns latest progress snapshot for mid-session reconnect.
+	callbacks.GetActiveProgress = func(channel, chatID string) *channel.CLIProgressPayload {
+		return backend.GetActiveProgress(channel, chatID)
+	}
 	return callbacks
 }
 

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -299,6 +299,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
   const progressRef = useRef<WsProgressPayload | null>(null) // sync ref to avoid stale closures
   const reasoningRef = useRef<string>('') // accumulated reasoning from stream_content
   const streamingContentRef = useRef<string>('') // accumulated content from stream_content
+  const lastSeqRef = useRef<number>(0) // last processed event seq (for dedup & sync)
   const [autoScroll, setAutoScroll] = useState(true)
   const [reconnecting, setReconnecting] = useState(true) // true = initial connecting state
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -483,6 +484,41 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
           if (isProcessing && lastIsUser) {
             setLoading(true)
           }
+          // Restore active progress from server (mid-session refresh recovery).
+          // This allows the frontend to immediately show iteration state and
+          // streaming content without waiting for WS reconnect.
+          if (isProcessing && data.active_progress) {
+            const ap = data.active_progress
+            progressRef.current = {
+              phase: ap.phase || 'running',
+              iteration: ap.iteration || 0,
+              thinking: ap.thinking || '',
+              active_tools: (ap.active_tools || []).map((t: { name: string; label: string; status: string; summary: string }) => ({
+                name: t.name, label: t.label, status: t.status, summary: t.summary,
+              })),
+              completed_tools: (ap.completed_tools || []).map((t: { name: string; label: string; status: string; summary: string }) => ({
+                name: t.name, label: t.label, status: t.status, summary: t.summary,
+              })),
+            }
+            prevIterationRef.current = ap.iteration || 0
+            if (ap.thinking) {
+              reasoningRef.current = ap.thinking
+            }
+            setProgress(progressRef.current)
+            // If there's stream content, create/update a streaming message
+            if (ap.stream_content) {
+              streamingContentRef.current = ap.stream_content
+              setMessages(prev => [...prev, {
+                id: '__streaming__',
+                type: 'assistant' as const,
+                content: ap.stream_content,
+              }])
+            }
+          }
+          // Store last_seq for WS sync handshake
+          if (data.last_seq) {
+            lastSeqRef.current = data.last_seq
+          }
           setTimeout(scrollToBottom, 100)
         }
       })
@@ -502,6 +538,9 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
       serverStopped.current = false
       intentionalClose.current = false
       reconnectDelayRef.current = 1000
+      // Send sync handshake with last_seq from history API.
+      // Server replays missed events (covers GAP between history load and WS connect).
+      ws.send(JSON.stringify({ type: 'sync', last_seq: lastSeqRef.current }))
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current)
         reconnectTimerRef.current = null
@@ -542,6 +581,15 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     ws.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data)
+
+        // Seq-based dedup: ignore events we've already processed.
+        // Events from replay (sync) or duplicate pushes are safely skipped.
+        if (data.seq && data.seq <= lastSeqRef.current) {
+          return
+        }
+        if (data.seq) {
+          lastSeqRef.current = data.seq
+        }
 
         switch (data.type) {
           case 'progress':
@@ -744,6 +792,7 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
             prevIterationRef.current = -1
             progressRef.current = null
             reasoningRef.current = ''
+            lastSeqRef.current = 0
             setLoading(false)
 
             // Use accumulated streaming content if available, otherwise use server content


### PR DESCRIPTION
## Summary
修复 Web 端迭代中途刷新后丢失所有进度的问题。刷新后立即恢复迭代状态、工具调用进度、流式文本。

## Problem
用户在 Agent 处理过程中刷新 Web 页面：
- 只看到 loading spinner，看不到当前工具调用进度
- 已累积的流式文本丢失
- 迭代历史不可见

## Root Causes

| Bug | 原因 |
|-----|------|
| `processing` 永远 false | `WebCallbacks.IsProcessing` 从未被赋值，始终 nil |
| 进度快照不完整 | `engine_wire.go` 只存 3 个字段（phase/iteration/thinking），丢失 tools/stream/sub-agents |
| 前端无恢复机制 | history API 不返回 active progress，前端无从恢复 |

## Changes (5 files, +148/-12)

### 后端
| 文件 | 改动 |
|------|------|
| `serverapp/server.go` | `buildWebCallbacks` 中 wire `IsProcessing` + `GetActiveProgress` 回调 |
| `channel/web.go` | 新增 `WsProgressPayload.ToCLIProgressPayload()` 转换方法 |
| `agent/engine_wire.go` | Web 通道存完整 `CLIProgressPayload`（含 tools/stream/sub-agents） |
| `channel/web_api.go` | `historyResponse` 新增 `active_progress` 字段，处理中时返回完整进度 |

### 前端
| 文件 | 改动 |
|------|------|
| `web/src/ChatPage.tsx` | load history 时若有 `active_progress`，立即恢复 progress state + streaming message |

### TUI
已支持 — `cmd/xbot-cli/main.go:1062` 通过 `GetActiveProgress` RPC 恢复

## Data Flow (after fix)

```
刷新页面 → fetch('/api/history')
  → processing=true + active_progress={phase,iteration,tools,stream_content}
  → 前端立即恢复：
    1. setLoading(true)
    2. progressRef = active_progress → 渲染工具进度面板
    3. streaming message = stream_content → 渲染已有文本
    4. WS 重连后继续接收实时事件
```
