### PR TITLE
fix(feishu): revert model tab max_context/output to select_static

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -43,6 +43,7 @@
 ### Startup
 - `NewOpenAILLM` loads model list asynchronously. `ListModels()` returns fallback immediately.
 - Settings save is synchronous — all local I/O, no network calls.
+- **`SaveToFile` uses deep JSON merge to preserve unknown fields.** `json.Unmarshal` silently drops fields not in the Go struct. `SaveToFile` reads the existing disk file first and recursively merges struct JSON into it, so user-added custom fields (or future struct fields added in newer versions) survive load→save cycles. Never bypass `SaveToFile` with raw `json.Marshal` writes to config.json.
 
 ### CLI / BubbleTea
 - **`parseKeyInput` with modifiers must NOT set `Text` field.** `Key.String()` returns `Text` if non-empty (ultraviolet `key.go:392`), bypassing `Keystroke()`. `{Code:'c', Text:"c", Mod:ModCtrl}.String()` → `"c"` not `"ctrl+c"`, breaking cancel.

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -683,7 +683,12 @@ func (a *Agent) buildSubAgentRunConfig(
 	}
 
 	// 构建 SubAgent 的 system prompt：通用模板 + 角色专有能力描述
+	// parentCtx.WorkspaceRoot 在 remote 模式下为空（buildToolContext 清空了宿主机路径），
+	// 回退到 a.workDir 确保提示词中始终包含正确的工作目录。
 	workDir := parentCtx.WorkspaceRoot
+	if workDir == "" {
+		workDir = a.workDir
+	}
 	if parentCtx.Sandbox != nil && parentCtx.Sandbox.Name() != "none" {
 		workDir = parentCtx.Sandbox.Workspace(parentCtx.OriginUserID)
 	}
@@ -817,7 +822,15 @@ func (a *Agent) buildSubAgentRunConfig(
 			}
 			return "none"
 		}(),
-		InitialCWD: parentCtx.CurrentDir, // 继承父 Agent 的 CWD
+		// 继承父 Agent 的 CWD。remote 模式下 parentCtx.CurrentDir 可能为空
+		//（buildToolContext 清空了宿主机路径，且 session 未存过 CWD），
+		// 回退到 a.workDir 确保子 Agent 有正确的初始目录。
+		InitialCWD: func() string {
+			if parentCtx.CurrentDir != "" {
+				return parentCtx.CurrentDir
+			}
+			return a.workDir
+		}(),
 
 		MaxIterations: a.getMaxIterations(), // 继承主 Agent 配置
 		// SubAgent 不设独立超时，直接使用父 context 携带的 deadline

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -1284,8 +1284,9 @@ func (a *Agent) ListInteractiveSessions(channel, chatID string) []InteractiveSes
 // parseInteractiveKeyChatID extracts the parent chatID from an interactive key.
 // Key format: "channel:chatID/roleName:instance"
 func parseInteractiveKeyChatID(key string) string {
-	// Find the "/" separator between chatID and roleName
-	slashIdx := strings.Index(key, "/")
+	// Find the last "/" separator between chatID and roleName.
+	// Use LastIndex because chatID can contain "/" (e.g. CLI absolute paths like /home/user/workspace).
+	slashIdx := strings.LastIndex(key, "/")
 	if slashIdx <= 0 {
 		return ""
 	}

--- a/agent/interactive_test.go
+++ b/agent/interactive_test.go
@@ -24,6 +24,30 @@ func TestInteractiveKey(t *testing.T) {
 	}
 }
 
