### PR TITLE
fix: create dist/ before tarring frontend in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Package frontend dist
         run: |
+          mkdir -p dist
           cd web
           tar czf ../dist/xbot-web-dist.tar.gz -C dist .
 


### PR DESCRIPTION
## Problem

Release CI (`v0.0.23`) failed at the `Package frontend dist` step:

``
tar (child): ../dist/xbot-web-dist.tar.gz: Cannot open: No such file or directory
``

The `mkdir -p dist` command was only in the `Build CLI binaries` step, which runs *after* `Package frontend dist`.

## Fix

Add `mkdir -p dist` before `tar czf` in the `Package frontend dist` step.