### PR TITLE
fix: restore full iteration history on web refresh

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -250,6 +250,11 @@ type Agent struct {
 	// key: "channel:chatID" -> *channel.CLIProgressPayload
 	lastProgressSnapshot sync.Map
 
+	// iterationHistories stores completed iteration snapshots per active chat.
+	// key: "channel:chatID" -> *[]channel.CLIProgressPayload (one per completed iteration)
+	// On turn end, the entry is deleted.
+	iterationHistories sync.Map
+
 	// interactiveSubAgents stores interactive SubAgent sessions
 	// key: "channel:chatID/roleName" -> *interactiveAgent
 	// sync.Map provides atomic Load/Store/Delete/LoadOrStore, no additional mutex needed
@@ -1389,7 +1394,9 @@ func (a *Agent) chatProcessLoop(ctx context.Context, chatKey string, ch <-chan b
 			defer func() {
 				reqCancel()
 				a.chatCancelCh.Delete(cancelKey)
-				a.lastProgressSnapshot.Delete(msg.Channel + ":" + msg.ChatID)
+				key := msg.Channel + ":" + msg.ChatID
+				a.lastProgressSnapshot.Delete(key)
+				a.iterationHistories.Delete(key)
 				<-sem // 释放槽位
 			}()
 

--- a/agent/backend_local.go
+++ b/agent/backend_local.go
@@ -91,13 +91,27 @@ func (b *LocalBackend) IsProcessing(ch, chatID string) bool {
 	return found
 }
 
-// GetActiveProgress returns the latest progress snapshot for an active turn.
+// GetActiveProgress returns the latest progress snapshot for an active turn,
+// including completed iteration history for mid-session reconnect.
 func (b *LocalBackend) GetActiveProgress(ch, chatID string) *channel.CLIProgressPayload {
 	key := ch + ":" + chatID
-	if v, ok := b.agent.lastProgressSnapshot.Load(key); ok {
-		return v.(*channel.CLIProgressPayload)
+	v, ok := b.agent.lastProgressSnapshot.Load(key)
+	if !ok {
+		return nil
 	}
-	return nil
+	snapshot := v.(*channel.CLIProgressPayload)
+	// Attach iteration history if available
+	if histPtr, ok := b.agent.iterationHistories.Load(key); ok {
+		hist := *histPtr.(*[]channel.CLIProgressPayload)
+		if len(hist) > 0 {
+			// Clone to avoid mutating shared state
+			result := *snapshot
+			result.IterationHistory = make([]channel.CLIProgressPayload, len(hist))
+			copy(result.IterationHistory, hist)
+			return &result
+		}
+	}
+	return snapshot
 }
 
 // OnProgress is a no-op for LocalBackend: progress flows through the

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -277,7 +277,25 @@ func (a *Agent) buildMainRunConfig(
 							}
 						}
 						cliCh.SendProgress(chatID, payload)
-						// Save snapshot for mid-session reconnect (GetActiveProgress RPC).
+						// Save snapshot + track iteration history for mid-session reconnect.
+						if prevSnap, loaded := a.lastProgressSnapshot.Load(progressKey); loaded {
+							prev := prevSnap.(*channelpkg.CLIProgressPayload)
+							if s.Iteration > prev.Iteration && prev.Iteration >= 0 {
+								histPtr, _ := a.iterationHistories.LoadOrStore(progressKey, &[]channelpkg.CLIProgressPayload{})
+								hist := *histPtr.(*[]channelpkg.CLIProgressPayload)
+								already := false
+								for _, h := range hist {
+									if h.Iteration == prev.Iteration {
+										already = true
+										break
+									}
+								}
+								if !already {
+									updated := append(hist, *prev)
+									a.iterationHistories.Store(progressKey, &updated)
+								}
+							}
+						}
 						a.lastProgressSnapshot.Store(progressKey, payload)
 					}
 					if remoteCLICh != nil {
@@ -408,9 +426,32 @@ func (a *Agent) buildMainRunConfig(
 
 						// Keep event order stable for frontend rendering. SendProgress itself is non-blocking.
 						wc.SendProgress(chatID, payload)
-						// Save full progress snapshot for mid-session reconnect.
-						// CLIProgressPayload is the union format used by GetActiveProgress.
-						a.lastProgressSnapshot.Store(progressKey, payload.ToCLIProgressPayload())
+
+						// Track iteration history: when iteration advances, snapshot the
+						// PREVIOUS iteration into the history list for mid-session reconnect.
+						cliSnapshot := payload.ToCLIProgressPayload()
+						if prevSnap, loaded := a.lastProgressSnapshot.Load(progressKey); loaded {
+							prev := prevSnap.(*channelpkg.CLIProgressPayload)
+							if s.Iteration > prev.Iteration && prev.Iteration >= 0 {
+								// Iteration advanced — save previous iteration to history
+								histPtr, _ := a.iterationHistories.LoadOrStore(progressKey, &[]channelpkg.CLIProgressPayload{})
+								hist := *histPtr.(*[]channelpkg.CLIProgressPayload)
+								// Only append if this iteration isn't already recorded
+								already := false
+								for _, h := range hist {
+									if h.Iteration == prev.Iteration {
+										already = true
+										break
+									}
+								}
+								if !already {
+									updated := append(hist, *prev)
+									a.iterationHistories.Store(progressKey, &updated)
+								}
+							}
+						}
+						// Save current iteration snapshot
+						a.lastProgressSnapshot.Store(progressKey, cliSnapshot)
 					}
 				} else {
 					log.WithField("channel", channel).Warn("Web channel found but type assertion failed, skipping ProgressEventHandler")

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -205,9 +205,10 @@ type CLIProgressPayload struct {
 	Reasoning              string // model's reasoning/thinking chain (reasoning_content)
 	SubAgents              []CLISubAgent
 	Todos                  []CLITodoItem
-	TokenUsage             *CLITokenUsage // Token 用量快照（实时更新）
-	StreamContent          string         // LLM streaming text content (accumulated, for real-time render)
-	ReasoningStreamContent string         // LLM streaming reasoning content (accumulated, for real-time render)
+	TokenUsage             *CLITokenUsage       // Token 用量快照（实时更新）
+	StreamContent          string               // LLM streaming text content (accumulated, for real-time render)
+	ReasoningStreamContent string               // LLM streaming reasoning content (accumulated, for real-time render)
+	IterationHistory       []CLIProgressPayload // completed iteration snapshots (for mid-session reconnect restore)
 }
 
 // CLITokenUsage Token 使用量（对应 agent.TokenUsageSnapshot）

--- a/channel/web_api.go
+++ b/channel/web_api.go
@@ -27,12 +27,19 @@ type historyResponse struct {
 }
 
 type histProgress struct {
-	Phase          string     `json:"phase,omitempty"`
+	Phase            string             `json:"phase,omitempty"`
+	Iteration        int                `json:"iteration"`
+	Thinking         string             `json:"thinking,omitempty"`
+	ActiveTools      []histTool         `json:"active_tools,omitempty"`
+	CompletedTools   []histTool         `json:"completed_tools,omitempty"`
+	StreamContent    string             `json:"stream_content,omitempty"`
+	IterationHistory []histIterSnapshot `json:"iteration_history,omitempty"` // completed iterations 1..N-1
+}
+
+type histIterSnapshot struct {
 	Iteration      int        `json:"iteration"`
 	Thinking       string     `json:"thinking,omitempty"`
-	ActiveTools    []histTool `json:"active_tools,omitempty"`
 	CompletedTools []histTool `json:"completed_tools,omitempty"`
-	StreamContent  string     `json:"stream_content,omitempty"`
 }
 
 type histTool struct {
@@ -165,6 +172,19 @@ func (wc *WebChannel) handleHistoryGet(w http.ResponseWriter, r *http.Request, s
 				hp.CompletedTools = append(hp.CompletedTools, histTool{
 					Name: t.Name, Label: t.Label, Status: t.Status, Summary: t.Summary,
 				})
+			}
+			// Attach iteration history (completed iterations 1..N-1)
+			for _, iter := range p.IterationHistory {
+				snap := histIterSnapshot{
+					Iteration: iter.Iteration,
+					Thinking:  iter.Thinking,
+				}
+				for _, t := range iter.CompletedTools {
+					snap.CompletedTools = append(snap.CompletedTools, histTool{
+						Name: t.Name, Label: t.Label, Status: t.Status, Summary: t.Summary,
+					})
+				}
+				hp.IterationHistory = append(hp.IterationHistory, snap)
 			}
 			activeProgress = hp
 		}

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -514,6 +514,22 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
                 content: ap.stream_content,
               }])
             }
