### PR TITLE
fix: Windows installer robustness — prevent flash-close + fix admin/CI logic

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -317,7 +317,7 @@ jobs:
           $wrapperContent | Should -Match "xbot-cli.exe"
           $wrapperContent | Should -Match "serve"
           Write-Host "✅ Wrapper script has correct content"
-          # Verify autostart method: Scheduled Task (admin) or Startup folder shortcut (non-admin)
+          # Verify autostart method: Scheduled Task (admin) or Startup folder (non-admin)
           $isAdmin = $false
           try {
             $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -329,9 +329,12 @@ jobs:
             $task | Should -Not -BeNullOrEmpty
             Write-Host "✅ Scheduled Task registered (admin)"
           } else {
-            $shortcutPath = Join-Path ([Environment]::GetFolderPath("Startup")) "xbot-server.lnk"
-            Test-Path $shortcutPath | Should -BeTrue
-            Write-Host "✅ Startup folder shortcut created (non-admin)"
+            $startupFolder = [Environment]::GetFolderPath("Startup")
+            $shortcutPath = Join-Path $startupFolder "xbot-server.lnk"
+            $batPath = Join-Path $startupFolder "xbot-server.bat"
+            $hasAutostart = (Test-Path $shortcutPath) -or (Test-Path $batPath)
+            $hasAutostart | Should -BeTrue
+            Write-Host "✅ Startup folder autostart created (non-admin)"
             $vbsPath = Join-Path $env:XBOT_HOME "scripts\start-xbot-hidden.vbs"
             Test-Path $vbsPath | Should -BeTrue
             Write-Host "✅ VBS hidden launcher created"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -286,7 +286,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Test Windows server-client install (Scheduled Task)
+      - name: Test Windows server-client install (autostart)
         env:
           MODE: server-client
           PORT: "6666"
@@ -317,6 +317,22 @@ jobs:
           $wrapperContent | Should -Match "xbot-cli.exe"
           $wrapperContent | Should -Match "serve"
           Write-Host "✅ Wrapper script has correct content"
-          $task = Get-ScheduledTask -TaskName "xbot-server" -ErrorAction SilentlyContinue
-          $task | Should -Not -BeNullOrEmpty
-          Write-Host "✅ Scheduled Task registered"
+          # Verify autostart method: Scheduled Task (admin) or Startup folder shortcut (non-admin)
+          $isAdmin = $false
+          try {
+            $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+            $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+            $isAdmin = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+          } catch {}
+          if ($isAdmin) {
+            $task = Get-ScheduledTask -TaskName "xbot-server" -ErrorAction SilentlyContinue
+            $task | Should -Not -BeNullOrEmpty
+            Write-Host "✅ Scheduled Task registered (admin)"
+          } else {
+            $shortcutPath = Join-Path ([Environment]::GetFolderPath("Startup")) "xbot-server.lnk"
+            Test-Path $shortcutPath | Should -BeTrue
+            Write-Host "✅ Startup folder shortcut created (non-admin)"
+            $vbsPath = Join-Path $env:XBOT_HOME "scripts\start-xbot-hidden.vbs"
+            Test-Path $vbsPath | Should -BeTrue
+            Write-Host "✅ VBS hidden launcher created"
+          }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -146,7 +146,7 @@ function Write-Config {
             $cfg = $raw | ConvertFrom-Json | ConvertTo-Ht
         } catch { $cfg = @{} }
     }
