### PR TITLE
feat: no-root install scripts + cross-platform CI tests

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -264,12 +264,12 @@ jobs:
         env:
           MODE: standalone
           VERSION: v0.0.23
-          InstallPath: D:\test-install\bin
+          INSTALL_PATH: D:\test-install\bin
           XBOT_HOME: D:\test-install\.xbot
         shell: pwsh
         run: |
           .\scripts\install.ps1 -NonInteractive
-          $binPath = Join-Path $env:InstallPath "xbot-cli.exe"
+          $binPath = Join-Path $env:INSTALL_PATH "xbot-cli.exe"
           Test-Path $binPath | Should -BeTrue
           Write-Host "✅ Binary installed"
           $configPath = Join-Path $env:XBOT_HOME "config.json"
@@ -291,12 +291,12 @@ jobs:
           MODE: server-client
           PORT: "6666"
           VERSION: v0.0.23
-          InstallPath: D:\test-install\bin
+          INSTALL_PATH: D:\test-install\bin
           XBOT_HOME: D:\test-install\.xbot
         shell: pwsh
         run: |
           .\scripts\install.ps1 -NonInteractive
-          $binPath = Join-Path $env:InstallPath "xbot-cli.exe"
+          $binPath = Join-Path $env:INSTALL_PATH "xbot-cli.exe"
           Test-Path $binPath | Should -BeTrue
           Write-Host "✅ Binary installed"
           $configPath = Join-Path $env:XBOT_HOME "config.json"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,322 @@