+func TestParseInteractiveKeyChatID(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"CLI absolute path", "cli:/home/user/workspace/explore:oneshot-explore-1234", "/home/user/workspace"},
+		{"Feishu chatID", "feishu:oc_abc123/explore:session-1", "oc_abc123"},
+		{"Web chatID", "web:senderID/explore:inst", "senderID"},
+		{"multi-slash path", "cli:/a/b/c/d/explore:oneshot-explore-9876", "/a/b/c/d"},
+		{"empty chatID", "cli:/explore:inst", ""},
+		{"no slash", "cli:explore:inst", ""},
+		{"no colon", "cli/explore:inst", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseInteractiveKeyChatID(tt.key)
+			if got != tt.want {
+				t.Errorf("parseInteractiveKeyChatID(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveOriginIDs_WithMetadata(t *testing.T) {
 	msg := bus.InboundMessage{
 		Channel:  "agent",

--- a/agent/llm_factory.go
+++ b/agent/llm_factory.go
@@ -506,9 +506,18 @@ func (f *LLMFactory) ListAllModelsForUser(senderID string) []string {
 		}
 	}
 
-	// All subscription model fields (no API calls, just DB records)
-	if f.subscriptionSvc != nil && senderID != "" {
-		if subs, err := f.subscriptionSvc.List(senderID); err == nil {
+	// All subscription model fields (no API calls, just DB records).
+	// When senderID is empty, collect models from ALL subscriptions
+	// (used by settings card tier selectors which need a global model list).
+	if f.subscriptionSvc != nil {
+		var subs []*sqlite.LLMSubscription
+		var err error
+		if senderID != "" {
+			subs, err = f.subscriptionSvc.List(senderID)
+		} else {
+			subs, err = f.subscriptionSvc.ListAll()
+		}
+		if err == nil {
 			for _, sub := range subs {
 				if sub.Model != "" && !seen[sub.Model] {
 					seen[sub.Model] = true

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -183,9 +183,10 @@ func newGlamourRenderer(wrapWidth int) *glamour.TermRenderer {
 
 // cliCommands 已知命令列表（用于 Tab 补全，§8）
 var cliCommands = []string{
-	"/cancel", "/chat", "/clear", "/compact", "/context", "/exit", "/help",
-	"/new", "/quit", "/rewind", "/search", "/sessions", "/settings", "/setup",
-	"/ss", "/su", "/tasks", "/update", "/usage",
+	"/cancel", "/channel", "/chat", "/clear", "/compact", "/context", "/exit",
+	"/help", "/model", "/models", "/new", "/quit", "/rewind", "/search",
+	"/sessions", "/settings", "/setup", "/ss", "/su", "/tasks", "/update",
+	"/usage",
 }
 
 // §19 长消息折叠阈值

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -738,6 +738,30 @@ func (m *cliModel) panelWidth(want int) int {
 	return want
 }
 
+// truncateCompHint truncates a styled completion hint string to fit within
+// maxW columns. It uses lipgloss.Width for ANSI-aware measurement and
+// removes trailing items (from the last " · " separator backwards) until
+// it fits, appending "…" to indicate truncation.
+func truncateCompHint(hint string, maxW int) string {
+	if maxW <= 0 || lipgloss.Width(hint) <= maxW {
+		return hint
+	}
+	sep := " · "
+	for {
+		idx := strings.LastIndex(hint, sep)
+		if idx < 0 {
+			break
+		}
+		candidate := hint[:idx]
+		if lipgloss.Width(candidate+"…") <= maxW {
+			return candidate + "…"
+		}
+		hint = candidate
+	}
+	// Fallback: return as-is (should rarely happen; each item is short).
+	return hint
+}
+
 // renderCompletionsHint returns the dynamic border color and completions hint string
 // based on the current input content (slash commands, @ file references, etc.).
 func (m *cliModel) renderCompletionsHint(inputValue string) (borderColor color.Color, hint string) {
@@ -759,7 +783,7 @@ func (m *cliModel) renderCompletionsHint(inputValue string) (borderColor color.C
 					parts[i] = m.styles.CompItem.Render(c)
 				}
 			}
-			hint = m.styles.CompHint.Render(strings.Join(parts, " · "))
+			hint = truncateCompHint(m.styles.CompHint.Render(strings.Join(parts, " · ")), m.width)
 		} else {
 			var matches []string
 			for _, cmd := range cliCommands {
@@ -768,7 +792,7 @@ func (m *cliModel) renderCompletionsHint(inputValue string) (borderColor color.C
 				}
 			}
 			if len(matches) > 0 {
-				hint = m.styles.CompHintBorder.Render("[Tab] " + strings.Join(matches, " · "))
+				hint = truncateCompHint(m.styles.CompHintBorder.Render("[Tab] "+strings.Join(matches, " · ")), m.width)
 			}
 		}
 		return

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -120,9 +120,7 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 	case "settings_set_max_context":
 		maxCtxStr := parsed["max_context"]
 		if maxCtxStr == "" {
-			if opt, ok := actionData["selected_option"].(string); ok {
-				maxCtxStr = opt
-			}
+			maxCtxStr = formStr(actionData, "max_context_k")
 		}
 		if maxCtxStr == "" {
 			return nil, fmt.Errorf("missing max_context")
@@ -145,9 +143,7 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 	case "settings_set_max_output_tokens":
 		maxOutStr := parsed["max_output_tokens"]
 		if maxOutStr == "" {
-			if opt, ok := actionData["selected_option"].(string); ok {
-				maxOutStr = opt
-			}
+			maxOutStr = formStr(actionData, "max_output_k")
 		}
 		if maxOutStr == "" {
 			return nil, fmt.Errorf("missing max_output_tokens")
@@ -1138,46 +1134,31 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		maxContextDisplay = fmt.Sprintf("%dk", currentMaxContext/1000)
 	}
 
-	// Build options in k units, always include current value.
-	currentMaxCtxK := currentMaxContext / 1000
-	presetKCtx := []int{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
-	maxCtxOptions := make([]map[string]any, 0, len(presetKCtx)+1)
-	seenCtx := make(map[int]bool)
-	if currentMaxCtxK > 0 {
-		seenCtx[currentMaxCtxK] = true
-		maxCtxOptions = append(maxCtxOptions, map[string]any{
-			"text":  map[string]any{"tag": "plain_text", "content": fmt.Sprintf("%dk", currentMaxCtxK)},
-			"value": fmt.Sprintf("%d", currentMaxCtxK),
-		})
+	maxCtxInitial := ""
+	if currentMaxContext > 0 {
+		maxCtxInitial = fmt.Sprintf("%d", currentMaxContext/1000)
 	}
-	for _, v := range presetKCtx {
-		if !seenCtx[v] {
-			label := "默认"
-			if v > 0 {
-				label = fmt.Sprintf("%dk", v)
-			}
-			maxCtxOptions = append(maxCtxOptions, map[string]any{
-				"text":  map[string]any{"tag": "plain_text", "content": label},
-				"value": fmt.Sprintf("%d", v),
-			})
-		}
-	}
-	elements = append(elements, buildSettingRow(
-		"最大上下文 (k)",
-		maxContextDisplay,
-		map[string]any{
-			"tag":            "select_static",
-			"name":           "settings_max_context_select",
-			"placeholder":    map[string]any{"tag": "plain_text", "content": "选择上下文长度 (k)..."},
-			"initial_option": fmt.Sprintf("%d", currentMaxCtxK),
-			"options":        maxCtxOptions,
-			"value": map[string]string{
-				"action_data": mustMapToJSON(map[string]string{
-					"action": "settings_set_max_context",
-				}),
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": fmt.Sprintf("**最大上下文 (k)**　当前: %s", maxContextDisplay),
+	})
+	elements = append(elements, map[string]any{
+		"tag": "form",
+		"name": []map[string]any{
+			{
+				"tag":           "input",
+				"name":          "max_context_k",
+				"label":         map[string]any{"tag": "plain_text", "content": "上下文长度 (k)"},
+				"placeholder":   map[string]any{"tag": "plain_text", "content": "如 400 = 400k"},
+				"initial_value": maxCtxInitial,
 			},
 		},
-	))
+		"value": map[string]string{
+			"action_data": mustMapToJSON(map[string]string{
+				"action": "settings_set_max_context",
+			}),
+		},
+	})
 
 	// Max output tokens setting (unit: k, stored as k*1000)
 	currentMaxOutputTokens := 0
@@ -1189,45 +1170,31 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		maxOutputDisplay = fmt.Sprintf("%dk", currentMaxOutputTokens/1000)
 	}
 
-	currentMaxOutK := currentMaxOutputTokens / 1000
-	presetKOut := []int{0, 1, 2, 4, 8, 16, 32, 64, 128, 256}
-	maxOutOptions := make([]map[string]any, 0, len(presetKOut)+1)
-	seenOut := make(map[int]bool)
-	if currentMaxOutK > 0 {
-		seenOut[currentMaxOutK] = true
-		maxOutOptions = append(maxOutOptions, map[string]any{
-			"text":  map[string]any{"tag": "plain_text", "content": fmt.Sprintf("%dk", currentMaxOutK)},
-			"value": fmt.Sprintf("%d", currentMaxOutK),
-		})
+	maxOutInitial := ""
+	if currentMaxOutputTokens > 0 {
+		maxOutInitial = fmt.Sprintf("%d", currentMaxOutputTokens/1000)
 	}
-	for _, v := range presetKOut {
-		if !seenOut[v] {
-			label := "默认"
-			if v > 0 {
-				label = fmt.Sprintf("%dk", v)
-			}
-			maxOutOptions = append(maxOutOptions, map[string]any{
-				"text":  map[string]any{"tag": "plain_text", "content": label},
-				"value": fmt.Sprintf("%d", v),
-			})
-		}
-	}
-	elements = append(elements, buildSettingRow(
-		"最大输出 Token (k)",
-		maxOutputDisplay,
-		map[string]any{
-			"tag":            "select_static",
-			"name":           "settings_max_output_tokens_select",
-			"placeholder":    map[string]any{"tag": "plain_text", "content": "选择最大输出 (k)..."},
-			"initial_option": fmt.Sprintf("%d", currentMaxOutK),
-			"options":        maxOutOptions,
-			"value": map[string]string{
-				"action_data": mustMapToJSON(map[string]string{
-					"action": "settings_set_max_output_tokens",
-				}),
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": fmt.Sprintf("**最大输出 Token (k)**　当前: %s", maxOutputDisplay),
+	})
+	elements = append(elements, map[string]any{
+		"tag": "form",
+		"name": []map[string]any{
+			{
+				"tag":           "input",
+				"name":          "max_output_k",
+				"label":         map[string]any{"tag": "plain_text", "content": "最大输出 (k)"},
+				"placeholder":   map[string]any{"tag": "plain_text", "content": "如 16 = 16k，0 = 默认"},
+				"initial_value": maxOutInitial,
 			},
 		},
-	))
+		"value": map[string]string{
+			"action_data": mustMapToJSON(map[string]string{
+				"action": "settings_set_max_output_tokens",
+			}),
+		},
+	})
 
 	// LLM concurrency settings (personal only)
 	personalConc := 3 // default

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -120,7 +120,9 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 	case "settings_set_max_context":
 		maxCtxStr := parsed["max_context"]
 		if maxCtxStr == "" {
-			maxCtxStr = formStr(actionData, "settings_max_context_input")
+			if opt, ok := actionData["selected_option"].(string); ok {
+				maxCtxStr = opt
+			}
 		}
 		if maxCtxStr == "" {
 			return nil, fmt.Errorf("missing max_context")
@@ -143,7 +145,9 @@ func (f *FeishuChannel) HandleSettingsAction(ctx context.Context, actionData map
 	case "settings_set_max_output_tokens":
 		maxOutStr := parsed["max_output_tokens"]
 		if maxOutStr == "" {
-			maxOutStr = formStr(actionData, "settings_max_output_tokens_input")
+			if opt, ok := actionData["selected_option"].(string); ok {
+				maxOutStr = opt
+			}
 		}
 		if maxOutStr == "" {
 			return nil, fmt.Errorf("missing max_output_tokens")
@@ -1134,18 +1138,39 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		maxContextDisplay = fmt.Sprintf("%dk", currentMaxContext/1000)
 	}
 
-	maxContextInitial := "0"
-	if currentMaxContext > 0 {
-		maxContextInitial = fmt.Sprintf("%d", currentMaxContext/1000)
+	// Build options in k units, always include current value.
+	currentMaxCtxK := currentMaxContext / 1000
+	presetKCtx := []int{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
+	maxCtxOptions := make([]map[string]any, 0, len(presetKCtx)+1)
+	seenCtx := make(map[int]bool)
+	if currentMaxCtxK > 0 {
+		seenCtx[currentMaxCtxK] = true
+		maxCtxOptions = append(maxCtxOptions, map[string]any{
+			"text":  map[string]any{"tag": "plain_text", "content": fmt.Sprintf("%dk", currentMaxCtxK)},
+			"value": fmt.Sprintf("%d", currentMaxCtxK),
+		})
+	}
+	for _, v := range presetKCtx {
+		if !seenCtx[v] {
+			label := "默认"
+			if v > 0 {
+				label = fmt.Sprintf("%dk", v)
+			}
+			maxCtxOptions = append(maxCtxOptions, map[string]any{
+				"text":  map[string]any{"tag": "plain_text", "content": label},
+				"value": fmt.Sprintf("%d", v),
+			})
+		}
 	}
 	elements = append(elements, buildSettingRow(
 		"最大上下文 (k)",
 		maxContextDisplay,
 		map[string]any{
-			"tag":           "input",
-			"name":          "settings_max_context_input",
-			"placeholder":   map[string]any{"tag": "plain_text", "content": "如 128 = 128k"},
-			"initial_value": maxContextInitial,
+			"tag":            "select_static",
+			"name":           "settings_max_context_select",
+			"placeholder":    map[string]any{"tag": "plain_text", "content": "选择上下文长度 (k)..."},
+			"initial_option": fmt.Sprintf("%d", currentMaxCtxK),
+			"options":        maxCtxOptions,
 			"value": map[string]string{
 				"action_data": mustMapToJSON(map[string]string{
 					"action": "settings_set_max_context",
@@ -1164,18 +1189,38 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		maxOutputDisplay = fmt.Sprintf("%dk", currentMaxOutputTokens/1000)
 	}
 
-	maxOutputInitial := "0"
-	if currentMaxOutputTokens > 0 {
-		maxOutputInitial = fmt.Sprintf("%d", currentMaxOutputTokens/1000)
+	currentMaxOutK := currentMaxOutputTokens / 1000
+	presetKOut := []int{0, 1, 2, 4, 8, 16, 32, 64, 128, 256}
+	maxOutOptions := make([]map[string]any, 0, len(presetKOut)+1)
+	seenOut := make(map[int]bool)
+	if currentMaxOutK > 0 {
+		seenOut[currentMaxOutK] = true
+		maxOutOptions = append(maxOutOptions, map[string]any{
+			"text":  map[string]any{"tag": "plain_text", "content": fmt.Sprintf("%dk", currentMaxOutK)},
+			"value": fmt.Sprintf("%d", currentMaxOutK),
+		})
+	}
+	for _, v := range presetKOut {
+		if !seenOut[v] {
+			label := "默认"
+			if v > 0 {
+				label = fmt.Sprintf("%dk", v)
+			}
+			maxOutOptions = append(maxOutOptions, map[string]any{
+				"text":  map[string]any{"tag": "plain_text", "content": label},
+				"value": fmt.Sprintf("%d", v),
+			})
+		}
 	}
 	elements = append(elements, buildSettingRow(
 		"最大输出 Token (k)",
 		maxOutputDisplay,
 		map[string]any{
-			"tag":           "input",
-			"name":          "settings_max_output_tokens_input",
-			"placeholder":   map[string]any{"tag": "plain_text", "content": "如 16 = 16k"},
-			"initial_value": maxOutputInitial,
+			"tag":            "select_static",
+			"name":           "settings_max_output_tokens_select",
+			"placeholder":    map[string]any{"tag": "plain_text", "content": "选择最大输出 (k)..."},
+			"initial_option": fmt.Sprintf("%d", currentMaxOutK),
+			"options":        maxOutOptions,
 			"value": map[string]string{
 				"action_data": mustMapToJSON(map[string]string{
 					"action": "settings_set_max_output_tokens",

--- a/channel/web.go
+++ b/channel/web.go
@@ -749,6 +749,12 @@ func (wc *WebChannel) SetCallbacks(cb WebCallbacks) {
 	wc.callbacks = cb
 }
 
+// SetRPCHandler sets or replaces the RPC handler. Used to wire the handler
+// after the dispatcher and message bus are available.
+func (wc *WebChannel) SetRPCHandler(fn func(method string, params json.RawMessage, senderID string) (json.RawMessage, error)) {
+	wc.callbacks.RPCHandler = fn
+}
+
 func (wc *WebChannel) Name() string { return "web" }
 
 // ---------------------------------------------------------------------------

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -103,9 +103,15 @@ func (app *cliApp) refreshRemoteValuesCache() {
 }
 
 func saveCLIConfig(cfg *config.Config) error {
-	merged := config.LoadFromFile(config.ConfigFilePath())
+	path := config.ConfigFilePath()
+	merged := config.LoadFromFile(path)
 	if merged == nil {
-		merged = &config.Config{}
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			merged = &config.Config{}
+		} else {
+			log.WithField("path", path).Error("saveCLIConfig: config file exists but cannot parse, refusing to overwrite")
+			return fmt.Errorf("config file parse error, not overwriting")
+		}
 	}
 	// CLI only ever modifies these sections:
 	merged.LLM = cfg.LLM     // via settings panel / subscription switch
@@ -114,7 +120,7 @@ func saveCLIConfig(cfg *config.Config) error {
 	if cfg.CLI.ServerURL != "" || cfg.CLI.Token != "" {
 		merged.CLI = cfg.CLI
 	}
-	return config.SaveToFile(config.ConfigFilePath(), merged)
+	return config.SaveToFile(path, merged)
 }
 
 func isCLISubscriptionSettingKey(key string) bool {
@@ -937,7 +943,7 @@ func main() {
 				defer app.agentCacheMu.RUnlock()
 				return app.agentCacheCount
 			}
-			return app.backend.CountInteractiveSessions("cli", "")
+			return app.backend.CountInteractiveSessions("cli", absWorkDir)
 		},
 		AgentList: func() []channel.AgentPanelEntry {
 			if app.backend == nil {
@@ -948,7 +954,7 @@ func main() {
 				defer app.agentCacheMu.RUnlock()
 				return app.agentCacheList
 			}
-			sessions := app.backend.ListInteractiveSessions("cli", "")
+			sessions := app.backend.ListInteractiveSessions("cli", absWorkDir)
 			entries := make([]channel.AgentPanelEntry, len(sessions))
 			for i, s := range sessions {
 				entries[i] = channel.AgentPanelEntry{
@@ -1042,7 +1048,7 @@ func main() {
 					Label:   "主会话  You ↔ Agent",
 					Active:  true,
 				})
-				sessions := app.backend.ListInteractiveSessions("cli", "")
+				sessions := app.backend.ListInteractiveSessions("cli", absWorkDir)
 				for _, s := range sessions {
 					agentKey := s.Role + ":" + s.Instance
 					if seen[agentKey] {
@@ -1498,8 +1504,8 @@ func main() {
 					if app.backend == nil {
 						return
 					}
-					count := app.backend.CountInteractiveSessions("cli", "")
-					sessions := app.backend.ListInteractiveSessions("cli", "")
+					count := app.backend.CountInteractiveSessions("cli", absWorkDir)
+					sessions := app.backend.ListInteractiveSessions("cli", absWorkDir)
 					entries := make([]channel.AgentPanelEntry, len(sessions))
 					for i, s := range sessions {
 						entries[i] = channel.AgentPanelEntry{

--- a/config/config.go
+++ b/config/config.go
@@ -271,17 +271,32 @@ func LoadFromFile(path string) *Config {
 }
 
 // SaveToFile 将配置保存到 JSON 文件（原子写入：先写临时文件再 rename）。
+// 它会先读取磁盘上已有的文件，将 Go struct 序列化后的顶层 key 覆盖到原始 JSON 上，
+// 同时保留磁盘文件中存在但 Go struct 未定义的字段（未知 key）。
+// 这样用户手动添加的自定义字段或未来新增的 struct 字段不会被静默丢弃。
 func SaveToFile(path string, cfg *Config) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
-	data, err := json.MarshalIndent(cfg, "", "  ")
+
+	// 序列化 Go struct
+	structData, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)
 	}
+
+	// 尝试读取磁盘上已有的文件，做 JSON 级合并以保留未知字段
+	finalData := structData
+	if existing, readErr := os.ReadFile(path); readErr == nil && len(existing) > 0 {
+		if merged, mergeErr := mergeJSONPreserveUnknown(existing, structData); mergeErr == nil {
+			finalData = merged
+		}
+		// 合并失败时回退到纯 struct 序列化（安全降级）
+	}
+
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	if err := os.WriteFile(tmp, finalData, 0o600); err != nil {
 		return fmt.Errorf("write temp config: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
@@ -289,6 +304,61 @@ func SaveToFile(path string, cfg *Config) error {
 		return fmt.Errorf("rename config: %w", err)
 	}
 	return nil
+}
+
+// mergeJSONPreserveUnknown 将 structData 的顶层 key 深度合并到 existing 上。
+// 对于两边都是 JSON object 的嵌套值，递归合并以保留 unknown 字段。
+// structData 中的 key 始终覆盖 existing 中的同名 key（非 object 时直接替换）。
+func mergeJSONPreserveUnknown(existing, structData []byte) ([]byte, error) {
+	var existingMap map[string]json.RawMessage
+	if err := json.Unmarshal(existing, &existingMap); err != nil {
+		return nil, err
+	}
+	var structMap map[string]json.RawMessage
+	if err := json.Unmarshal(structData, &structMap); err != nil {
+		return nil, err
+	}
+	// 递归合并：两边都是 object 时深度合并，否则 struct 覆盖
+	for k, structVal := range structMap {
+		if existingVal, ok := existingMap[k]; ok {
+			merged, err := deepMergeJSON(existingVal, structVal)
+			if err != nil {
+				// 降级为直接覆盖
+				existingMap[k] = structVal
+				continue
+			}
+			existingMap[k] = merged
+		} else {
+			existingMap[k] = structVal
+		}
+	}
+	return json.MarshalIndent(existingMap, "", "  ")
+}
+
+// deepMergeJSON 对两个 JSON 值做深度合并。
+// 如果两者都是 JSON object，递归合并（structVal 的 key 覆盖 existingVal）。
+// 否则返回 structVal（直接替换）。
+func deepMergeJSON(existing, structVal json.RawMessage) (json.RawMessage, error) {
+	var existingObj, structObj map[string]json.RawMessage
+	existingIsObj := json.Unmarshal(existing, &existingObj) == nil
+	structIsObj := json.Unmarshal(structVal, &structObj) == nil
+
+	if existingIsObj && structIsObj {
+		for k, v := range structObj {
+			if ev, ok := existingObj[k]; ok {
+				merged, err := deepMergeJSON(ev, v)
+				if err != nil {
+					existingObj[k] = v
+					continue
+				}
+				existingObj[k] = merged
+			} else {
+				existingObj[k] = v
+			}
+		}
+		return json.Marshal(existingObj)
+	}
+	return structVal, nil
 }
 
 func splitCommaTrim(s string) []string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -120,5 +123,180 @@ func TestSubscriptionMigrationFromEmpty(t *testing.T) {
 	}
 	if !sub.Active {
 		t.Error("expected Active=true for migrated subscription")
+	}
+}
+
+func TestSaveToFilePreservesUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// 1. Write initial config with a custom unknown field
+	initial := `{
+  "llm": {"provider": "openai", "model": "gpt-4"},
+  "agent": {"work_dir": "/tmp/test", "prompt_file": "CLAUDE.md", "custom_future_field": "keep_me"},
+  "my_custom_section": {"key": "value"}
+}`
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial: %v", err)
+	}
+
+	// 2. Load, modify a known field, save
+	cfg := LoadFromFile(path)
+	if cfg == nil {
+		t.Fatal("LoadFromFile returned nil")
+	}
+	cfg.Agent.MaxIterations = 500
+
+	if err := SaveToFile(path, cfg); err != nil {
+		t.Fatalf("SaveToFile: %v", err)
+	}
+
+	// 3. Verify unknown fields are preserved
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, `"custom_future_field": "keep_me"`) {
+		t.Errorf("custom_future_field not preserved in output:\n%s", content)
+	}
+	if !strings.Contains(content, `"my_custom_section"`) {
+		t.Errorf("my_custom_section not preserved in output:\n%s", content)
+	}
+
+	// 4. Verify known fields are correctly updated
+	if !strings.Contains(content, `"max_iterations": 500`) {
+		t.Errorf("max_iterations not updated in output:\n%s", content)
+	}
+	if !strings.Contains(content, `"prompt_file": "CLAUDE.md"`) {
+		t.Errorf("prompt_file not preserved in output:\n%s", content)
+	}
+	if !strings.Contains(content, `"work_dir": "/tmp/test"`) {
+		t.Errorf("work_dir not preserved in output:\n%s", content)
+	}
+}
+
+func TestSaveToFileCreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := &Config{
+		LLM:   LLMConfig{Provider: "openai", Model: "gpt-4"},
+		Agent: AgentConfig{WorkDir: "/tmp", PromptFile: "prompt.md"},
+	}
+
+	if err := SaveToFile(path, cfg); err != nil {
+		t.Fatalf("SaveToFile: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var loaded Config
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if loaded.LLM.Model != "gpt-4" {
+		t.Errorf("expected model gpt-4, got %s", loaded.LLM.Model)
+	}
+	if loaded.Agent.PromptFile != "prompt.md" {
+		t.Errorf("expected prompt.md, got %s", loaded.Agent.PromptFile)
+	}
+}
+
+func TestMergeJSONPreserveUnknown(t *testing.T) {
+	existing := `{"a": 1, "b": 2, "unknown_key": "keep"}`
+	structData := `{"a": 10, "c": 3}`
+
+	merged, err := mergeJSONPreserveUnknown([]byte(existing), []byte(structData))
+	if err != nil {
+		t.Fatalf("mergeJSONPreserveUnknown: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(merged, &m); err != nil {
+		t.Fatalf("unmarshal merged: %v", err)
+	}
+
+	// struct key overrides existing
+	if m["a"] != float64(10) {
+		t.Errorf("expected a=10, got %v", m["a"])
+	}
+	// existing-only key preserved
+	if m["b"] != float64(2) {
+		t.Errorf("expected b=2, got %v", m["b"])
+	}
+	// unknown key preserved
+	if m["unknown_key"] != "keep" {
+		t.Errorf("expected unknown_key=keep, got %v", m["unknown_key"])
+	}
+	// struct-only key added
+	if m["c"] != float64(3) {
+		t.Errorf("expected c=3, got %v", m["c"])
+	}
+}
+
+func TestSaveToFileLoadSaveRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Write a full config with all known fields
+	cfg := &Config{
+		LLM: LLMConfig{
+			Provider: "anthropic",
+			BaseURL:  "https://open.bigmodel.cn/api/anthropic",
+			APIKey:   "test-key",
+			Model:    "glm-5.1",
+		},
+		Agent: AgentConfig{
+			MaxIterations:    2000,
+			MaxConcurrency:   3,
+			MemoryProvider:   "flat",
+			WorkDir:          "/ipfs_flash/test",
+			PromptFile:       "CLAUDE.md",
+			MaxContextTokens: 200000,
+		},
+		Feishu: FeishuConfig{
+			Enabled: true,
+			AppID:   "test-app",
+		},
+	}
+
+	if err := SaveToFile(path, cfg); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	// Load and save again (simulates the load → modify → save cycle)
+	cfg2 := LoadFromFile(path)
+	if cfg2 == nil {
+		t.Fatal("LoadFromFile returned nil")
+	}
+	cfg2.Agent.MaxIterations = 3000
+	if err := SaveToFile(path, cfg2); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	// Verify all fields preserved
+	cfg3 := LoadFromFile(path)
+	if cfg3 == nil {
+		t.Fatal("final LoadFromFile returned nil")
+	}
+	if cfg3.Agent.PromptFile != "CLAUDE.md" {
+		t.Errorf("prompt_file lost: got %q", cfg3.Agent.PromptFile)
+	}
+	if cfg3.Agent.WorkDir != "/ipfs_flash/test" {
+		t.Errorf("work_dir lost: got %q", cfg3.Agent.WorkDir)
+	}
+	if cfg3.Agent.MaxIterations != 3000 {
+		t.Errorf("max_iterations not updated: got %d", cfg3.Agent.MaxIterations)
+	}
+	if cfg3.LLM.Provider != "anthropic" {
+		t.Errorf("llm provider lost: got %q", cfg3.LLM.Provider)
+	}
+	if cfg3.Feishu.AppID != "test-app" {
+		t.Errorf("feishu app_id lost: got %q", cfg3.Feishu.AppID)
 	}
 }

--- a/docs/agent/llm.md
+++ b/docs/agent/llm.md
@@ -23,6 +23,10 @@
 - Must send Usage before Done event (`openai.go:836`)
 - Provider without `finish_reason` but with tool_calls: infer reason as tool_calls (`openai.go:844`)
 
+## Reasoning History Replay
+
+- In OpenAI-compatible auto mode, if any assistant message in the conversation already has `reasoning_content`, replay all assistant history messages with a `reasoning_content` field as well (use `""` when the original reasoning was lost, e.g. after compression). Some reasoning providers reject mixed assistant history shapes.
+
 ## Retry Behavior
 
 - Creates fresh context per attempt (`context.Background()`), not inheriting parent deadline (`retry.go:230-257`)

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -290,11 +290,23 @@ type assistantMessageWithReasoning struct {
 	ToolCalls        any    `json:"tool_calls,omitempty"`
 }
 
+func hasAssistantReasoningHistory(messages []ChatMessage) bool {
+	for _, msg := range messages {
+		if msg.Role == "assistant" && msg.ReasoningContent != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // toOpenAIMessages 将业务消息转换为 OpenAI 消息格式。
-// thinkingMode 非 "disabled" 时，所有 assistant 消息都会包含 reasoning_content 字段
-// （即使为空字符串），以满足 DeepSeek thinking mode 的要求。
+// 显式开启 thinking mode 时，所有 assistant 消息都会包含 reasoning_content 字段。
+// 在 auto 模式下，只要历史里已经出现过 assistant reasoning，也会为所有 assistant
+// 消息补齐该字段（缺失时传空字符串），以满足 DeepSeek/OpenAI reasoning provider
+// 对历史消息形状的一致性要求。
 func toOpenAIMessages(messages []ChatMessage, thinkingMode string) []openai.ChatCompletionMessageParamUnion {
 	thinkingEnabled := thinkingMode != "" && thinkingMode != "disabled"
+	reasoningHistoryObserved := thinkingMode != "disabled" && hasAssistantReasoningHistory(messages)
 	result := make([]openai.ChatCompletionMessageParamUnion, 0, len(messages))
 	for _, msg := range messages {
 		switch msg.Role {
@@ -329,7 +341,7 @@ func toOpenAIMessages(messages []ChatMessage, thinkingMode string) []openai.Chat
 		case "assistant":
 			// Thinking mode 开启，或有实际 reasoning_content 时，使用 param.Override 路径
 			// 确保 reasoning_content 字段始终传给 API（DeepSeek thinking mode 要求）
-			if thinkingEnabled || msg.ReasoningContent != "" {
+			if thinkingEnabled || reasoningHistoryObserved || msg.ReasoningContent != "" {
 				var content any = msg.Content
 				if msg.Content == "" {
 					content = nil // OpenAI 协议: 空 content 用 null

--- a/llm/openai_reasoning_test.go
+++ b/llm/openai_reasoning_test.go
@@ -186,6 +186,48 @@ func TestToOpenAIMessages_ThinkingModeEmptyReasoning(t *testing.T) {
 	}
 }
 
+func TestToOpenAIMessages_AutoModeWithReasoningHistoryKeepsEmptyReasoningField(t *testing.T) {
+	// Auto mode should preserve reasoning_content shape once the conversation
+	// already contains assistant reasoning. Some reasoning providers require
+	// all assistant history messages to carry the field, even when empty.
+	messages := []ChatMessage{
+		NewUserMessage("hello"),
+		{
+			Role:    "assistant",
+			Content: "Hi there!",
+		},
+		NewUserMessage("what is 1+1?"),
+		{
+			Role:             "assistant",
+			Content:          "The answer is 2.",
+			ReasoningContent: "Simple addition.",
+		},
+	}
+
+	result := toOpenAIMessages(messages, "")
+	if len(result) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(result))
+	}
+
+	jsonBytes1, _ := json.Marshal(result[1].OfAssistant)
+	var parsed1 map[string]any
+	json.Unmarshal(jsonBytes1, &parsed1)
+	if rc, ok := parsed1["reasoning_content"]; !ok {
+		t.Error("auto mode with reasoning history: assistant message MUST have reasoning_content field")
+	} else if rcStr, ok := rc.(string); !ok || rcStr != "" {
+		t.Errorf("auto mode with reasoning history: expected empty string for reasoning_content, got %v", rc)
+	}
+
+	jsonBytes2, _ := json.Marshal(result[3].OfAssistant)
+	var parsed2 map[string]any
+	json.Unmarshal(jsonBytes2, &parsed2)
+	if rc, ok := parsed2["reasoning_content"]; !ok {
+		t.Error("auto mode with reasoning history: final assistant message MUST have reasoning_content field")
+	} else if rcStr, ok := rc.(string); !ok || rcStr != "Simple addition." {
+		t.Errorf("auto mode with reasoning history: expected preserved reasoning_content, got %v", rc)
+	}
+}
+
 func TestToOpenAIMessages_ToolCallsArgumentsRemainJSONString(t *testing.T) {
 	// When assistant has both reasoning_content and tool_calls,
 	// DeepSeek/OpenAI-compatible APIs expect function.arguments to remain a JSON string.

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -160,7 +161,7 @@ func createAdminLLM(cfg *config.Config) (llm_pkg.LLM, error) {
 // handleCLIRPC dispatches RPC requests from CLI RemoteBackend clients
 // to the server's LocalBackend. This is the server-side counterpart of
 // RemoteBackend.callRPC().
-func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, method string, params json.RawMessage, senderID string) (json.RawMessage, error) {
+func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.Dispatcher, msgBus *bus.MessageBus, method string, params json.RawMessage, senderID string) (json.RawMessage, error) {
 	// bizID is the resolved business identity for DB operations.
 	// senderID is the WS auth identity, used ONLY for isAdmin() authorization.
 	// Admin ("admin") is a role, not a business ID — all admin's CLI data
@@ -1027,6 +1028,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, method string,
 		return nil, nil
 
 	case "get_channel_config":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("access denied")
+		}
 		cfgs, err := backend.GetChannelConfigs()
 		if err != nil {
 			return nil, err
@@ -1046,6 +1050,34 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, method string,
 		}
 		if err := backend.SetChannelConfig(p.Channel, p.Values); err != nil {
 			return nil, err
+		}
+		// Dynamic channel start/stop: detect enabled flag change.
+		if enabledVal, ok := p.Values["enabled"]; ok {
+			if disp == nil || msgBus == nil {
+				return nil, nil // channels not yet initialized
+			}
+			enabled, _ := strconv.ParseBool(enabledVal)
+			_, alreadyRunning := disp.GetChannel(p.Channel)
+			if enabled && !alreadyRunning {
+				// Channel was disabled, now enabled — start it.
+				if ch := createChannelInstance(p.Channel, cfg, msgBus); ch != nil {
+					disp.Register(ch)
+					go func(n string, c channel.Channel) {
+						defer func() {
+							if r := recover(); r != nil {
+								log.WithFields(log.Fields{"channel": n, "panic": r}).Error("Dynamic channel start panicked\n" + string(debug.Stack()))
+							}
+						}()
+						log.WithField("channel", n).Info("Dynamically starting channel...")
+						if err := c.Start(); err != nil {
+							log.WithError(err).WithField("channel", n).Error("Dynamic channel failed")
+						}
+					}(ch.Name(), ch)
+				}
+			} else if !enabled && alreadyRunning {
+				// Channel was enabled, now disabled — stop it.
+				disp.Unregister(p.Channel)
+			}
 		}
 		return nil, nil
 
@@ -1241,10 +1273,7 @@ func buildWebCallbacks(cfg *config.Config, backend agent.AgentBackend, webDB *sq
 			return ws, nil
 		},
 	}
-	// Wire RPC handler for CLI RemoteBackend clients
-	callbacks.RPCHandler = func(method string, params json.RawMessage, senderID string) (json.RawMessage, error) {
-		return handleCLIRPC(cfg, backend, method, params, senderID)
-	}
+	// RPCHandler is wired in Run() after disp/msgBus are available.
 	// Wire IsProcessing — check if agent is actively processing a request for the user.
 	// In WebChannel, senderID == chatID.
 	callbacks.IsProcessing = func(senderID string) bool {
@@ -1358,6 +1387,36 @@ func resolveStaticDir(cfg *config.Config) string {
 		}
 	}
 	return ""
+}
+
+// createChannelInstance creates a channel instance by name using current config.
+// Returns nil for channels that require complex setup (e.g. web with DB/OSS).
+// Used for dynamic channel start/stop without server restart.
+func createChannelInstance(name string, cfg *config.Config, msgBus *bus.MessageBus) channel.Channel {
+	switch name {
+	case "feishu":
+		return channel.NewFeishuChannel(channel.FeishuConfig{
+			AppID:             cfg.Feishu.AppID,
+			AppSecret:         cfg.Feishu.AppSecret,
+			EncryptKey:        cfg.Feishu.EncryptKey,
+			VerificationToken: cfg.Feishu.VerificationToken,
+			AllowFrom:         cfg.Feishu.AllowFrom,
+		}, msgBus)
+	case "qq":
+		return channel.NewQQChannel(channel.QQConfig{
+			AppID:        cfg.QQ.AppID,
+			ClientSecret: cfg.QQ.ClientSecret,
+			AllowFrom:    cfg.QQ.AllowFrom,
+		}, msgBus)
+	case "napcat":
+		return channel.NewNapCatChannel(channel.NapCatConfig{
+			WSUrl:     cfg.NapCat.WSUrl,
+			Token:     cfg.NapCat.Token,
+			AllowFrom: cfg.NapCat.AllowFrom,
+		}, msgBus)
+	default:
+		return nil
+	}
 }
 
 // registerChannels creates and registers all channels.
@@ -1706,6 +1765,13 @@ func Run(args []string) error {
 	feishuCh, webCh, err := registerChannels(disp, cfg, msgBus, backend, webDB, workDir)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to register channels")
+	}
+
+	// Wire RPC handler for CLI RemoteBackend clients (after disp/msgBus are available).
+	if webCh != nil {
+		webCh.SetRPCHandler(func(method string, params json.RawMessage, senderID string) (json.RawMessage, error) {
+			return handleCLIRPC(cfg, backend, disp, msgBus, method, params, senderID)
+		})
 	}
 
 	// Register virtual CLI channel for remote mode (CLI→WS→server).
@@ -2413,14 +2479,24 @@ func migrateCLIUserSettingsFromGlobalIfNeeded(cfg *config.Config, backend agent.
 // Copying extra fields (Sandbox, CLI, Admin, Web, etc.) will overwrite user-set
 // values with in-memory defaults, which is exactly the class of bug this function prevents.
 func saveServerConfig(cfg *config.Config) error {
-	merged := config.LoadFromFile(config.ConfigFilePath())
+	path := config.ConfigFilePath()
+	merged := config.LoadFromFile(path)
 	if merged == nil {
-		merged = &config.Config{}
+		// Config file doesn't exist or has parse errors.
+		// Refuse to overwrite — writing an empty config would destroy
+		// all user settings (feishu, qq, web, etc.).
+		// Only create a new file if it truly doesn't exist.
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			merged = &config.Config{}
+		} else {
+			log.WithField("path", path).Error("saveServerConfig: config file exists but cannot parse, refusing to overwrite")
+			return fmt.Errorf("config file parse error, not overwriting")
+		}
 	}
 	// Server only ever modifies these two sections:
 	merged.LLM = cfg.LLM     // via applyRuntimeSetting / rebuildLLMFromSubscription
 	merged.Agent = cfg.Agent // via applyRuntimeSetting (max_iterations, max_concurrency, etc.)
-	return config.SaveToFile(config.ConfigFilePath(), merged)
+	return config.SaveToFile(path, merged)
 }
 
 // adminSenderID is the WS auth identity for admin users.

--- a/serverapp/server_test.go
+++ b/serverapp/server_test.go
@@ -71,7 +71,7 @@ func TestHandleCLIRPCAdminAddSubscription_ListRoundTrip(t *testing.T) {
 		BaseURL: "https://api.openai.com/v1", APIKey: "sk-test", Model: "gpt-4",
 	}
 	addParams, _ := json.Marshal(map[string]any{"sub": sub})
-	if _, err := handleCLIRPC(aCfg, lb, "add_subscription", addParams, "admin"); err != nil {
+	if _, err := handleCLIRPC(aCfg, lb, nil, nil, "add_subscription", addParams, "admin"); err != nil {
 		t.Fatalf("add_subscription: %v", err)
 	}
 
@@ -79,7 +79,7 @@ func TestHandleCLIRPCAdminAddSubscription_ListRoundTrip(t *testing.T) {
 	// Before fix: senderIDFromParams falls back to "admin" → empty list
 	// After fix: should return the subscription
 	listParams, _ := json.Marshal(map[string]string{"sender_id": ""})
-	raw, err := handleCLIRPC(aCfg, lb, "list_subscriptions", listParams, "admin")
+	raw, err := handleCLIRPC(aCfg, lb, nil, nil, "list_subscriptions", listParams, "admin")
 	if err != nil {
 		t.Fatalf("list_subscriptions: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestHandleCLIRPCSetDefaultSubscriptionRefreshesSenderCache(t *testing.T) {
 	}
 
 	params, _ := json.Marshal(map[string]string{"id": "sub-glm"})
-	if _, err := handleCLIRPC(aCfg, lb, "set_default_subscription", params, "admin"); err != nil {
+	if _, err := handleCLIRPC(aCfg, lb, nil, nil, "set_default_subscription", params, "admin"); err != nil {
 		t.Fatalf("handleCLIRPC set_default_subscription: %v", err)
 	}
 	_, model, _, _ = factory.GetLLM("cli_user")
@@ -349,7 +349,7 @@ func TestHandleCLIRPCSetDefaultSubscription_CrossIdentity(t *testing.T) {
 
 	// RPC call with WS auth "admin", no sender_id in params (matches real CLI behavior)
 	params, _ := json.Marshal(map[string]string{"id": "sub-glm"})
-	if _, err := handleCLIRPC(aCfg, lb, "set_default_subscription", params, "admin"); err != nil {
+	if _, err := handleCLIRPC(aCfg, lb, nil, nil, "set_default_subscription", params, "admin"); err != nil {
 		t.Fatalf("handleCLIRPC set_default_subscription: %v", err)
 	}
 	// The key assertion: GetLLM("cli_user") must see the new model

--- a/storage/sqlite/user_llm_subscription.go
+++ b/storage/sqlite/user_llm_subscription.go
@@ -74,6 +74,32 @@ func decryptAPIKey(sub *LLMSubscription, encryptedAPIKey string) {
 	}
 }
 
+// ListAll returns all subscriptions across all users, ordered by creation time.
+func (s *LLMSubscriptionService) ListAll() ([]*LLMSubscription, error) {
+	conn := s.db.Conn()
+	rows, err := conn.Query(`
+		SELECT id, sender_id, name, provider, base_url, api_key, model, is_default, max_context, max_output_tokens, thinking_mode, cached_models, created_at, updated_at
+			FROM user_llm_subscriptions
+			ORDER BY created_at ASC
+		`)
+	if err != nil {
+		return nil, fmt.Errorf("list all subscriptions: %w", err)
+	}
+	defer rows.Close()
+
+	var subs []*LLMSubscription
+	for rows.Next() {
+		sub := &LLMSubscription{}
+		encryptedAPIKey, _, err := scanSubscription(rows, sub)
+		if err != nil {
+			return nil, fmt.Errorf("scan subscription: %w", err)
+		}
+		decryptAPIKey(sub, encryptedAPIKey)
+		subs = append(subs, sub)
+	}
+	return subs, rows.Err()
+}
+
 // List returns all subscriptions for a user, ordered by creation time.
 func (s *LLMSubscriptionService) List(senderID string) ([]*LLMSubscription, error) {
 	conn := s.db.Conn()


### PR DESCRIPTION
## 问题

PR #498 将「最大上下文」和「最大输出 Token」从 `select_static` 改为 `input`。但飞书卡片 `input` 组件**必须嵌套在 `form` 容器内**，放在 `column_set` 里会导致飞书 SDK 静默拒绝整个卡片更新，使模型 tab 无响应。

## 修复

回退为 `select_static`，使用 k 单位预设值：
- 最大上下文：0, 1k, 2k, 4k, 8k, 16k, 32k, 64k, 128k, 256k, 512k, 1024k
- 最大输出 Token：0, 1k, 2k, 4k, 8k, 16k, 32k, 64k, 128k, 256k
- 始终包含当前已配置值作为选项
- 存储时 k×1000 转换