### PR TITLE
style: visually differentiate reasoning vs thinking in iteration history

### DIFF
--- a/channel/web_api.go
+++ b/channel/web_api.go
@@ -176,11 +176,11 @@ func (wc *WebChannel) handleHistoryGet(w http.ResponseWriter, r *http.Request, s
 			}
 			// Attach iteration history (completed iterations 1..N-1)
 			for _, iter := range p.IterationHistory {
-					snap := histIterSnapshot{
-						Iteration: iter.Iteration,
-						Thinking:  iter.Thinking,
-						Reasoning: iter.Reasoning,
-					}
+				snap := histIterSnapshot{
+					Iteration: iter.Iteration,
+					Thinking:  iter.Thinking,
+					Reasoning: iter.Reasoning,
+				}
 				for _, t := range iter.CompletedTools {
 					snap.CompletedTools = append(snap.CompletedTools, histTool{
 						Name: t.Name, Label: t.Label, Status: t.Status, Summary: t.Summary,

--- a/web/src/components/AssistantTurn.tsx
+++ b/web/src/components/AssistantTurn.tsx
@@ -55,8 +55,9 @@ interface Message {
 
 // Memoized thinking display — only re-renders when content actually changes
 const ThinkingBlock = memo(({ content }: { content: string }) => (
-  <div className="px-3 py-2 text-xs text-slate-400 italic whitespace-pre-wrap break-words">
-    {content}
+  <div className="px-2 py-1.5 rounded bg-indigo-500/10 border-l-2 border-indigo-500/40">
+    <div className="text-[10px] text-indigo-400/70 font-medium mb-0.5">💭 Reasoning</div>
+    <div className="text-xs text-indigo-300/90 whitespace-pre-wrap break-words">{content}</div>
   </div>
 ))
 
@@ -217,13 +218,15 @@ export default function AssistantTurn({ messages, progress, liveIterations, load
                     #{snap.iteration}
                   </div>
                   {snap.reasoning && (
-                    <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">
-                      {snap.reasoning}
+                    <div className="px-2 py-1.5 mb-1 rounded bg-indigo-500/10 border-l-2 border-indigo-500/40">
+                      <div className="text-[10px] text-indigo-400/70 font-medium mb-0.5">💭 Reasoning</div>
+                      <div className="text-xs text-indigo-300/90 whitespace-pre-wrap break-words">{snap.reasoning}</div>
                     </div>
                   )}
                   {snap.thinking && (
-                    <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">
-                      {snap.thinking}
+                    <div className="px-2 py-1.5 mb-1 rounded bg-amber-500/10 border-l-2 border-amber-500/40">
+                      <div className="text-[10px] text-amber-400/70 font-medium mb-0.5">💡 Thinking</div>
+                      <div className="text-xs text-amber-300/80 italic whitespace-pre-wrap break-words">{snap.thinking}</div>
                     </div>
                   )}
                   <div className="space-y-0.5">

--- a/web/src/components/ProgressPanel.tsx
+++ b/web/src/components/ProgressPanel.tsx
@@ -154,8 +154,18 @@ export function CompletedIteration({ snap }: { snap: IterationSnapshot }) {
   return (
     <div className="px-3 py-2 border-b border-slate-700/30 last:border-b-0">
       <div className="flex items-center gap-1 text-[11px] text-slate-600/90 font-mono mb-1">#{snap.iteration}</div>
-      {hasReasoning && <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">{snap.reasoning}</div>}
-      {hasThinking && <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">{snap.thinking}</div>}
+      {hasReasoning && (
+        <div className="px-2 py-1.5 mb-1 rounded bg-indigo-500/10 border-l-2 border-indigo-500/40">
+          <div className="text-[10px] text-indigo-400/70 font-medium mb-0.5">💭 Reasoning</div>
+          <div className="text-xs text-indigo-300/90 whitespace-pre-wrap break-words">{snap.reasoning}</div>
+        </div>
+      )}
+      {hasThinking && (
+        <div className="px-2 py-1.5 mb-1 rounded bg-amber-500/10 border-l-2 border-amber-500/40">
+          <div className="text-[10px] text-amber-400/70 font-medium mb-0.5">💡 Thinking</div>
+          <div className="text-xs text-amber-300/80 italic whitespace-pre-wrap break-words">{snap.thinking}</div>
+        </div>
+      )}
       {hasTools && (
         <div className="space-y-0.5">
           {(snap.tools ?? []).map((tool, i) => {
@@ -293,7 +303,10 @@ export default function ProgressPanel({ progress, liveIterations, loading }: Pro
               <div className="flex items-center gap-1 text-[11px] text-slate-600/90 font-mono mb-1">#{progress.iteration}</div>
 
               {shouldShowCurrentThinking && (
-                <div className="px-2 py-1 mb-1 text-xs text-slate-400 italic whitespace-pre-wrap break-words">{progress.thinking}</div>
+                <div className="px-2 py-1.5 mb-1 rounded bg-indigo-500/10 border-l-2 border-indigo-500/40">
+                  <div className="text-[10px] text-indigo-400/70 font-medium mb-0.5">💭 Reasoning</div>
+                  <div className="text-xs text-indigo-300/90 whitespace-pre-wrap break-words">{progress.thinking}</div>
+                </div>
               )}
 
               {progress.phase === 'thinking' && !progress.thinking && <BouncingDots text="thinking…" />}


### PR DESCRIPTION
## Changes

Visually differentiate reasoning and thinking in iteration history display:

- **Reasoning**: 💭 indigo left-border card, blue-toned text, `Reasoning` label
- **Thinking**: 💡 amber left-border card, warm italic text, `Thinking` label

Updated in 4 locations:
1. `CompletedIteration` (ProgressPanel) — completed iteration snapshots
2. Live iteration display (AssistantTurn) — during streaming
3. `ThinkingBlock` (AssistantTurn) — current iteration live reasoning
4. Live progress panel (ProgressPanel) — standalone progress view