### PR TITLE
fix: show reasoning in iteration history on web

### DIFF
--- a/channel/web_api.go
+++ b/channel/web_api.go
@@ -39,6 +39,7 @@ type histProgress struct {
 type histIterSnapshot struct {
 	Iteration      int        `json:"iteration"`
 	Thinking       string     `json:"thinking,omitempty"`
+	Reasoning      string     `json:"reasoning,omitempty"`
 	CompletedTools []histTool `json:"completed_tools,omitempty"`
 }
 
@@ -175,10 +176,11 @@ func (wc *WebChannel) handleHistoryGet(w http.ResponseWriter, r *http.Request, s
 			}
 			// Attach iteration history (completed iterations 1..N-1)
 			for _, iter := range p.IterationHistory {
-				snap := histIterSnapshot{
-					Iteration: iter.Iteration,
-					Thinking:  iter.Thinking,
-				}
+					snap := histIterSnapshot{
+						Iteration: iter.Iteration,
+						Thinking:  iter.Thinking,
+						Reasoning: iter.Reasoning,
+					}
 				for _, t := range iter.CompletedTools {
 					snap.CompletedTools = append(snap.CompletedTools, histTool{
 						Name: t.Name, Label: t.Label, Status: t.Status, Summary: t.Summary,

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -78,6 +78,9 @@ function normalizeIterationHistory(input: unknown): IterationSnapshot[] {
     const thinkingRaw = snap.thinking ?? snap.Thinking
     const thinking = typeof thinkingRaw === 'string' ? thinkingRaw : undefined
 
+    const reasoningRaw = snap.reasoning ?? snap.Reasoning
+    const reasoning = typeof reasoningRaw === 'string' ? reasoningRaw : undefined
+
     const rawTools = Array.isArray(snap.tools) ? snap.tools : (Array.isArray(snap.Tools) ? snap.Tools : [])
     const tools = rawTools
       .filter((t): t is Record<string, unknown> => !!t && typeof t === 'object')
@@ -101,6 +104,7 @@ function normalizeIterationHistory(input: unknown): IterationSnapshot[] {
     normalized.push({
       iteration,
       thinking,
+      reasoning,
       tools,
     })
   }
@@ -111,6 +115,7 @@ function normalizeIterationHistory(input: unknown): IterationSnapshot[] {
     byIteration.set(snap.iteration, {
       iteration: snap.iteration,
       thinking: snap.thinking,
+      reasoning: snap.reasoning,
       tools: Array.isArray(snap.tools) ? snap.tools : [],
     })
   }
@@ -522,17 +527,18 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
             // Restore iteration history (completed iterations 1..N-1)
             if (ap.iteration_history && ap.iteration_history.length > 0) {
               const restoredIterations: IterationSnapshot[] = ap.iteration_history.map(
-                (iter: { iteration: number; thinking?: string; completed_tools?: { name: string; label?: string; status: string; summary?: string }[] }) => ({
-                  iteration: iter.iteration,
-                  thinking: iter.thinking || '',
-                  tools: (iter.completed_tools || []).map(t => ({
-                    name: t.name,
-                    label: t.label,
-                    status: t.status,
-                    summary: t.summary,
-                  })),
-                })
-              )
+	                (iter: { iteration: number; thinking?: string; reasoning?: string; completed_tools?: { name: string; label?: string; status: string; summary?: string }[] }) => ({
+	                  iteration: iter.iteration,
+	                  thinking: iter.thinking || '',
+	                  reasoning: iter.reasoning || '',
+	                  tools: (iter.completed_tools || []).map(t => ({
+	                    name: t.name,
+	                    label: t.label,
+	                    status: t.status,
+	                    summary: t.summary,
+	                  })),
+	                })
+	              )
               setLiveIterationsSync(restoredIterations)
             }
           }

--- a/web/src/components/AssistantTurn.tsx
+++ b/web/src/components/AssistantTurn.tsx
@@ -216,6 +216,11 @@ export default function AssistantTurn({ messages, progress, liveIterations, load
                   <div className="text-[11px] text-slate-600/90 font-mono mb-1">
                     #{snap.iteration}
                   </div>
+                  {snap.reasoning && (
+                    <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">
+                      {snap.reasoning}
+                    </div>
+                  )}
                   {snap.thinking && (
                     <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">
                       {snap.thinking}

--- a/web/src/components/ProgressPanel.tsx
+++ b/web/src/components/ProgressPanel.tsx
@@ -34,6 +34,7 @@ interface WsProgressPayload {
 export interface IterationSnapshot {
   iteration: number
   thinking?: string
+  reasoning?: string
   tools: IterationToolSnapshot[]
 }
 
@@ -147,11 +148,13 @@ export function BouncingDots({ text }: { text?: string }) {
 
 export function CompletedIteration({ snap }: { snap: IterationSnapshot }) {
   const hasThinking = !!(snap.thinking || '').trim()
+  const hasReasoning = !!(snap.reasoning || '').trim()
   const hasTools = (snap.tools ?? []).length > 0
-  const isEmpty = !hasThinking && !hasTools
+  const isEmpty = !hasThinking && !hasReasoning && !hasTools
   return (
     <div className="px-3 py-2 border-b border-slate-700/30 last:border-b-0">
       <div className="flex items-center gap-1 text-[11px] text-slate-600/90 font-mono mb-1">#{snap.iteration}</div>
+      {hasReasoning && <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">{snap.reasoning}</div>}
       {hasThinking && <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">{snap.thinking}</div>}
       {hasTools && (
         <div className="space-y-0.5">


### PR DESCRIPTION
## Problem
Iteration history on web only showed `thinking` but not `reasoning` (the model's reasoning/thinking chain from `reasoning_content`). These are separate fields in the backend but the frontend only surfaced one.

## Root Cause
1. Backend `histIterSnapshot` in `web_api.go` lacked `Reasoning` field — dropped during serialization
2. Frontend `IterationSnapshot` type lacked `reasoning` field
3. Frontend `normalizeIterationHistory` didn't extract `reasoning`
4. Frontend `CompletedIteration` and live iteration display only rendered `thinking`

## Changes
**Backend** (1 file):
- `channel/web_api.go`: Added `Reasoning` to `histIterSnapshot` + mapping

**Frontend** (3 files):
- `ProgressPanel.tsx`: Added `reasoning` to `IterationSnapshot` type, render in `CompletedIteration`
- `AssistantTurn.tsx`: Render `reasoning` in live iteration display
- `ChatPage.tsx`: Extract `reasoning` in `normalizeIterationHistory` + history restore

**Streaming**: Already works — `reasoning_stream_content` is mapped to `progress.thinking` and shown in `ThinkingBlock` during live streaming.