### PR TITLE
chore: add install-cli make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint test build run dev clean ci clean-memory
+.PHONY: fmt lint test build run dev clean ci clean-memory install-cli
 
 BINARY_NAME := xbot
 
@@ -33,4 +33,8 @@ ci: lint build test
 clean-memory:
 	rm -rf .xbot/
 	@echo "Memory cleaned!"
+
+install-cli:
+	go build -ldflags "$(LDFLAGS)" -o /tmp/xbot-cli ./cmd/xbot-cli
+	sudo mv /tmp/xbot-cli /usr/local/bin/
 


### PR DESCRIPTION
## Summary

Add `make install-cli` target that builds `cmd/xbot-cli` to `/tmp` then moves it to `/usr/local/bin/`.

- Reuses existing `VERSION` and `LDFLAGS` for build metadata
- Added to `.PHONY` list

## Usage

```bash
make install-cli
```