+name: Install Script Tests
+
+on:
+  push:
+    branches: [master, feat/install-no-sudo-ci-test]
+    paths:
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - '.github/workflows/install-test.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - '.github/workflows/install-test.yml'
+  workflow_dispatch:
+
+jobs:
+  # ── Linux ──────────────────────────────────────────────
+  linux-standalone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test standalone install (non-interactive)
+        env:
+          MODE: standalone
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          test -x "${INSTALL_PATH}/xbot-cli"
+          echo "✅ Binary installed"
+          jq empty "${XBOT_HOME}/config.json"
+          echo "✅ Config valid"
+          server_url=$(jq -r '.cli.server_url // empty' "${XBOT_HOME}/config.json")
+          if [ -n "$server_url" ]; then
+            echo "❌ Expected no server_url in standalone mode, got: $server_url"
+            exit 1
+          fi
+          echo "✅ Standalone mode correct"
+          token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          [ -n "$token" ] && [ "$token" != "null" ]
+          echo "✅ Admin token set"
+
+  linux-server-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test server-client install (non-interactive)
+        env:
+          MODE: server-client
+          PORT: "9999"
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          test -x "${INSTALL_PATH}/xbot-cli"
+          echo "✅ Binary installed"
+          jq empty "${XBOT_HOME}/config.json"
+          echo "✅ Config valid"
+          port=$(jq -r '.server.port' "${XBOT_HOME}/config.json")
+          [ "$port" = "9999" ]
+          echo "✅ Port configured"
+          server_url=$(jq -r '.cli.server_url' "${XBOT_HOME}/config.json")
+          [ "$server_url" = "ws://127.0.0.1:9999" ]
+          echo "✅ Server URL configured"
+          web_enable=$(jq -r '.web.enable' "${XBOT_HOME}/config.json")
+          [ "$web_enable" = "true" ]
+          echo "✅ Web enabled"
+          token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          [ -n "$token" ] && [ "$token" != "null" ]
+          echo "✅ Admin token set"
+          unit_file="${HOME}/.config/systemd/user/xbot-server.service"
+          test -f "$unit_file"
+          echo "✅ systemd --user unit created"
+          grep -q "ExecStart=.*/xbot-cli serve" "$unit_file"
+          echo "✅ Unit file has correct ExecStart"
+          grep -q "WantedBy=default.target" "$unit_file"
+          echo "✅ Unit file uses default.target (user-level)"
+          grep -q "Type=simple" "$unit_file"
+          echo "✅ Unit file has Type=simple"
+
+  linux-config-preserve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test config preservation on reinstall
+        env:
+          MODE: server-client
+          PORT: "8888"
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          first_token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          echo "First token: $first_token"
+          jq '.server.custom_field = "preserve_me"' "${XBOT_HOME}/config.json" > "${XBOT_HOME}/config.json.tmp"
+          mv "${XBOT_HOME}/config.json.tmp" "${XBOT_HOME}/config.json"
+          bash scripts/install.sh
+          second_token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          custom=$(jq -r '.server.custom_field' "${XBOT_HOME}/config.json")
+          [ "$first_token" = "$second_token" ]
+          echo "✅ Token preserved on reinstall"
+          [ "$custom" = "preserve_me" ]
+          echo "✅ Custom fields preserved on reinstall"
+          port=$(jq -r '.server.port' "${XBOT_HOME}/config.json")
+          [ "$port" = "8888" ]
+          echo "✅ Port updated on reinstall"
+          ls "${XBOT_HOME}/config.json.bak."* >/dev/null 2>&1
+          echo "✅ Backup created on reinstall"
+
+  linux-port-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test default port (8082)
+        env:
+          MODE: server-client
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          port=$(jq -r '.server.port' "${XBOT_HOME}/config.json")
+          [ "$port" = "8082" ]
+          echo "✅ Default port 8082 applied"
+
+  # ── macOS ──────────────────────────────────────────────
+  macos-standalone:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test macOS standalone install
+        env:
+          MODE: standalone
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          test -x "${INSTALL_PATH}/xbot-cli"
+          echo "✅ Binary installed"
+          jq empty "${XBOT_HOME}/config.json"
+          echo "✅ Config valid"
+          agent_workdir=$(jq -r '.agent.work_dir' "${XBOT_HOME}/config.json")
+          [ -n "$agent_workdir" ]
+          echo "✅ agent.work_dir set"
+          server_url=$(jq -r '.cli.server_url // empty' "${XBOT_HOME}/config.json")
+          if [ -n "$server_url" ]; then
+            echo "❌ Expected no server_url in standalone mode, got: $server_url"
+            exit 1
+          fi
+          echo "✅ Standalone mode correct (no server_url)"
+          token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          [ -n "$token" ] && [ "$token" != "null" ]
+          echo "✅ Admin token set"
+
+  macos-server-client:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test macOS server-client install (launchd)
+        env:
+          MODE: server-client
+          PORT: "7777"
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          test -x "${INSTALL_PATH}/xbot-cli"
+          echo "✅ Binary installed"
+          jq empty "${XBOT_HOME}/config.json"
+          echo "✅ Config valid"
+          port=$(jq -r '.server.port' "${XBOT_HOME}/config.json")
+          [ "$port" = "7777" ]
+          echo "✅ Port configured"
+          server_url=$(jq -r '.cli.server_url' "${XBOT_HOME}/config.json")
+          [ "$server_url" = "ws://127.0.0.1:7777" ]
+          echo "✅ Server URL configured"
+          web_enable=$(jq -r '.web.enable' "${XBOT_HOME}/config.json")
+          [ "$web_enable" = "true" ]
+          echo "✅ Web enabled"
+          token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          [ -n "$token" ] && [ "$token" != "null" ]
+          echo "✅ Admin token set"
+          plist="$HOME/Library/LaunchAgents/com.xbot.server.plist"
+          test -f "$plist"
+          echo "✅ launchd plist created"
+          grep -q "RunAtLoad" "$plist"
+          echo "✅ Plist has RunAtLoad"
+          grep -q "KeepAlive" "$plist"
+          echo "✅ Plist has KeepAlive"
+          grep -q "xbot-cli" "$plist"
+          echo "✅ Plist references xbot-cli binary"
+          grep -q "serve" "$plist"
+          echo "✅ Plist has serve argument"
+
+  macos-config-preserve:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test macOS config preservation on reinstall
+        env:
+          MODE: server-client
+          PORT: "5555"
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          first_token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          jq '.agent.custom_setting = "keep_me"' "${XBOT_HOME}/config.json" > "${XBOT_HOME}/config.json.tmp"
+          mv "${XBOT_HOME}/config.json.tmp" "${XBOT_HOME}/config.json"
+          bash scripts/install.sh
+          second_token=$(jq -r '.admin.token' "${XBOT_HOME}/config.json")
+          custom=$(jq -r '.agent.custom_setting' "${XBOT_HOME}/config.json")
+          [ "$first_token" = "$second_token" ]
+          echo "✅ Token preserved on reinstall"
+          [ "$custom" = "keep_me" ]
+          echo "✅ Custom fields preserved on reinstall"
+          port=$(jq -r '.server.port' "${XBOT_HOME}/config.json")
+          [ "$port" = "5555" ]
+          echo "✅ Port updated on reinstall"
+          ls "${XBOT_HOME}/config.json.bak."* >/dev/null 2>&1
+          echo "✅ Backup created on reinstall"
+          plist="$HOME/Library/LaunchAgents/com.xbot.server.plist"
+          test -f "$plist"
+          echo "✅ launchd plist still exists after reinstall"
+
+  macos-port-default:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test macOS default port (8082)
+        env:
+          MODE: server-client
+          VERSION: v0.0.23
+          INSTALL_PATH: ${{ github.workspace }}/test-install/bin
+          XBOT_HOME: ${{ github.workspace }}/test-install/.xbot
+          NONINTERACTIVE: "1"
+        run: |
+          bash scripts/install.sh
+          port=$(jq -r '.server.port' "${XBOT_HOME}/config.json")
+          [ "$port" = "8082" ]
+          echo "✅ Default port 8082 applied"
+
+  # ── Windows ────────────────────────────────────────────
+  windows-standalone:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Windows standalone install
+        env:
+          MODE: standalone
+          VERSION: v0.0.23
+          InstallPath: D:\test-install\bin
+          XBOT_HOME: D:\test-install\.xbot
+        shell: pwsh
+        run: |
+          .\scripts\install.ps1 -NonInteractive
+          $binPath = Join-Path $env:InstallPath "xbot-cli.exe"
+          Test-Path $binPath | Should -BeTrue
+          Write-Host "✅ Binary installed"
+          $configPath = Join-Path $env:XBOT_HOME "config.json"
+          Test-Path $configPath | Should -BeTrue
+          $cfg = Get-Content $configPath -Raw | ConvertFrom-Json
+          $cfg.cli.server_url | Should -BeNullOrEmpty
+          Write-Host "✅ Standalone mode correct (no server_url)"
+          $cfg.admin.token | Should -Not -BeNullOrEmpty
+          Write-Host "✅ Admin token set"
+          $cfg.agent.work_dir | Should -Not -BeNullOrEmpty
+          Write-Host "✅ agent.work_dir set"
+
+  windows-server-client:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Windows server-client install (Scheduled Task)
+        env:
+          MODE: server-client
+          PORT: "6666"
+          VERSION: v0.0.23
+          InstallPath: D:\test-install\bin
+          XBOT_HOME: D:\test-install\.xbot
+        shell: pwsh
+        run: |
+          .\scripts\install.ps1 -NonInteractive
+          $binPath = Join-Path $env:InstallPath "xbot-cli.exe"
+          Test-Path $binPath | Should -BeTrue
+          Write-Host "✅ Binary installed"
+          $configPath = Join-Path $env:XBOT_HOME "config.json"
+          Test-Path $configPath | Should -BeTrue
+          $cfg = Get-Content $configPath -Raw | ConvertFrom-Json
+          $cfg.server.port | Should -Be 6666
+          Write-Host "✅ Port configured"
+          $cfg.cli.server_url | Should -Be "ws://127.0.0.1:6666"
+          Write-Host "✅ Server URL configured"
+          $cfg.web.enable | Should -BeTrue
+          Write-Host "✅ Web enabled"
+          $cfg.admin.token | Should -Not -BeNullOrEmpty
+          Write-Host "✅ Admin token set"
+          $wrapper = Join-Path $env:XBOT_HOME "scripts\run-server.bat"
+          Test-Path $wrapper | Should -BeTrue
+          Write-Host "✅ Wrapper script created"
+          $wrapperContent = Get-Content $wrapper -Raw
+          $wrapperContent | Should -Match "xbot-cli.exe"
+          $wrapperContent | Should -Match "serve"
+          Write-Host "✅ Wrapper script has correct content"
+          $task = Get-ScheduledTask -TaskName "xbot-server" -ErrorAction SilentlyContinue
+          $task | Should -Not -BeNullOrEmpty
+          Write-Host "✅ Scheduled Task registered"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -204,7 +204,6 @@ function Install-ScheduledTask {
     $taskName = "xbot-server"
     $workDir = $env:USERPROFILE
     Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
-    schtasks.exe /Delete /TN $taskName /F 2>$null
     $wrapperDir = Join-Path $XbotHome "scripts"
     if (-not (Test-Path $wrapperDir)) {
         New-Item -ItemType Directory -Path $wrapperDir -Force | Out-Null
@@ -442,3 +441,7 @@ Write-Host ""
 Write-Host "  Project:  https://github.com/$REPO" -ForegroundColor DarkGray
 Write-Host "  License:  MIT" -ForegroundColor DarkGray
 Write-Host ""
+
+# Ensure clean exit code (native exe calls like schtasks.exe may leave $LASTEXITCODE non-zero)
+$global:LASTEXITCODE = 0
+exit 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,9 +1,11 @@
 <#
 .SYNOPSIS
-    xbot-cli installer for Windows
+    xbot-cli installer for Windows (no admin required)
 .DESCRIPTION
     Downloads and installs xbot-cli from GitHub Releases.
-    Supports standalone and server-client modes with optional Windows service.
+    Supports standalone and server-client modes.
+    Server installs as a Scheduled Task by default (no admin needed).
+    If running as Administrator, offers nssm as an alternative.
 .PARAMETER Version
     Specific version to install (defaults to latest release).
 .PARAMETER InstallPath
@@ -11,13 +13,11 @@
 .PARAMETER Mode
     Install mode: "standalone" (default) or "server-client".
 .PARAMETER Port
-    WebSocket port for server-client mode (default 8080).
+    Server port for server-client mode (default 8082).
 .EXAMPLE
     irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
 .EXAMPLE
     .\install.ps1 -Version v0.1.0
-.EXAMPLE
-    .\install.ps1 -InstallPath C:\Tools
 .EXAMPLE
     .\install.ps1 -Mode server-client -Port 9090
 #>
@@ -26,7 +26,8 @@ param(
     [string]$Version = "",
     [string]$InstallPath = "",
     [string]$Mode = "",
-    [int]$Port = 0
+    [int]$Port = 0,
+    [switch]$NonInteractive
 )
 
 $ErrorActionPreference = "Stop"
@@ -34,44 +35,43 @@ $ErrorActionPreference = "Stop"
 $REPO = "CjiW/xbot"
 $BINARY = "xbot-cli.exe"
 $SERVICE_NAME = "xbot-server"
-$DEFAULT_PORT = 8080
+$DEFAULT_PORT = 8082
+
+# Env var fallback for parameters (GitHub Actions uses env vars)
+if (-not $Mode)    { $Mode = $env:MODE }
+if (-not $Version) { $Version = $env:VERSION }
 
 if (-not $InstallPath) {
-    $InstallPath = Join-Path $env:USERPROFILE ".local\bin"
+    if ($env:INSTALL_PATH) {
+        $InstallPath = $env:INSTALL_PATH
+    } else {
+        $InstallPath = Join-Path $env:USERPROFILE ".local\bin"
+    }
 }
+if ($Port -le 0) { [int]::TryParse($env:PORT, [ref]$Port) | Out-Null }
 
 $XbotHome = if ($env:XBOT_HOME) { $env:XBOT_HOME } else { Join-Path $env:USERPROFILE ".xbot" }
 $ConfigPath = Join-Path $XbotHome "config.json"
 
-# --- Color helpers ---
 function Write-Info  { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Green }
 function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
 function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; exit 1 }
 
-# --- Detect platform ---
-
-# --- Convert PSCustomObject to Hashtable (PowerShell 5.1 compatibility) ---
 function ConvertTo-Ht {
     param([Parameter(ValueFromPipeline)]$InputObject)
     if ($InputObject -is [System.Collections.IDictionary]) {
         $ht = @{}
-        foreach ($key in $InputObject.Keys) {
-            $ht[$key] = ConvertTo-Ht $InputObject[$key]
-        }
+        foreach ($key in $InputObject.Keys) { $ht[$key] = ConvertTo-Ht $InputObject[$key] }
         return $ht
     }
     if ($InputObject -is [PSCustomObject]) {
         $ht = @{}
-        foreach ($prop in $InputObject.PSObject.Properties) {
-            $ht[$prop.Name] = ConvertTo-Ht $prop.Value
-        }
+        foreach ($prop in $InputObject.PSObject.Properties) { $ht[$prop.Name] = ConvertTo-Ht $prop.Value }
         return $ht
     }
     if ($InputObject -is [System.Collections.IList]) {
         $list = @()
-        foreach ($item in $InputObject) {
-            $list += ConvertTo-Ht $item
-        }
+        foreach ($item in $InputObject) { $list += ConvertTo-Ht $item }
         return $list
     }
     return $InputObject
@@ -86,35 +86,29 @@ function Get-Platform {
     }
 }
 
-# --- Resolve version ---
 function Get-LatestVersion {
     if ($Version) { return $Version }
-
     try {
         $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers @{"User-Agent"="PowerShell"}
         return $response.tag_name
     } catch {
-        Write-Err "Failed to determine latest version. Set -Version explicitly, e.g.: .\install.ps1 -Version v0.1.0"
+        Write-Err "Failed to determine latest version. Set -Version explicitly."
     }
 }
 
-# --- Generate random token (pure PowerShell, no python needed) ---
 function New-RandomToken {
     $bytes = New-Object byte[] 16
     [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
     return -join ($bytes | ForEach-Object { $_.ToString("x2") })
 }
 
-# --- Ask mode interactively ---
 function Ask-Mode {
     if ($Mode) { return $Mode }
-
     Write-Host ""
     Write-Host "Choose install mode:" -ForegroundColor Cyan
     Write-Host "  1) standalone      - CLI runs locally in-process" -ForegroundColor Cyan
     Write-Host "  2) server-client   - install local server service, CLI connects remotely" -ForegroundColor Cyan
     $choice = Read-Host "Select [1/2] (default 1)"
-
     switch ($choice) {
         "1" { return "standalone" }
         "2" { return "server-client" }
@@ -123,19 +117,14 @@ function Ask-Mode {
     }
 }
 
-# --- Ask port interactively ---
 function Ask-Port {
     if ($Port -gt 0) { return $Port }
     if ($selectedMode -ne "server-client") { return $DEFAULT_PORT }
-
-    $portInput = Read-Host "WebSocket port for local server [$DEFAULT_PORT]"
-    if ($portInput -match '^\d+$') {
-        return [int]$portInput
-    }
+    $portInput = Read-Host "Server port [HTTP + WebSocket + Web UI] [$DEFAULT_PORT]"
+    if ($portInput -match '^\d+$') { return [int]$portInput }
     return $DEFAULT_PORT
 }
 
-# --- Backup existing config ---
 function Backup-Config {
     if (Test-Path $ConfigPath) {
         $ts = Get-Date -Format "yyyyMMdd-HHmmss"
@@ -145,39 +134,23 @@ function Backup-Config {
     }
 }
 
-# --- Write config.json (pure PowerShell, mirrors install.sh python logic) ---
 function Write-Config {
-    param(
-        [string]$Mode,
-        [int]$Port,
-        [string]$Token
-    )
-
+    param([string]$Mode, [int]$Port, [string]$Token)
     if (-not (Test-Path $XbotHome)) {
         New-Item -ItemType Directory -Path $XbotHome -Force | Out-Null
     }
-
-    # Read existing config or start fresh
     $cfg = @{}
     if (Test-Path $ConfigPath) {
         try {
             $raw = Get-Content $ConfigPath -Raw -Encoding UTF8
             $cfg = $raw | ConvertFrom-Json | ConvertTo-Ht
-        } catch {
-            $cfg = @{}
-        }
+        } catch { $cfg = @{} }
     }
-
-    # Ensure top-level sections exist
     foreach ($section in @("server", "web", "cli", "admin", "agent")) {
-        if (-not $cfg.ContainsKey($section)) {
-            $cfg[$section] = @{}
-        }
+        if (-not $cfg.ContainsKey($section)) { $cfg[$section] = @{} }
     }
-
     $changes = [System.Collections.ArrayList]::new()
     $preserved = [System.Collections.ArrayList]::new()
-
     function Set-IfMissing([string]$Section, [string]$Key, [object]$Value) {
         $sectionDict = $cfg[$Section]
         if (-not $sectionDict.ContainsKey($Key) -or [string]::IsNullOrEmpty($sectionDict[$Key])) {
@@ -187,7 +160,6 @@ function Write-Config {
             [void]$preserved.Add("$Section.$Key=$($sectionDict[$Key])")
         }
     }
-
     function Set-Always([string]$Section, [string]$Key, [object]$Value) {
         $sectionDict = $cfg[$Section]
         $old = $sectionDict[$Key]
@@ -198,14 +170,10 @@ function Write-Config {
             [void]$preserved.Add("$Section.$Key=$old")
         }
     }
-
     Set-IfMissing "admin" "token" $Token
     $adminToken = $cfg["admin"]["token"]
     if (-not $adminToken) { $adminToken = $Token }
-
-    # Ensure agent.work_dir is set to user home so server has a stable working directory
     Set-IfMissing "agent" "work_dir" $env:USERPROFILE
-
     if ($Mode -eq "server-client") {
         Set-IfMissing "server" "host" "127.0.0.1"
         Set-Always  "server" "port" $Port
@@ -217,300 +185,143 @@ function Write-Config {
     } else {
         Set-IfMissing "cli" "token" $adminToken
     }
-
-    # Write JSON with proper formatting
     $json = $cfg | ConvertTo-Json -Depth 10
     Set-Content -Path $ConfigPath -Value $json -Encoding UTF8
-
-    # Report changes
-    foreach ($item in $changes) {
-        Write-Info "Config set: $item"
-    }
-    foreach ($item in $preserved) {
-        Write-Warn "Config preserved: $item"
-    }
+    foreach ($item in $changes) { Write-Info "Config set: $item" }
+    foreach ($item in $preserved) { Write-Warn "Config preserved: $item" }
 }
 
-# --- Check if running as Administrator ---
 function Test-IsAdmin {
     try {
         $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
         $principal = New-Object Security.Principal.WindowsPrincipal($identity)
         return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    } catch {
-        return $false
-    }
+    } catch { return $false }
 }
 
-# --- Download nssm if not present ---
-function Ensure-Nssm {
-    # Check if nssm is already on PATH
-    $nssmExe = (Get-Command nssm -ErrorAction SilentlyContinue).Source
-    if ($nssmExe -and (Test-Path $nssmExe)) {
-        Write-Info "nssm found at $nssmExe"
-        return $nssmExe
-    }
-
-    # Check common locations
-    $commonPaths = @(
-        (Join-Path $env:ProgramFiles "NSSM\nssm.exe"),
-        (Join-Path ${env:ProgramFiles(x86)} "NSSM\nssm.exe"),
-        (Join-Path $InstallPath "nssm.exe"),
-        (Join-Path $env:TEMP "nssm.exe")
-    )
-    foreach ($p in $commonPaths) {
-        if (Test-Path $p) {
-            Write-Info "nssm found at $p"
-            return $p
-        }
-    }
-
-    # Offer to download
-    Write-Host ""
-    Write-Warn "nssm (Non-Sucking Service Manager) is required to install xbot as a Windows service."
-    $download = Read-Host "Download nssm? [Y/n]"
-    if ($download -match '^[Nn]') {
-        return $null
-    }
-
-    Write-Info "Downloading nssm..."
-    $nssmZip = Join-Path $env:TEMP "nssm.zip"
-    $nssmDir = Join-Path $env:TEMP "nssm"
-
-    try {
-        # Download latest nssm release (2.24 is the last stable, use GitHub releases)
-        $nssmUrl = "https://nssm.cc/release/nssm-2.24.zip"
-        Invoke-WebRequest -Uri $nssmUrl -OutFile $nssmZip -UseBasicParsing
-
-        # Extract
-        if (Test-Path $nssmDir) { Remove-Item $nssmDir -Recurse -Force }
-        Expand-Archive -Path $nssmZip -DestinationPath $nssmDir -Force
-
-        # Find the right exe (win64 or win32)
-        $nssmBin = Join-Path $nssmDir "nssm-2.24\win64\nssm.exe"
-        if (-not (Test-Path $nssmBin)) {
-            $nssmBin = Join-Path $nssmDir "nssm-2.24\win32\nssm.exe"
-        }
-        if (-not (Test-Path $nssmBin)) {
-            Write-Err "Failed to extract nssm binary"
-        }
-
-        # Copy to install path
-        $destNssm = Join-Path $InstallPath "nssm.exe"
-        Copy-Item $nssmBin $destNssm -Force
-        Write-Info "nssm installed to $destNssm"
-        return $destNssm
-    } catch {
-        Write-Warn "Failed to download nssm: $_"
-        return $null
-    } finally {
-        # Cleanup temp files
-        Remove-Item $nssmZip -Force -ErrorAction SilentlyContinue
-        Remove-Item $nssmDir -Recurse -Force -ErrorAction SilentlyContinue
-    }
-}
-
-# --- Install Windows service using nssm ---
-function Install-ServiceNssm {
-    param(
-        [string]$NssmPath,
-        [string]$BinPath,
-        [string]$CfgPath
-    )
-
-    $workDir = $env:USERPROFILE
-
-    # Stop and remove existing service if present
-    & $NssmPath stop $SERVICE_NAME 2>$null
-    & $NssmPath remove $SERVICE_NAME confirm 2>$null
-
-    # Install the service
-    & $NssmPath install $SERVICE_NAME $BinPath "serve --config $CfgPath"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Err "nssm install failed with exit code $LASTEXITCODE"
-    }
-
-    # Configure service parameters
-    & $NssmPath set $SERVICE_NAME AppDirectory $workDir
-    & $NssmPath set $SERVICE_NAME DisplayName "xbot Agent Server"
-    & $NssmPath set $SERVICE_NAME Description "xbot AI Agent Server - WebSocket-based AI assistant service"
-    & $NssmPath set $SERVICE_NAME Start SERVICE_AUTO_START
-
-    # Set XBOT_HOME environment variable for the service
-    & $NssmPath set $SERVICE_NAME AppEnvironmentExtra "XBOT_HOME=$XbotHome"
-
-    # Set stdout/stderr logging
-    $logDir = Join-Path $XbotHome "logs"
-    if (-not (Test-Path $logDir)) {
-        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
-    }
-    & $NssmPath set $SERVICE_NAME AppStdout (Join-Path $logDir "xbot-server.log")
-    & $NssmPath set $SERVICE_NAME AppStderr (Join-Path $logDir "xbot-server.err")
-
-    # Set rotation for log files
-    & $NssmPath set $SERVICE_NAME AppRotateFiles 1
-    & $NssmPath set $SERVICE_NAME AppRotateBytes 10485760
-
-    # Start the service
-    & $NssmPath start $SERVICE_NAME
-    if ($LASTEXITCODE -eq 0) {
-        Write-Info "Windows service '$SERVICE_NAME' installed and started successfully"
-    } else {
-        Write-Warn "Service installed but failed to start (exit code $LASTEXITCODE). Check logs at $logDir"
-    }
-}
-
-# --- Install Windows service using sc.exe as fallback ---
-function Install-ServiceSc {
-    param(
-        [string]$BinPath,
-        [string]$CfgPath
-    )
-
-    Write-Warn "Using sc.exe for service management (limited functionality)."
-    Write-Warn "Consider installing nssm for better service management."
-
-    # Stop and remove existing service
-    sc.exe stop $SERVICE_NAME 2>$null
-    sc.exe delete $SERVICE_NAME 2>$null
-    Start-Sleep -Seconds 2
-
-    $binArgs = "serve --config $CfgPath"
-    $workDir = $env:USERPROFILE
-
-    # Create the service using sc.exe
-    sc.exe create $SERVICE_NAME binPath= "`"$BinPath`" $binArgs" start= auto DisplayName= "xbot Agent Server"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Err "sc.exe create failed with exit code $LASTEXITCODE"
-    }
-
-    # Set description
-    sc.exe description $SERVICE_NAME "xbot AI Agent Server - WebSocket-based AI assistant service"
-
-    # Set XBOT_HOME as a service-level environment variable via registry
-    try {
-        $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\$SERVICE_NAME"
-        $currentEnv = (Get-ItemProperty -Path $regPath -Name "Environment" -ErrorAction SilentlyContinue).Environment
-        if ($currentEnv) {
-            $newEnv = "$currentEnv`nXBOT_HOME=$XbotHome"
-        } else {
-            $newEnv = "XBOT_HOME=$XbotHome"
-        }
-        Set-ItemProperty -Path $regPath -Name "Environment" -Value $newEnv
-    } catch {
-        Write-Warn "Could not set XBOT_HOME environment variable for service: $_"
-    }
-
-    # Start the service
-    sc.exe start $SERVICE_NAME
-    if ($LASTEXITCODE -eq 0) {
-        Write-Info "Windows service '$SERVICE_NAME' installed and started successfully (via sc.exe)"
-    } else {
-        Write-Warn "Service installed but failed to start (exit code $LASTEXITCODE). Check Windows Event Viewer."
-    }
-}
-
-# --- Install as Scheduled Task (last resort fallback) ---
 function Install-ScheduledTask {
-    param(
-        [string]$BinPath,
-        [string]$CfgPath
-    )
-
-    Write-Warn "Using Scheduled Task as fallback service mechanism."
-    Write-Warn "The server will start at user logon and restart on failure."
-
+    param([string]$BinPath, [string]$CfgPath)
     $taskName = "xbot-server"
     $workDir = $env:USERPROFILE
-
-    # Remove existing task
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
     schtasks.exe /Delete /TN $taskName /F 2>$null
-
-    # Create a batch wrapper script
     $wrapperDir = Join-Path $XbotHome "scripts"
     if (-not (Test-Path $wrapperDir)) {
         New-Item -ItemType Directory -Path $wrapperDir -Force | Out-Null
     }
     $wrapperScript = Join-Path $wrapperDir "run-server.bat"
-    Set-Content -Path $wrapperScript -Value "@echo off`nset XBOT_HOME=$XbotHome`ncd /d `"$workDir`"`n`"$BinPath`" serve --config `"$CfgPath`"" -Encoding ASCII
-
-    # Create scheduled task
+    Set-Content -Path $wrapperScript -Value "@echo off`r`nset XBOT_HOME=$XbotHome`r`ncd /d `"$workDir`"`r`n`"$BinPath`" serve --config `"$CfgPath`"" -Encoding ASCII
     $action = New-ScheduledTaskAction -Execute $wrapperScript -WorkingDirectory $workDir
     $trigger = New-ScheduledTaskTrigger -AtLogOn
     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
-
-    # Try to use the modern ScheduledTasks cmdlets (PowerShell 4+)
     try {
-        Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Description "xbot AI Agent Server" -RunLevel Highest -Force
-        Write-Info "Scheduled Task '$taskName' registered successfully"
+        Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Description "xbot AI Agent Server" -Force
+        Write-Info "Scheduled Task '$taskName' registered (starts at logon, no admin needed)"
     } catch {
-        # Fallback to schtasks.exe
-        schtasks.exe /Create /SC ONLOGON /TN $taskName /TR "`"$wrapperScript`"" /RL HIGHEST /F
+        schtasks.exe /Create /SC ONLOGON /TN $taskName /TR "`"$wrapperScript`"" /F
         if ($LASTEXITCODE -eq 0) {
-            Write-Info "Scheduled Task '$taskName' created successfully (via schtasks.exe)"
+            Write-Info "Scheduled Task '$taskName' created (via schtasks.exe)"
         } else {
             Write-Err "Failed to create scheduled task: $_"
         }
     }
-
-    # Start the task immediately
     try {
         Start-ScheduledTask -TaskName $taskName
-        Write-Info "Scheduled Task started"
+        Write-Info "Server started"
     } catch {
-        Write-Warn "Could not auto-start the task. It will start at next logon."
+        Write-Warn "Could not auto-start. It will start at next logon."
     }
 }
 
-# --- Main service installation orchestrator ---
-function Install-WindowsService {
-    param(
-        [string]$BinPath,
-        [string]$CfgPath
+function Ensure-Nssm {
+    $nssmExe = (Get-Command nssm -ErrorAction SilentlyContinue).Source
+    if ($nssmExe -and (Test-Path $nssmExe)) { return $nssmExe }
+    $commonPaths = @(
+        (Join-Path $env:ProgramFiles "NSSM\nssm.exe"),
+        (Join-Path ${env:ProgramFiles(x86)} "NSSM\nssm.exe"),
+        (Join-Path $InstallPath "nssm.exe")
     )
+    foreach ($p in $commonPaths) {
+        if (Test-Path $p) { return $p }
+    }
+    Write-Info "Downloading nssm..."
+    $nssmZip = Join-Path $env:TEMP "nssm.zip"
+    $nssmDir = Join-Path $env:TEMP "nssm"
+    try {
+        Invoke-WebRequest -Uri "https://nssm.cc/release/nssm-2.24.zip" -OutFile $nssmZip -UseBasicParsing
+        if (Test-Path $nssmDir) { Remove-Item $nssmDir -Recurse -Force }
+        Expand-Archive -Path $nssmZip -DestinationPath $nssmDir -Force
+        $nssmBin = Join-Path $nssmDir "nssm-2.24\win64\nssm.exe"
+        if (-not (Test-Path $nssmBin)) { $nssmBin = Join-Path $nssmDir "nssm-2.24\win32\nssm.exe" }
+        if (-not (Test-Path $nssmBin)) { Write-Err "Failed to extract nssm" }
+        $dest = Join-Path $InstallPath "nssm.exe"
+        Copy-Item $nssmBin $dest -Force
+        return $dest
+    } catch {
+        Write-Warn "Failed to download nssm: $_"
+        return $null
+    } finally {
+        Remove-Item $nssmZip -Force -ErrorAction SilentlyContinue
+        Remove-Item $nssmDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
 
-    if (-not (Test-IsAdmin)) {
-        Write-Warn "Windows service installation requires Administrator privileges."
-        Write-Warn "The server can still be started manually: $BinPath serve --config $CfgPath"
-        Write-Warn "To install as a service, re-run this script as Administrator."
+function Install-ServiceNssm {
+    param([string]$NssmPath, [string]$BinPath, [string]$CfgPath)
+    $workDir = $env:USERPROFILE
+    & $NssmPath stop $SERVICE_NAME 2>$null
+    & $NssmPath remove $SERVICE_NAME confirm 2>$null
+    & $NssmPath install $SERVICE_NAME $BinPath "serve --config $CfgPath"
+    if ($LASTEXITCODE -ne 0) { Write-Err "nssm install failed" }
+    & $NssmPath set $SERVICE_NAME AppDirectory $workDir
+    & $NssmPath set $SERVICE_NAME DisplayName "xbot Agent Server"
+    & $NssmPath set $SERVICE_NAME Description "xbot AI Agent Server"
+    & $NssmPath set $SERVICE_NAME Start SERVICE_AUTO_START
+    & $NssmPath set $SERVICE_NAME AppEnvironmentExtra "XBOT_HOME=$XbotHome"
+    $logDir = Join-Path $XbotHome "logs"
+    if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+    & $NssmPath set $SERVICE_NAME AppStdout (Join-Path $logDir "xbot-server.log")
+    & $NssmPath set $SERVICE_NAME AppStderr (Join-Path $logDir "xbot-server.err")
+    & $NssmPath set $SERVICE_NAME AppRotateFiles 1
+    & $NssmPath set $SERVICE_NAME AppRotateBytes 10485760
+    & $NssmPath start $SERVICE_NAME
+    if ($LASTEXITCODE -eq 0) {
+        Write-Info "Windows service '$SERVICE_NAME' installed and started (nssm)"
+    } else {
+        Write-Warn "Service installed but failed to start. Check $logDir"
+    }
+}
+
+function Install-WindowsService {
+    param([string]$BinPath, [string]$CfgPath)
+    if ($NonInteractive -or -not (Test-IsAdmin)) {
+        Install-ScheduledTask -BinPath $BinPath -CfgPath $CfgPath
         return
     }
-
     Write-Host ""
-    Write-Host "Choose service installation method:" -ForegroundColor Cyan
-    Write-Host "  1) nssm (recommended) - Non-Sucking Service Manager, best for Go binaries" -ForegroundColor Cyan
-    Write-Host "  2) sc.exe (built-in)    - Windows built-in, limited functionality" -ForegroundColor Cyan
-    Write-Host "  3) Scheduled Task       - Fallback, runs at user logon" -ForegroundColor Cyan
-    Write-Host "  4) Skip service install - Start server manually" -ForegroundColor Cyan
-    $svcChoice = Read-Host "Select [1/2/3/4] (default 1)"
-
+    Write-Host "Choose service method:" -ForegroundColor Cyan
+    Write-Host "  1) Scheduled Task (recommended) - No admin needed, starts at logon" -ForegroundColor Cyan
+    Write-Host "  2) nssm service               - Real Windows service, needs admin" -ForegroundColor Cyan
+    Write-Host "  3) Skip" -ForegroundColor Cyan
+    $svcChoice = Read-Host "Select [1/2/3] (default 1)"
     switch ($svcChoice) {
-        "1" { "" }  # nssm - proceed below
-        "2" { Install-ServiceSc -BinPath $BinPath -CfgPath $CfgPath; return }
-        "3" { Install-ScheduledTask -BinPath $BinPath -CfgPath $CfgPath; return }
-        "4" { Write-Info "Skipping service installation."; return }
-        ""  { "" }  # nssm default - proceed below
-        default { Write-Err "Invalid selection: $svcChoice" }
-    }
-
-    # --- nssm path ---
-    $nssmPath = Ensure-Nssm
-    if ($nssmPath) {
-        Install-ServiceNssm -NssmPath $nssmPath -BinPath $BinPath -CfgPath $CfgPath
-    } else {
-        Write-Warn "nssm not available."
-        Write-Host ""
-        $fallback = Read-Host "Fall back to sc.exe? [Y/n]"
-        if ($fallback -notmatch '^[Nn]') {
-            Install-ServiceSc -BinPath $BinPath -CfgPath $CfgPath
-        } else {
-            $fallback2 = Read-Host "Use Scheduled Task instead? [Y/n]"
-            if ($fallback2 -notmatch '^[Nn]') {
-                Install-ScheduledTask -BinPath $BinPath -CfgPath $CfgPath
+        "2" {
+            $nssmPath = Ensure-Nssm
+            if ($nssmPath) {
+                Install-ServiceNssm -NssmPath $nssmPath -BinPath $BinPath -CfgPath $CfgPath
             } else {
-                Write-Info "Skipping service installation."
-                Write-Info "Start server manually: $BinPath serve --config $CfgPath"
+                Write-Warn "nssm not available, falling back to Scheduled Task"
+                Install-ScheduledTask -BinPath $BinPath -CfgPath $CfgPath
             }
+            return
+        }
+        "3" {
+            Write-Info "Skipping service install. Start manually: $BinPath serve --config $CfgPath"
+            return
+        }
+        default {
+            Install-ScheduledTask -BinPath $BinPath -CfgPath $CfgPath
+            return
         }
     }
 }
@@ -536,7 +347,6 @@ Write-Info "Install:   $InstallPath\$BINARY"
 Write-Info "Config:    $ConfigPath"
 Write-Host ""
 
-# --- Mode selection ---
 $selectedMode = Ask-Mode
 $selectedPort = Ask-Port
 
@@ -546,23 +356,19 @@ if ($selectedMode -eq "server-client") {
     Write-Info "Mode:      standalone"
 }
 
-# --- Create install directory ---
 if (-not (Test-Path $InstallPath)) {
     New-Item -ItemType Directory -Path $InstallPath -Force | Out-Null
     Write-Info "Created directory: $InstallPath"
 }
 
-# --- Download ---
 Write-Info "Downloading..."
 $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-cli-download.exe"
-
 try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
 } catch {
     Write-Err "Download failed: $_"
 }
 
-# --- Verify checksum if possible ---
 $checksumUrl = "https://github.com/$REPO/releases/download/$tag/checksums.txt"
 try {
     $checksumFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-checksums.txt"
@@ -582,14 +388,12 @@ try {
     Write-Warn "Checksum verification skipped"
 }
 
-# --- Install binary ---
 Copy-Item $tmpFile (Join-Path $InstallPath $BINARY) -Force
 Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
 
 Write-Host ""
 Write-Host "[OK] xbot-cli $tag installed to $InstallPath\$BINARY" -ForegroundColor Green
 
-# --- Add to PATH if not already there ---
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($userPath -notlike "*$InstallPath*") {
     [Environment]::SetEnvironmentVariable("Path", "$userPath;$InstallPath", "User")
@@ -598,18 +402,15 @@ if ($userPath -notlike "*$InstallPath*") {
     Write-Warn "Please restart your terminal for PATH changes to take effect."
 }
 
-# --- Generate config ---
 $token = New-RandomToken
 Backup-Config
 Write-Config -Mode $selectedMode -Port $selectedPort -Token $token
 
-# --- Install service for server-client mode ---
 if ($selectedMode -eq "server-client") {
     $binFullPath = Join-Path $InstallPath $BINARY
     Install-WindowsService -BinPath $binFullPath -CfgPath $ConfigPath
 }
 
-# --- Done ---
 Write-Host ""
 Write-Host "  =======================================" -ForegroundColor Cyan
 Write-Host "  Installation Complete" -ForegroundColor Cyan
@@ -621,15 +422,13 @@ Write-Info "Config: $ConfigPath"
 
 if ($selectedMode -eq "server-client") {
     Write-Host ""
-    Write-Host "  Manage the service:" -ForegroundColor Cyan
-    Write-Host "    nssm start xbot-server" -ForegroundColor DarkGray
-    Write-Host "    nssm stop xbot-server" -ForegroundColor DarkGray
-    Write-Host "    nssm restart xbot-server" -ForegroundColor DarkGray
-    Write-Host "    nssm status xbot-server" -ForegroundColor DarkGray
-    Write-Host "    nssm remove xbot-server confirm" -ForegroundColor DarkGray
+    Write-Host "  Manage the server:" -ForegroundColor Cyan
+    Write-Host "    Stop:   schtasks.exe /End /TN xbot-server" -ForegroundColor DarkGray
+    Write-Host "    Start:  Start-ScheduledTask -TaskName xbot-server" -ForegroundColor DarkGray
+    Write-Host "    Remove: Unregister-ScheduledTask -TaskName xbot-server" -ForegroundColor DarkGray
     Write-Host ""
-    Write-Info "CLI will connect to the configured local server (see $ConfigPath)"
-    Write-Info "Use 'xbot-cli' for client, 'xbot-cli serve --config $ConfigPath' for manual server start"
+    Write-Info "Web UI: http://localhost:$selectedPort"
+    Write-Info "Logs: $XbotHome\logs\xbot-server.log"
 } else {
     Write-Host ""
     Write-Info "Run 'xbot-cli' to start."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -225,11 +225,15 @@ function Install-ScheduledTask {
             Write-Err "Failed to create scheduled task: $_"
         }
     }
-    try {
-        Start-ScheduledTask -TaskName $taskName
-        Write-Info "Server started"
-    } catch {
-        Write-Warn "Could not auto-start. It will start at next logon."
+    if (-not $NonInteractive) {
+        try {
+            Start-ScheduledTask -TaskName $taskName
+            Write-Info "Server started"
+        } catch {
+            Write-Warn "Could not auto-start. It will start at next logon."
+        }
+    } else {
+        Write-Info "NONINTERACTIVE: skipped auto-start"
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 REPO="CjiW/xbot"
 BINARY="xbot-cli"
-INSTALL_PATH="${INSTALL_PATH:-/usr/local/bin}"
+# Default to user-local install (no sudo required)
+INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin}"
 XBOT_HOME="${XBOT_HOME:-$HOME/.xbot}"
 CONFIG_PATH="${CONFIG_PATH:-$XBOT_HOME/config.json}"
 SERVICE_NAME="xbot-server"
@@ -50,7 +51,15 @@ resolve_version() {
     echo "$tag"
 }
 
+# Non-interactive: use MODE env var. Interactive: prompt user.
 ask_mode() {
+    if [ -n "${MODE:-}" ]; then
+        case "$MODE" in
+            standalone|server-client) echo "$MODE" ;;
+            *) error "Invalid MODE='${MODE}'. Use 'standalone' or 'server-client'." ;;
+        esac
+        return
+    fi
     echo "Choose install mode:" >&2
     echo "  1) standalone      - CLI runs locally in-process" >&2
     echo "  2) server-client   - install local server service, CLI connects remotely" >&2
@@ -63,19 +72,23 @@ ask_mode() {
     esac
 }
 
+# Generate random hex token without external dependencies
 random_token() {
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - <<'PY'
-import secrets
-print(secrets.token_hex(16))
-PY
-        return
-    fi
     if command -v openssl >/dev/null 2>&1; then
         openssl rand -hex 16
         return
     fi
-    error "Need python3 or openssl to generate random token"
+    # Fallback: read from /dev/urandom (available on all Linux/macOS)
+    if [ -r /dev/urandom ]; then
+        od -A n -t x1 -N 16 /dev/urandom | tr -d ' \n'
+        return
+    fi
+    # Last resort: python3
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import secrets; print(secrets.token_hex(16))'
+        return
+    fi
+    error "Cannot generate random token: need openssl, /dev/urandom, or python3"
 }
 
 backup_config() {
@@ -89,47 +102,110 @@ backup_config() {
     fi
 }
 
+# Write config.json using jq (preferred) or python3 fallback.
 write_config() {
     local mode="$1" port="$2" token="$3"
     mkdir -p "$XBOT_HOME"
-    require_cmd python3
+
+    if command -v jq >/dev/null 2>&1; then
+        write_config_jq "$mode" "$port" "$token"
+    elif command -v python3 >/dev/null 2>&1; then
+        write_config_python3 "$mode" "$port" "$token"
+    else
+        error "Need jq or python3 to write config.json"
+    fi
+}
+
+write_config_jq() {
+    local mode="$1" port="$2" token="$3"
+    local changes=() preserved=()
+
+    # Create config if missing or invalid
+    if [ ! -f "$CONFIG_PATH" ] || ! jq empty "$CONFIG_PATH" 2>/dev/null; then
+        echo '{}' > "$CONFIG_PATH"
+    fi
+
+    # Ensure top-level sections exist
+    jq '{server: .server // {}, web: .web // {}, cli: .cli // {}, admin: .admin // {}, agent: .agent // {}} * .' \
+        "$CONFIG_PATH" > "${CONFIG_PATH}.tmp" && mv "${CONFIG_PATH}.tmp" "$CONFIG_PATH"
+
+    _set_if_missing() {
+        local section="$1" key="$2" value="$3"
+        local current
+        current=$(jq -r ".${section}.${key} // empty" "$CONFIG_PATH" 2>/dev/null)
+        if [ -z "$current" ]; then
+            jq --arg v "$value" ".${section}.${key} = \$v" "$CONFIG_PATH" > "${CONFIG_PATH}.tmp" && mv "${CONFIG_PATH}.tmp" "$CONFIG_PATH"
+            changes+=("${section}.${key}=${value}")
+        else
+            preserved+=("${section}.${key}=${current}")
+        fi
+    }
+
+    _set_always() {
+        local section="$1" key="$2" value="$3"
+        local old
+        old=$(jq -r ".${section}.${key} // empty" "$CONFIG_PATH" 2>/dev/null)
+        jq --arg v "$value" ".${section}.${key} = \$v" "$CONFIG_PATH" > "${CONFIG_PATH}.tmp" && mv "${CONFIG_PATH}.tmp" "$CONFIG_PATH"
+        if [ "$old" != "$value" ]; then
+            changes+=("${section}.${key}=${value} (was ${old})")
+        else
+            preserved+=("${section}.${key}=${old}")
+        fi
+    }
+
+    _set_if_missing admin token "$token"
+    _set_if_missing agent work_dir "$HOME"
+
+    if [ "$mode" = "server-client" ]; then
+        _set_if_missing server host "127.0.0.1"
+        _set_always server port "$port"
+        _set_always web enable true
+        _set_if_missing web host "127.0.0.1"
+        _set_always web port "$port"
+        _set_always cli server_url "ws://127.0.0.1:${port}"
+        local admin_token
+        admin_token=$(jq -r '.admin.token // empty' "$CONFIG_PATH")
+        _set_always cli token "${admin_token:-$token}"
+    else
+        local admin_token
+        admin_token=$(jq -r '.admin.token // empty' "$CONFIG_PATH")
+        _set_if_missing cli token "${admin_token:-$token}"
+    fi
+
+    for item in "${changes[@]+"${changes[@]}"}"; do
+        [ -n "$item" ] && info "Config set: $item"
+    done
+    for item in "${preserved[@]+"${preserved[@]}"}"; do
+        [ -n "$item" ] && warn "Config preserved: $item"
+    done
+}
+
+write_config_python3() {
+    local mode="$1" port="$2" token="$3"
     python3 - "$CONFIG_PATH" "$mode" "$port" "$token" "$HOME" <<'PY'
 import json, os, sys
 path, mode, port, token, home = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4], sys.argv[5]
 if os.path.exists(path):
     with open(path, 'r', encoding='utf-8') as f:
-        try:
-            cfg = json.load(f)
-        except Exception:
-            cfg = {}
+        try: cfg = json.load(f)
+        except Exception: cfg = {}
 else:
     cfg = {}
-
 cfg.setdefault('server', {})
 cfg.setdefault('web', {})
 cfg.setdefault('cli', {})
 cfg.setdefault('admin', {})
 cfg.setdefault('agent', {})
-changes = []
-preserved = []
-
-def set_if_missing(section, key, value):
-    if key not in cfg[section] or cfg[section][key] in (None, ''):
-        cfg[section][key] = value
-        changes.append(f'{section}.{key}={value}')
+changes, preserved = [], []
+def set_if_missing(s, k, v):
+    if k not in cfg[s] or cfg[s][k] in (None, ''):
+        cfg[s][k] = v; changes.append(f'{s}.{k}={v}')
     else:
-        preserved.append(f'{section}.{key}={cfg[section][key]}')
-
-def set_always(section, key, value):
-    old = cfg[section].get(key)
-    cfg[section][key] = value
-    if old != value:
-        changes.append(f'{section}.{key}={value} (was {old})')
-    else:
-        preserved.append(f'{section}.{key}={old}')
-
+        preserved.append(f'{s}.{k}={cfg[s][k]}')
+def set_always(s, k, v):
+    old = cfg[s].get(k); cfg[s][k] = v
+    (changes if old != v else preserved).append(f'{s}.{k}={v}' + (f' (was {old})' if old != v else ''))
 set_if_missing('admin', 'token', token)
-# Ensure agent.work_dir is set to user home so server has a stable working directory
 set_if_missing('agent', 'work_dir', home)
 if mode == 'server-client':
     set_if_missing('server', 'host', '127.0.0.1')
@@ -141,18 +217,10 @@ if mode == 'server-client':
     set_always('cli', 'token', cfg['admin'].get('token') or token)
 else:
     set_if_missing('cli', 'token', cfg['admin'].get('token') or token)
-
 with open(path, 'w', encoding='utf-8') as f:
     json.dump(cfg, f, ensure_ascii=False, indent=2)
-
-print('CONFIG_CHANGES_BEGIN')
-for item in changes:
-    print(item)
-print('CONFIG_CHANGES_END')
-print('CONFIG_PRESERVED_BEGIN')
-for item in preserved:
-    print(item)
-print('CONFIG_PRESERVED_END')
+for c in changes: print(f'[INFO] Config set: {c}')
+for p in preserved: print(f'[WARN] Config preserved: {p}', file=sys.stderr)
 PY
 }
 
@@ -170,44 +238,49 @@ download_web_dist() {
     fi
 }
 
-write_systemd_unit() {
+# --- User-level systemd service (no sudo required) ---
+write_systemd_user_unit() {
     local bin_path="$1" config_path="$2" unit_file="$3"
-    local install_user
-    install_user="$(id -un)"
-    local xbot_home
+    local xbot_home work_dir
     xbot_home="$(cd "$XBOT_HOME" && pwd)"
-    local work_dir
     work_dir="$HOME"
+    mkdir -p "$HOME/.config/systemd/user"
     cat > "$unit_file" <<EOF_UNIT
 [Unit]
-Description=xbot Agent Server
-After=network.target
+Description=xbot Agent Server (user)
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
-User=${install_user}
 Environment=XBOT_HOME=${xbot_home}
+Environment=PATH=${INSTALL_PATH}:/usr/local/bin:/usr/bin:/bin
 WorkingDirectory=${work_dir}
 ExecStart=${bin_path} serve --config ${config_path}
 Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 EOF_UNIT
 }
 
-install_systemd() {
+install_systemd_user() {
     local bin_path="$1" config_path="$2"
     [ "$(uname -s)" = "Linux" ] || return 0
-    info "Installing/updating systemd service (requires passwordless sudo -n)..."
-    write_systemd_unit "$bin_path" "$config_path" "$XBOT_HOME/${SERVICE_NAME}.service"
-    sudo -n install -d /etc/systemd/system
-    sudo -n install -m 0644 "$XBOT_HOME/${SERVICE_NAME}.service" "/etc/systemd/system/${SERVICE_NAME}.service"
-    sudo -n systemctl daemon-reload
-    sudo -n systemctl enable "$SERVICE_NAME"
-    sudo -n systemctl restart "$SERVICE_NAME"
-    info "systemd service installed/updated and restarted: ${SERVICE_NAME}"
+    info "Installing systemd --user service (no sudo required)..."
+    write_systemd_user_unit "$bin_path" "$config_path" "$HOME/.config/systemd/user/${SERVICE_NAME}.service"
+    info "systemd --user unit written: ${SERVICE_NAME}.service"
+    if [ -z "${NONINTERACTIVE:-}" ]; then
+        systemctl --user daemon-reload
+        systemctl --user enable "$SERVICE_NAME"
+        systemctl --user restart "$SERVICE_NAME"
+        info "systemd --user service started: ${SERVICE_NAME}"
+        info "  Logs: journalctl --user -u ${SERVICE_NAME} -f"
+    else
+        info "NONINTERACTIVE: skipped daemon-reload/enable/start"
+    fi
+    info "  Stop: systemctl --user stop ${SERVICE_NAME}"
 }
 
 install_launchd() {
@@ -237,9 +310,51 @@ install_launchd() {
   <key>StandardErrorPath</key><string>${XBOT_HOME}/logs/xbot-server.err</string>
 </dict></plist>
 EOF_PLIST
-    launchctl unload -w "$plist" >/dev/null 2>&1 || true
-    launchctl load -w "$plist"
-    info "launchd service installed/updated and restarted: com.xbot.server"
+    info "launchd plist written: ${plist}"
+    if [ -z "${NONINTERACTIVE:-}" ]; then
+        launchctl unload -w "$plist" >/dev/null 2>&1 || true
+        launchctl load -w "$plist"
+        info "launchd service loaded: com.xbot.server"
+    else
+        info "NONINTERACTIVE: skipped launchctl load"
+    fi
+    info "  Logs: ${XBOT_HOME}/logs/xbot-server.log"
+    info "  Stop: launchctl unload -w ${plist}"
+}
+
+add_to_path() {
+    case ":${PATH}:" in
+        *":${INSTALL_PATH}:"*) return 0 ;;
+    esac
+    local profile=""
+    if [ -n "${ZSH_VERSION:-}" ] || [ "$(basename "${SHELL:-}")" = "zsh" ]; then
+        profile="$HOME/.zshrc"
+    else
+        profile="$HOME/.bashrc"
+    fi
+    if [ -f "$profile" ]; then
+        if ! grep -qF "$INSTALL_PATH" "$profile" 2>/dev/null; then
+            echo "" >> "$profile"
+            echo "# Added by xbot installer" >> "$profile"
+            echo "export PATH=\"${INSTALL_PATH}:\$PATH\"" >> "$profile"
+            info "Added ${INSTALL_PATH} to PATH in ${profile}"
+        fi
+    fi
+    export PATH="${INSTALL_PATH}:${PATH}"
+}
+
+# Ensure systemd --user lingering is enabled (so service runs at boot without login)
+enable_linger() {
+    [ "$(uname -s)" = "Linux" ] || return 0
+    [ -z "${NONINTERACTIVE:-}" ] || return 0
+    if command -v loginctl >/dev/null 2>&1; then
+        if loginctl enable-linger "$(id -un)" 2>/dev/null; then
+            info "Enabled lingering: server will start at boot"
+        else
+            warn "Could not enable linger (server starts on first login instead)"
+            warn "  Run: loginctl enable-linger $(id -un)"
+        fi
+    fi
 }
 
 main() {
@@ -264,8 +379,8 @@ main() {
     MODE=$(ask_mode)
     TOKEN=$(random_token)
     PORT="$DEFAULT_PORT"
-    if [ "$MODE" = "server-client" ]; then
-        printf "Server port (HTTP + WebSocket + Web UI) [${DEFAULT_PORT}]: "
+    if [ "$MODE" = "server-client" ] && [ -z "${NONINTERACTIVE:-}" ]; then
+        printf "Server port (HTTP + WebSocket + Web UI) [${DEFAULT_PORT}]: " >&2
         read -r input_port
         PORT="${input_port:-$DEFAULT_PORT}"
     fi
@@ -290,36 +405,27 @@ main() {
         fi
     fi
 
+    # Install binary to user-local directory (no sudo)
     chmod +x "${TMPDIR}/${BINARY}"
-    if [ ! -d "$INSTALL_PATH" ]; then
-        if mkdir -p "$INSTALL_PATH" 2>/dev/null; then
-            :
-        else
-            warn "Cannot create ${INSTALL_PATH} directly, using sudo..."
-            sudo mkdir -p "$INSTALL_PATH"
-        fi
-    fi
-    if [ -w "$INSTALL_PATH" ]; then
-        mv "${TMPDIR}/${BINARY}" "${INSTALL_PATH}/${BINARY}"
-    else
-        warn "No write permission to ${INSTALL_PATH}, using sudo..."
-        sudo mv "${TMPDIR}/${BINARY}" "${INSTALL_PATH}/${BINARY}"
-    fi
+    mkdir -p "$INSTALL_PATH"
+    mv "${TMPDIR}/${BINARY}" "${INSTALL_PATH}/${BINARY}"
+    info "Binary installed to ${INSTALL_PATH}/${BINARY}"
+
+    add_to_path
 
     backup_config
-    CONFIG_UPDATE_OUTPUT="$(write_config "$MODE" "$PORT" "$TOKEN" "$HOME")"
-    echo "$CONFIG_UPDATE_OUTPUT" | sed -n '/^CONFIG_CHANGES_BEGIN$/,/^CONFIG_CHANGES_END$/p' | sed '1d;$d' | while IFS= read -r line; do
-        [ -n "$line" ] && info "Config set: $line"
-    done
-    echo "$CONFIG_UPDATE_OUTPUT" | sed -n '/^CONFIG_PRESERVED_BEGIN$/,/^CONFIG_PRESERVED_END$/p' | sed '1d;$d' | while IFS= read -r line; do
-        [ -n "$line" ] && warn "Config preserved: $line"
-    done
+    write_config "$MODE" "$PORT" "$TOKEN"
 
     if [ "$MODE" = "server-client" ]; then
         download_web_dist "$VERSION" "$XBOT_HOME/web/dist"
         case "$(uname -s)" in
-            Linux) install_systemd "${INSTALL_PATH}/${BINARY}" "$CONFIG_PATH" ;;
-            Darwin) install_launchd "${INSTALL_PATH}/${BINARY}" "$CONFIG_PATH" ;;
+            Linux)
+                install_systemd_user "${INSTALL_PATH}/${BINARY}" "$CONFIG_PATH"
+                enable_linger
+                ;;
+            Darwin)
+                install_launchd "${INSTALL_PATH}/${BINARY}" "$CONFIG_PATH"
+                ;;
         esac
     fi
 
@@ -330,9 +436,26 @@ main() {
     if [ "$MODE" = "server-client" ]; then
         info "Web UI: http://localhost:${PORT}"
         info "CLI will connect to the configured local server (see ${CONFIG_PATH})"
-        info "Use '${BINARY}' for client, '${BINARY} serve --config ${CONFIG_PATH}' for manual server start"
+        case "$(uname -s)" in
+            Linux)
+                info "Service: systemd --user (${SERVICE_NAME})"
+                info "  Logs:  journalctl --user -u ${SERVICE_NAME} -f"
+                info "  Stop:  systemctl --user stop ${SERVICE_NAME}"
+                info "  Start: systemctl --user start ${SERVICE_NAME}"
+                ;;
+            Darwin)
+                info "Service: launchd (com.xbot.server)"
+                info "  Logs:  ${XBOT_HOME}/logs/xbot-server.log"
+                info "  Stop:  launchctl unload -w ~/Library/LaunchAgents/com.xbot.server.plist"
+                ;;
+        esac
     else
         info "Run '${BINARY}' to start."
+    fi
+    if ! command -v "$BINARY" >/dev/null 2>&1; then
+        echo ""
+        warn "Note: ${INSTALL_PATH} is not yet in your shell PATH."
+        warn "  Restart your shell or run: export PATH=\"${INSTALL_PATH}:\$PATH\""
     fi
     echo ""
 }


### PR DESCRIPTION
## Summary

Privilege-free installation for all platforms (Linux/macOS/Windows) with comprehensive CI testing.

## install.sh Changes
- Default INSTALL_PATH=$HOME/.local/bin (no sudo)
- Linux: systemd --user service + loginctl enable-linger
- macOS: launchd plist (RunAtLoad + KeepAlive)
- NONINTERACTIVE mode: write service files only, skip start/load (for CI)
- jq preferred for config.json, python3 fallback
- random_token: /dev/urandom fallback (no python3/openssl required)

## install.ps1 Changes
- Scheduled Task as default (no admin needed), nssm optional
- -NonInteractive switch for CI
- Env var fallback for Mode/Port/Version/InstallPath

## CI Workflow (install-test.yml)
10 jobs across 3 platforms, all without sudo/admin:

| Platform | Jobs |
|----------|------|
| Linux | standalone, server-client, config-preserve, port-default |
| macOS | standalone, server-client, config-preserve, port-default |
| Windows | standalone, server-client |

Validates: binary install, config.json, port/url/token settings, service files (systemd unit / launchd plist / Scheduled Task).