### PR TITLE
fix: override react-markdown pre component to eliminate code block double-frame

### DIFF
--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -187,6 +187,11 @@ export function getCodeBlockProps() {
     a(props: { href?: string; children?: React.ReactNode }) {
       return <a href={props.href} target="_blank" rel="noopener noreferrer">{props.children}</a>
     },
+    pre(props: { children?: React.ReactNode }) {
+      // Unwrap react-markdown's outer <pre> — the code component already
+      // renders its own container (.xbot-codeblock / .mermaid-wrapper / etc.)
+      return <>{props.children}</>
+    },
     table(props: { children?: React.ReactNode }) {
       return <div className="table-wrapper"><table>{props.children}</table></div>
     },


### PR DESCRIPTION
## Problem

Code blocks render with double frames — an outer `<pre>` from react-markdown (styled by `.markdown-body pre` CSS) wrapping the custom `.xbot-codeblock` container.

PR #484's CSS `:not(.xbot-codeblock-pre)` approach only prevents the **inner** `<pre>` from being styled, but the **outer** `<pre>` from react-markdown still matches `.markdown-body pre:not(.xbot-codeblock-pre)`, creating the double-frame.

## Fix

Override the `pre` component in `getCodeBlockProps()` to return `<>{children}</>`, stripping the outer `<pre>` wrapper entirely. The custom `code` component already renders the complete `.xbot-codeblock` container.