+            // Restore iteration history (completed iterations 1..N-1)
+            if (ap.iteration_history && ap.iteration_history.length > 0) {
+              const restoredIterations: IterationSnapshot[] = ap.iteration_history.map(
+                (iter: { iteration: number; thinking?: string; completed_tools?: { name: string; label?: string; status: string; summary?: string }[] }) => ({
+                  iteration: iter.iteration,
+                  thinking: iter.thinking || '',
+                  tools: (iter.completed_tools || []).map(t => ({
+                    name: t.name,
+                    label: t.label,
+                    status: t.status,
+                    summary: t.summary,
+                  })),
+                })
+              )
+              setLiveIterationsSync(restoredIterations)
+            }
           }
           // Store last_seq for WS sync handshake
           if (data.last_seq) {


### PR DESCRIPTION
## Summary
修复 Web 端迭代中途刷新后丢失已完成迭代历史的问题（迭代1-4不可见）。

## Problem
用户在迭代 5 时刷新页面：
- `liveIterations`（React state）丢失 → 迭代 1-4 全部消失
- `lastProgressSnapshot` 只存最新迭代（迭代 5）→ 之前的快照被覆盖
- History API 不含迭代历史

## Changes (6 files, +114/-15)

| 文件 | 改动 |
|------|------|
| `agent/agent.go` | 新增 `iterationHistories sync.Map`，turn 结束时清理 |
| `agent/engine_wire.go` | 迭代变化时（N→N+1）snapshot 迭代 N 到 history |
| `agent/backend_local.go` | `GetActiveProgress` 附加 `IterationHistory` |
| `channel/cli_types.go` | `CLIProgressPayload` 新增 `IterationHistory` 字段 |
| `channel/web_api.go` | `histProgress` 新增 `iteration_history` 字段 |
| `web/src/ChatPage.tsx` | 从 `active_progress.iteration_history` 恢复 `liveIterations` |

## Data Flow

```
迭代 1 → progress event → snapshot 存入 iterationHistories
迭代 2 → 迭代 1 追加到 history
迭代 3 → 迭代 2 追加到 history
迭代 4 → 迭代 3 追加到 history
迭代 5 → current snapshot = 迭代 5, history = [1,2,3,4]

刷新 → History API:
  active_progress.iteration = 5
  active_progress.iteration_history = [{iter:1,...},{iter:2,...},{iter:3,...},{iter:4,...}]

前端恢复:
  setLiveIterationsSync(iteration_history) → 迭代 1-4 立即渲染
  progress = 迭代 5 当前状态
```