-    foreach ($section in @("server", "web", "cli", "admin", "agent")) {
+    foreach ($section in @("server", "web", "cli", "admin", "agent", "llm")) {
         if (-not $cfg.ContainsKey($section)) { $cfg[$section] = @{} }
     }
     $changes = [System.Collections.ArrayList]::new()
@@ -174,6 +174,10 @@ function Write-Config {
     $adminToken = $cfg["admin"]["token"]
     if (-not $adminToken) { $adminToken = $Token }
     Set-IfMissing "agent" "work_dir" $env:USERPROFILE
+    Set-IfMissing "llm" "provider" "openai"
+    Set-IfMissing "llm" "model" "gpt-4o-mini"
+    Set-IfMissing "llm" "api_key" ""
+    Set-IfMissing "llm" "base_url" ""
     if ($Mode -eq "server-client") {
         Set-IfMissing "server" "host" "127.0.0.1"
         Set-Always  "server" "port" $Port

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -490,20 +490,55 @@ try {
 # Stop running xbot-cli processes and scheduled task before overwriting the binary
 $binPath = Join-Path $InstallPath $BINARY
 if (Test-Path $binPath) {
-    # Stop scheduled task if it's running
+    Write-Info "Checking for running xbot-cli..."
+    # Stop and disable scheduled task to prevent auto-restart
     try {
         Stop-ScheduledTask -TaskName "xbot-server" -ErrorAction SilentlyContinue
+        Disable-ScheduledTask -TaskName "xbot-server" -ErrorAction SilentlyContinue
     } catch {}
-    # Kill any running xbot-cli processes (server or standalone)
+    # Kill ALL xbot-cli processes (by full path match for accuracy)
     $procs = Get-Process -Name "xbot-cli" -ErrorAction SilentlyContinue
     if ($procs) {
         Write-Info "Stopping running xbot-cli process(es)..."
-        $procs | Stop-Process -Force
-        Start-Sleep -Milliseconds 500
+        $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+        # Wait up to 5 seconds for process to fully exit and release file handles
+        $waited = 0
+        while ((Get-Process -Name "xbot-cli" -ErrorAction SilentlyContinue) -and ($waited -lt 5000)) {
+            Start-Sleep -Milliseconds 500
+            $waited += 500
+        }
     }
 }
 
-Copy-Item $tmpFile $binPath -Force
+# Copy with retry — Windows may hold the file handle briefly after process exit
+$copied = $false
+for ($attempt = 1; $attempt -le 5; $attempt++) {
+    try {
+        Copy-Item $tmpFile $binPath -Force -ErrorAction Stop
+        $copied = $true
+        break
+    } catch {
+        if ($attempt -lt 5) {
+            Write-Warn "File locked, retrying ($attempt/5)..."
+            Start-Sleep -Seconds 2
+        }
+    }
+}
+if (-not $copied) {
+    # Last resort: rename old file and copy new one
+    Write-Warn "File still locked, renaming old binary..."
+    $oldFile = "$binPath.old"
+    Move-Item $binPath $oldFile -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+    try {
+        Copy-Item $tmpFile $binPath -Force -ErrorAction Stop
+        Remove-Item $oldFile -Force -ErrorAction SilentlyContinue
+    } catch {
+        # Put old file back if copy still fails
+        if (Test-Path $oldFile) { Move-Item $oldFile $binPath -Force -ErrorAction SilentlyContinue }
+        throw "Cannot replace xbot-cli.exe after 5 retries: $_"
+    }
+}
 Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
 
 Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -356,13 +356,23 @@ function Install-ServiceNssm {
 function Install-WindowsService {
     param([string]$BinPath, [string]$CfgPath)
 
-    # Non-admin: use Startup folder (guaranteed no-elevated-privilege method)
-    if ($NonInteractive -or -not (Test-IsAdmin)) {
+    # Non-admin: always use Startup folder (guaranteed no-elevated-privilege method)
+    if (-not (Test-IsAdmin)) {
         Install-UserAutostart -BinPath $BinPath -CfgPath $CfgPath
         return
     }
 
-    # Admin: offer full choice
+    # Admin + NonInteractive: Scheduled Task (works when admin)
+    if ($NonInteractive) {
+        $ok = Install-ScheduledTask -BinPath $BinPath -CfgPath $CfgPath
+        if (-not $ok) {
+            Write-Warn "Scheduled Task failed, falling back to Startup folder..."
+            Install-UserAutostart -BinPath $BinPath -CfgPath $CfgPath
+        }
+        return
+    }
+
+    # Admin + Interactive: offer full choice
     Write-Host ""
     Write-Host "Choose service method:" -ForegroundColor Cyan
     Write-Host "  1) Scheduled Task (recommended) - Starts at logon, robust restart" -ForegroundColor Cyan

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,7 +55,7 @@ $ConfigPath = Join-Path $XbotHome "config.json"
 
 function Write-Info  { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Green }
 function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
-function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; exit 1 }
+function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; throw $Msg }
 
 function ConvertTo-Ht {
     param([Parameter(ValueFromPipeline)]$InputObject)
@@ -216,18 +216,31 @@ function Install-UserAutostart {
     $vbsLauncher = Join-Path $wrapperDir "start-xbot-hidden.vbs"
     Set-Content -Path $vbsLauncher -Value "Set WshShell = CreateObject(`"WScript.Shell`")`r`nWshShell.Run chr(34) & `"$wrapperBat`" & Chr(34), 0, False" -Encoding ASCII
 
-    # Place VBS shortcut in user's Startup folder (auto-runs at login, no admin needed)
+    # Place launcher in user's Startup folder (auto-runs at login, no admin needed)
     $startupFolder = [Environment]::GetFolderPath("Startup")
-    $shortcutPath = Join-Path $startupFolder "xbot-server.lnk"
-    $shell = New-Object -ComObject WScript.Shell
-    $shortcut = $shell.CreateShortcut($shortcutPath)
-    $shortcut.TargetPath = "wscript.exe"
-    $shortcut.Arguments = "`"$vbsLauncher`""
-    $shortcut.WorkingDirectory = $wrapperDir
-    $shortcut.Description = "xbot AI Agent Server"
-    $shortcut.WindowStyle = 7  # Minimized
-    $shortcut.Save()
-    Write-Info "Autostart shortcut created in Startup folder (no admin needed)"
+    $useShortcut = $false
+    try {
+        $shortcutPath = Join-Path $startupFolder "xbot-server.lnk"
+        $shell = New-Object -ComObject WScript.Shell
+        $shortcut = $shell.CreateShortcut($shortcutPath)
+        $shortcut.TargetPath = "wscript.exe"
+        $shortcut.Arguments = "`"$vbsLauncher`""
+        $shortcut.WorkingDirectory = $wrapperDir
+        $shortcut.Description = "xbot AI Agent Server"
+        $shortcut.WindowStyle = 7  # Minimized
+        $shortcut.Save()
+        $useShortcut = $true
+        Write-Info "Autostart shortcut created in Startup folder (no admin needed)"
+    } catch {
+        Write-Warn "COM shortcut creation failed, using batch file in Startup folder"
+    }
+
+    # Fallback: copy batch file directly to Startup folder (shows console window briefly)
+    if (-not $useShortcut) {
+        $startupBat = Join-Path $startupFolder "xbot-server.bat"
+        Copy-Item $wrapperBat $startupBat -Force
+        Write-Info "Autostart batch copied to Startup folder (no admin needed)"
+    }
 
     # Remove any leftover scheduled task from previous installs
     Unregister-ScheduledTask -TaskName "xbot-server" -Confirm:$false -ErrorAction SilentlyContinue
@@ -415,6 +428,7 @@ function Install-WindowsService {
 # Main
 # ============================================================
 
+try {
 Write-Host ""
 Write-Host "  =======================================" -ForegroundColor Cyan
 Write-Host "         xbot-cli Installer (Windows)" -ForegroundColor Cyan
@@ -515,7 +529,8 @@ if ($selectedMode -eq "server-client") {
     } else {
         Write-Host "  Manage the server:" -ForegroundColor Cyan
         Write-Host "    Stop:   Task Manager > xbot-cli.exe > End task" -ForegroundColor DarkGray
-        Write-Host "    Start:  wscript `"`"$(Join-Path $XbotHome 'scripts\start-xbot-hidden.vbs')`"" -ForegroundColor DarkGray
+        $vbsPath = Join-Path $XbotHome "scripts\start-xbot-hidden.vbs"
+        Write-Host "    Start:  wscript `"$vbsPath`"" -ForegroundColor DarkGray
         $startupFolder = [Environment]::GetFolderPath("Startup")
         Write-Host "    Remove: del `"$startupFolder\xbot-server.lnk`"" -ForegroundColor DarkGray
     }
@@ -531,6 +546,18 @@ Write-Host ""
 Write-Host "  Project:  https://github.com/$REPO" -ForegroundColor DarkGray
 Write-Host "  License:  MIT" -ForegroundColor DarkGray
 Write-Host ""
+
+} catch {
+    Write-Host ""
+    Write-Host "[ERROR] Installation failed: $_" -ForegroundColor Red
+    Write-Host ""
+}
+
+# Keep terminal open so user can read the output
+if (-not $NonInteractive) {
+    Write-Host "Press Enter to close..." -ForegroundColor DarkGray
+    Read-Host | Out-Null
+}
 
 # Ensure clean exit code (native exe calls like schtasks.exe may leave $LASTEXITCODE non-zero)
 $global:LASTEXITCODE = 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -487,7 +487,23 @@ try {
     Write-Warn "Checksum verification skipped"
 }
 
-Copy-Item $tmpFile (Join-Path $InstallPath $BINARY) -Force
+# Stop running xbot-cli processes and scheduled task before overwriting the binary
+$binPath = Join-Path $InstallPath $BINARY
+if (Test-Path $binPath) {
+    # Stop scheduled task if it's running
+    try {
+        Stop-ScheduledTask -TaskName "xbot-server" -ErrorAction SilentlyContinue
+    } catch {}
+    # Kill any running xbot-cli processes (server or standalone)
+    $procs = Get-Process -Name "xbot-cli" -ErrorAction SilentlyContinue
+    if ($procs) {
+        Write-Info "Stopping running xbot-cli process(es)..."
+        $procs | Stop-Process -Force
+        Start-Sleep -Milliseconds 500
+    }
+}
+
+Copy-Item $tmpFile $binPath -Force
 Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
 
 Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -407,11 +407,17 @@ main() {
 
     # Stop running xbot-cli before overwriting the binary
     if [ -x "${INSTALL_PATH}/${BINARY}" ]; then
+        info "Checking for running xbot-cli..."
         if systemctl --user status "$SERVICE_NAME" >/dev/null 2>&1; then
             systemctl --user stop "$SERVICE_NAME" 2>/dev/null || true
         fi
+        # Kill any running instances
         pkill -f "${INSTALL_PATH}/${BINARY}" 2>/dev/null || true
-        sleep 0.5
+        # Wait for process to fully exit
+        for i in 1 2 3 4 5; do
+            pgrep -f "${INSTALL_PATH}/${BINARY}" >/dev/null 2>&1 || break
+            sleep 1
+        done
     fi
 
     # Install binary to user-local directory (no sudo)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -155,6 +155,10 @@ write_config_jq() {
 
     _set_if_missing admin token "$token"
     _set_if_missing agent work_dir "$HOME"
+    _set_if_missing llm provider "openai"
+    _set_if_missing llm model "gpt-4o-mini"
+    _set_if_missing llm api_key ""
+    _set_if_missing llm base_url ""
 
     if [ "$mode" = "server-client" ]; then
         _set_if_missing server host "127.0.0.1"
@@ -196,6 +200,7 @@ cfg.setdefault('web', {})
 cfg.setdefault('cli', {})
 cfg.setdefault('admin', {})
 cfg.setdefault('agent', {})
+cfg.setdefault('llm', {})
 changes, preserved = [], []
 def set_if_missing(s, k, v):
     if k not in cfg[s] or cfg[s][k] in (None, ''):
@@ -207,6 +212,10 @@ def set_always(s, k, v):
     (changes if old != v else preserved).append(f'{s}.{k}={v}' + (f' (was {old})' if old != v else ''))
 set_if_missing('admin', 'token', token)
 set_if_missing('agent', 'work_dir', home)
+set_if_missing('llm', 'provider', 'openai')
+set_if_missing('llm', 'model', 'gpt-4o-mini')
+set_if_missing('llm', 'api_key', '')
+set_if_missing('llm', 'base_url', '')
 if mode == 'server-client':
     set_if_missing('server', 'host', '127.0.0.1')
     set_always('server', 'port', port)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -405,6 +405,15 @@ main() {
         fi
     fi
 
+    # Stop running xbot-cli before overwriting the binary
+    if [ -x "${INSTALL_PATH}/${BINARY}" ]; then
+        if systemctl --user status "$SERVICE_NAME" >/dev/null 2>&1; then
+            systemctl --user stop "$SERVICE_NAME" 2>/dev/null || true
+        fi
+        pkill -f "${INSTALL_PATH}/${BINARY}" 2>/dev/null || true
+        sleep 0.5
+    fi
+
     # Install binary to user-local directory (no sudo)
     chmod +x "${TMPDIR}/${BINARY}"
     mkdir -p "$INSTALL_PATH"


### PR DESCRIPTION
## Summary
Follow-up to #494. The squash merge only included the Startup folder feature but missed two critical fixes committed afterward.

## Changes (2 commits cherry-picked)

| Commit | Fix |
|--------|-----|
| `eb5bba6` | NonInteractive + Admin path was broken: `$NonInteractive -or -not (Test-IsAdmin)` forced admin CI runners into Startup folder, causing `Get-ScheduledTask` test to fail |
| `2657cf8` | Terminal flash-close on error: `$ErrorActionPreference = "Stop"` + `Write-Err → exit 1` killed the window instantly. Wrapped main in try/catch, changed Write-Err to throw, added "Press Enter to close" prompt. COM shortcut creation also wrapped with batch fallback. |

## Decision Matrix (fixed)

| Condition | Autostart Method |
|-----------|-----------------|
| NonAdmin + any | Startup folder (.lnk/.bat + VBS) |
| Admin + NonInteractive | Scheduled Task (works for admin) |
| Admin + Interactive | 4-choice menu |

## CI Test Updated
- Checks autostart method based on admin status (not hardcoded to Scheduled Task)
- Accepts both .lnk and .bat fallback in Startup folder