### PR TITLE
fix: group chat bugs, SubAgent CWD/send, TUI settings cleanup

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -52,6 +52,8 @@
 - **SubAgent remote mode: `convertWsProgressToCLI` must copy StreamContent/ReasoningStreamContent** from WsProgressPayload to CLIProgressPayload — otherwise stream content never reaches CLI.
 - **SubAgent remote mode: tick chain breakage** — `tickCmd()` injection must be unconditional (not gated on `!m.fastTickActive`) in splashDoneMsg, PhaseDone return, and history reload paths. Conditional injection causes chain to break during session switches.
 - **SubAgent session view: viewport freeze on return** — when main session's turn ended while viewing agent session, PhaseDone is detected on return but assistant reply is missing. Tick handler with `busy=false` must check `!m.renderCacheValid` as fallback.
+- **SubAgent CWD inheritance**: `parent_cwd` metadata must fallback to `parentCtx.WorkingDir` when `parentCtx.CurrentDir` is empty (parent never Cd'd). `buildParentToolContext` must also fallback to `workspaceRoot`. Otherwise SubAgent starts in `a.workDir` (config value) instead of the parent's actual working directory.
+- **Group chat members must be pre-spawned**: `CreateChat(type="group")` must auto-spawn each member agent and register AgentChannel in Dispatcher. Otherwise `@mentions` in SendMessage fail with "unknown channel: agent:role/instance".
 
 ### Windows
 - `syscall.PROCESS_QUERY_LIMITED_INFORMATION` and `STILL_ACTIVE` not in Go stdlib — define as uint32 constants.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1728,6 +1728,21 @@ func (a *Agent) processMessage(ctx context.Context, msg bus.InboundMessage) (*bu
 			systemNotes = append(systemNotes, fmt.Sprintf("Active interactive agents: %s", strings.Join(agentParts, ", ")))
 		}
 
+		// Active group chats
+		groups := tools.ListGroups()
+		if len(groups) > 0 {
+			var groupParts []string
+			for _, g := range groups {
+				status := "open"
+				if g.Closed {
+					status = "closed"
+				}
+				members := strings.Join(g.Members, ",")
+				groupParts = append(groupParts, fmt.Sprintf("%s(%s, %d members: %s)", g.Name, status, len(g.Members), members))
+			}
+			systemNotes = append(systemNotes, fmt.Sprintf("Groups: %s", strings.Join(groupParts, "; ")))
+		}
+
 		if len(systemNotes) > 0 {
 			info := "\n[System] " + strings.Join(systemNotes, " | ")
 			// Append to a copy of the last user message to avoid mutating session data

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -54,19 +54,21 @@ type RunConfig struct {
 	FeishuUserID string // 非空表示通过飞书身份登录 web（用于 runner 路由）
 
 	// === 工作区 & 沙箱 ===
-	WorkingDir       string   // Agent 工作目录（宿主机）
-	WorkspaceRoot    string   // 用户可读写工作区根目录（宿主机路径）
-	ReadOnlyRoots    []string // 额外只读目录
-	SkillsDirs       []string // 全局 skill 目录列表
-	AgentsDir        string
-	MCPConfigPath    string        // 用户 MCP 配置路径
-	GlobalMCPConfig  string        // 全局 MCP 配置路径（只读）
-	DataDir          string        // 数据持久化目录
-	SandboxEnabled   bool          // 是否启用命令沙箱
-	PreferredSandbox string        // 沙箱类型（docker 优先）
-	Sandbox          tools.Sandbox // Sandbox 实例引用（V4 新增）
-	SandboxMode      string        // 实际沙箱模式："none", "docker", "remote"
-	InitialCWD       string        // 初始当前工作目录（宿主机路径，用于 SubAgent 继承父 Agent 的 CWD）
+	WorkingDir          string   // Agent 工作目录（宿主机）
+	WorkspaceRoot       string   // 用户可读写工作区根目录（宿主机路径）
+	ReadOnlyRoots       []string // 额外只读目录
+	SkillsDirs          []string // 全局 skill 目录列表
+	AgentsDir           string
+	MCPConfigPath       string        // 用户 MCP 配置路径
+	GlobalMCPConfig     string        // 全局 MCP 配置路径（只读）
+	DataDir             string        // 数据持久化目录
+	SandboxEnabled      bool          // 是否启用命令沙箱
+	PreferredSandbox    string        // 沙箱类型（docker 优先）
+	Sandbox             tools.Sandbox // Sandbox 实例引用（V4 新增）
+	SandboxMode         string        // 实际沙箱模式："none", "docker", "remote"
+	InitialCWD          string        // 初始当前工作目录（宿主机路径，用于 SubAgent 继承父 Agent 的 CWD）
+	InitialGroupID      string        // 群组 ID（SubAgent 继承，用于 SendMessage 跨群校验）
+	InitialGroupMembers []string      // 群组成员列表（用于 system prompt 注入）
 
 	// === 循环控制 ===
 	MaxIterations   int // 0 = 使用默认值 100
@@ -625,6 +627,17 @@ func (a *spawnAgentAdapter) buildMsg(parentCtx *tools.ToolContext, task, roleNam
 		if bg, ok := parentCtx.Metadata["background"]; ok {
 			metadata["background"] = bg
 		}
+		if gid, ok := parentCtx.Metadata["group_id"]; ok {
+			metadata["group_id"] = gid
+		}
+		if gms, ok := parentCtx.Metadata["group_members"]; ok {
+			metadata["group_members"] = gms
+		}
+	}
+	// Also propagate group from ToolContext fields (set by SpawnInteractive for group agents)
+	if parentCtx.GroupID != "" {
+		metadata["group_id"] = parentCtx.GroupID
+		metadata["group_members"] = strings.Join(parentCtx.GroupMembers, ",")
 	}
 	// Propagate model override from SubAgent role definition
 	if model != "" {
@@ -809,6 +822,10 @@ func buildToolContext(ctx context.Context, cfg *RunConfig) *tools.ToolContext {
 	// 注入 session cwd（PWD 工具优化）
 	if cfg.Session != nil {
 		tc.CurrentDir = cfg.Session.GetCurrentDir()
+		// Fallback: new session has empty CWD, use InitialCWD (inherited from parent).
+		if tc.CurrentDir == "" && cfg.InitialCWD != "" {
+			tc.CurrentDir = cfg.InitialCWD
+		}
 		tc.SetCurrentDir = func(dir string) {
 			cfg.Session.SetCurrentDir(dir)
 		}
@@ -829,6 +846,11 @@ func buildToolContext(ctx context.Context, cfg *RunConfig) *tools.ToolContext {
 		tc.SetCurrentDir = func(dir string) {
 			cfg.InitialCWD = dir
 		}
+	}
+	// Propagate group membership for cross-agent messaging
+	if cfg.InitialGroupID != "" {
+		tc.GroupID = cfg.InitialGroupID
+		tc.GroupMembers = cfg.InitialGroupMembers
 	}
 
 	return tc

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -630,9 +630,14 @@ func (a *spawnAgentAdapter) buildMsg(parentCtx *tools.ToolContext, task, roleNam
 	if model != "" {
 		metadata["model"] = model
 	}
-	// Propagate parent's CWD so SubAgent inherits working directory
-	if parentCtx.CurrentDir != "" {
-		metadata["parent_cwd"] = parentCtx.CurrentDir
+	// Propagate parent's CWD so SubAgent inherits working directory.
+	// If CurrentDir is empty (parent never Cd'd), fall back to WorkingDir.
+	parentCWD := parentCtx.CurrentDir
+	if parentCWD == "" {
+		parentCWD = parentCtx.WorkingDir
+	}
+	if parentCWD != "" {
+		metadata["parent_cwd"] = parentCWD
 	}
 
 	return bus.InboundMessage{

--- a/agent/engine_wire.go
+++ b/agent/engine_wire.go
@@ -647,6 +647,11 @@ func (a *Agent) buildSubAgentRunConfig(
 ) RunConfig {
 	parentAgentID := parentCtx.AgentID
 
+	// Interactive SubAgent 默认拥有 send_message 能力（群聊/agent 间通信必需）
+	if interactive {
+		caps.SendMessage = true
+	}
+
 	if systemPrompt == "" {
 		systemPrompt = "You are a helpful assistant. Complete the given task using the available tools."
 	}
@@ -661,6 +666,7 @@ func (a *Agent) buildSubAgentRunConfig(
 	// 以下工具永久可用，不受白名单限制：
 	//   - SubAgent（如果 caps.SpawnAgent=true）
 	//   - offload_recall、recall_masked（SubAgent 需要访问父 Agent 的 offload/mask 数据）
+	//   - SendMessage、CreateChat（interactive SubAgent 群聊/agent 间通信必需）
 	if len(allowedTools) > 0 {
 		allowed := make(map[string]bool, len(allowedTools))
 		for _, name := range allowedTools {
@@ -674,6 +680,10 @@ func (a *Agent) buildSubAgentRunConfig(
 			}
 			// offload_recall / recall_masked：SubAgent 始终可用
 			if toolName == "offload_recall" || toolName == "recall_masked" {
+				continue
+			}
+			// SendMessage / CreateChat：interactive SubAgent 始终可用（群聊通信）
+			if interactive && (toolName == "SendMessage" || toolName == "CreateChat") {
 				continue
 			}
 			if !allowed[toolName] {
@@ -720,6 +730,20 @@ func (a *Agent) buildSubAgentRunConfig(
 		sysPrompt += subagentExecutionModeOneShot
 	}
 	sysPrompt += "\n## 角色描述\n\n" + rolePrompt + "\n"
+
+	// 注入群组信息（当前 agent 是某个虚拟群组的成员）
+	if parentCtx.GroupID != "" && len(parentCtx.GroupMembers) > 0 {
+		sysPrompt += "\n## 群组协作\n\n"
+		sysPrompt += fmt.Sprintf("你是虚拟群组 **%s** 的成员。群组成员：\n", parentCtx.GroupID)
+		for _, m := range parentCtx.GroupMembers {
+			sysPrompt += fmt.Sprintf("- %s\n", m)
+		}
+		sysPrompt += "\n你可以使用 **SendMessage** 工具直接向群组中的其他成员发送消息：\n"
+		sysPrompt += "- `SendMessage(to=\"agent:角色/实例\", message=\"...\")` → 直接发送消息给该成员\n"
+		sysPrompt += "- `SendMessage(to=\"" + parentCtx.GroupID + "\", message=\"...\")` → 广播发给所有成员\n"
+		sysPrompt += "- `SendMessage(to=\"" + parentCtx.GroupID + "\", message=\"@agent:角色/实例 ...\")` → @提及特定成员\n"
+		sysPrompt += "\n**注意**：你只能向同组成员发消息，不能跨群组通信。群组通信是直接的——消息会进入对方的 session，他们能看到完整的上下文并自行判断如何回应。\n"
+	}
 
 	// 注入可用 agent 目录（只在 spawn_agent=true 时注入）
 	if caps.SpawnAgent {
@@ -831,6 +855,8 @@ func (a *Agent) buildSubAgentRunConfig(
 			}
 			return a.workDir
 		}(),
+		InitialGroupID:      parentCtx.GroupID,
+		InitialGroupMembers: parentCtx.GroupMembers,
 
 		MaxIterations: a.getMaxIterations(), // 继承主 Agent 配置
 		// SubAgent 不设独立超时，直接使用父 context 携带的 deadline

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -1167,6 +1167,11 @@ func (a *Agent) buildParentToolContext(ctx context.Context, channel, chatID, sen
 			tc.CurrentDir = cwd
 		}
 	}
+	// Fallback: if parent never Cd'd, use workspaceRoot as initial CWD
+	// so SubAgent starts in the same directory as the parent agent.
+	if tc.CurrentDir == "" && workspaceRoot != "" {
+		tc.CurrentDir = workspaceRoot
+	}
 	return tc
 }
 

--- a/agent/interactive.go
+++ b/agent/interactive.go
@@ -33,6 +33,7 @@ type bgParentKey struct{}
 type interactiveAgent struct {
 	roleName         string              // 角色名
 	instance         string              // instance ID
+	groupID          string              // 所属群聊 ID（如 "group:g1"，空=不属于群聊）
 	messages         []llm.ChatMessage   // 累积的对话历史（不含 system prompt）
 	iterationHistory []IterationSnapshot // 最近迭代快照，供 inspect/tail 使用
 	mu               sync.Mutex          // 保护会话状态并发访问
@@ -244,6 +245,15 @@ func (a *Agent) wireSubAgentCLIProgress(key, originChatID string, cfg *RunConfig
 // interactiveSubAgents entry, progress snapshot/iteration history, and tenant session (DB).
 // This ensures the next SubAgent with the same role/instance starts with a clean slate.
 func (a *Agent) destroyInteractiveSession(key string) {
+	// Auto-cleanup group membership: remove this agent from its group,
+	// delete the group if no members remain.
+	if val, ok := a.interactiveSubAgents.Load(key); ok {
+		if ia, ok := val.(*interactiveAgent); ok && ia != nil && ia.groupID != "" {
+			memberAddr := "agent:" + ia.roleName + "/" + ia.instance
+			tools.RemoveMember(ia.groupID, memberAddr)
+		}
+	}
+
 	a.interactiveSubAgents.Delete(key)
 
 	// Clean up progress snapshot and iteration history
@@ -293,6 +303,12 @@ func (a *Agent) SpawnInteractiveSession(
 
 	// 原子 check-and-store：如果 key 已存在，直接返回
 	placeholder := &interactiveAgent{roleName: roleName, instance: instance, lastUsed: time.Now(), background: background}
+	// Track group membership for auto-cleanup on unload
+	if msg.Metadata != nil {
+		if gid, ok := msg.Metadata["group_id"]; ok && gid != "" {
+			placeholder.groupID = gid
+		}
+	}
 	// Track parent session for cascade cleanup
 	if parentKey, ok := ctx.Value(bgParentKey{}).(string); ok {
 		placeholder.parentKey = parentKey
@@ -1165,6 +1181,13 @@ func (a *Agent) buildParentToolContext(ctx context.Context, channel, chatID, sen
 	if msg.Metadata != nil {
 		if cwd, ok := msg.Metadata["parent_cwd"]; ok && cwd != "" {
 			tc.CurrentDir = cwd
+		}
+		// Restore group membership for cross-agent messaging
+		if gid, ok := msg.Metadata["group_id"]; ok && gid != "" {
+			tc.GroupID = gid
+			if gms, ok := msg.Metadata["group_members"]; ok && gms != "" {
+				tc.GroupMembers = strings.Split(gms, ",")
+			}
 		}
 	}
 	// Fallback: if parent never Cd'd, use workspaceRoot as initial CWD

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -82,10 +82,6 @@ var cliActionSettingKeys = map[string]struct{}{
 }
 
 var cliSubscriptionScopedSettingKeys = map[string]struct{}{
-	"llm_provider":      {},
-	"llm_api_key":       {},
-	"llm_model":         {},
-	"llm_base_url":      {},
 	"max_output_tokens": {},
 	"thinking_mode":     {},
 }
@@ -137,17 +133,11 @@ func (m *cliModel) mergeCLISettingsValues() map[string]string {
 			values[k] = v
 		}
 	}
-	// LLM fields come exclusively from the active subscription (single source of truth).
-	// This replaces the old path where LLM values came from GetCurrentValues / user_settings.
+	// Subscription-scoped settings (max_output_tokens, thinking_mode) from active subscription.
 	if m.channel.subscriptionMgr != nil {
 		if sub, err := m.channel.subscriptionMgr.GetDefault(m.senderID); err == nil && sub != nil {
-			values["llm_provider"] = sub.Provider
-			values["llm_base_url"] = sub.BaseURL
-			values["llm_model"] = sub.Model
 			values["max_output_tokens"] = strconv.Itoa(sub.MaxOutputTokens)
 			values["thinking_mode"] = sub.ThinkingMode
-			// Don't overwrite api_key if GetCurrentValues already set it
-			// ( GetCurrentValues may have the unmasked key from backend)
 		}
 	}
 	// User-scoped settings (theme, language, context_mode, etc.) override GetCurrentValues
@@ -240,7 +230,7 @@ func (m *cliModel) openSettingsFromQuickSwitch() {
 	if m.channel.modelLister != nil {
 		allModels := m.channel.modelLister.ListAllModels()
 		for i, s := range schema {
-			if (s.Key == "llm_model" || s.Key == "vanguard_model" || s.Key == "balance_model" || s.Key == "swift_model") && len(allModels) > 0 {
+			if (s.Key == "vanguard_model" || s.Key == "balance_model" || s.Key == "swift_model") && len(allModels) > 0 {
 				opts := make([]SettingOption, len(allModels))
 				for j, ml := range allModels {
 					opts[j] = SettingOption{Label: ml, Value: ml}

--- a/channel/cli_helpers_test.go
+++ b/channel/cli_helpers_test.go
@@ -21,8 +21,8 @@ func TestCLISettingScope_KnownKeys(t *testing.T) {
 		"theme":               "user",
 		"language":            "user",
 		"runner_server":       "user",
-		"llm_provider":        "subscription",
-		"llm_model":           "subscription",
+		"max_output_tokens":   "subscription",
+		"thinking_mode":       "subscription",
 		"default_user":        "global",
 		"privileged_user":     "global",
 		"subscription_manage": "action",
@@ -55,7 +55,7 @@ func TestCLISettingScope_SettingsSchemaKeysAreClassified(t *testing.T) {
 }
 
 func TestIsSubscriptionScopedSettingKey(t *testing.T) {
-	for _, key := range []string{"llm_provider", "llm_api_key", "llm_model", "llm_base_url"} {
+	for _, key := range []string{"max_output_tokens", "thinking_mode"} {
 		if !isSubscriptionScopedSettingKey(key) {
 			t.Fatalf("expected %q to be subscription-scoped", key)
 		}
@@ -71,17 +71,15 @@ func TestOpenSettingsFromQuickSwitch_PreservesNonSubscriptionEdits(t *testing.T)
 	model := newCLIModel()
 	model.channel = &CLIChannel{}
 	model.panelValuesBackup = map[string]string{
-		"theme":        "mono",
-		"language":     "en",
-		"llm_provider": "should-refresh",
+		"theme":    "mono",
+		"language": "en",
 	}
-	model.panelCursorBackup = 2
+	model.panelCursorBackup = 1
 	model.panelOnSubmitBackup = func(map[string]string) {}
 	model.channel.config.GetCurrentValues = func() map[string]string {
 		return map[string]string{
-			"theme":        "midnight",
-			"language":     "zh",
-			"llm_provider": "openai",
+			"theme":    "midnight",
+			"language": "zh",
 		}
 	}
 	model.openSettingsFromQuickSwitch()
@@ -93,9 +91,6 @@ func TestOpenSettingsFromQuickSwitch_PreservesNonSubscriptionEdits(t *testing.T)
 	}
 	if got := model.panelValues["language"]; got != "en" {
 		t.Fatalf("language = %q, want en", got)
-	}
-	if got := model.panelValues["llm_provider"]; got != "openai" {
-		t.Fatalf("llm_provider = %q, want openai", got)
 	}
 }
 
@@ -982,7 +977,8 @@ func TestCLISettingScopeClassification(t *testing.T) {
 	}{
 		{key: "theme", scope: "user"},
 		{key: "runner_token", scope: "user"},
-		{key: "llm_model", scope: "subscription"},
+		{key: "max_output_tokens", scope: "subscription"},
+		{key: "thinking_mode", scope: "subscription"},
 		{key: "enable_stream", scope: "global"},
 		{key: "subscription_manage", scope: "action"},
 	}
@@ -995,13 +991,13 @@ func TestCLISettingScopeClassification(t *testing.T) {
 
 func TestMergeCLISettingsValues_OverlaysUserScopedOnly(t *testing.T) {
 	cfgVals := map[string]string{
-		"theme":     "midnight",
-		"llm_model": "gpt-4.1",
+		"theme":             "midnight",
+		"max_output_tokens": "8192",
 	}
 	settingsSvc := &testSettingsService{getResult: map[string]string{
-		"theme":         "mono",
-		"llm_model":     "claude-3-7",
-		"runner_server": "https://runner.example",
+		"theme":             "mono",
+		"max_output_tokens": "4096",
+		"runner_server":     "https://runner.example",
 	}}
 	model := newCLIModel()
 	model.channelName = "cli"
@@ -1013,8 +1009,8 @@ func TestMergeCLISettingsValues_OverlaysUserScopedOnly(t *testing.T) {
 	if got := merged["theme"]; got != "mono" {
 		t.Fatalf("theme = %q, want mono", got)
 	}
-	if got := merged["llm_model"]; got != "gpt-4.1" {
-		t.Fatalf("llm_model = %q, want config value gpt-4.1", got)
+	if got := merged["max_output_tokens"]; got != "8192" {
+		t.Fatalf("max_output_tokens = %q, want config value 8192", got)
 	}
 	if got := merged["runner_server"]; got != "https://runner.example" {
 		t.Fatalf("runner_server = %q, want settings value", got)
@@ -1035,9 +1031,9 @@ func TestPersistCLISettingsValues_PersistsUserScopedAndAppliesAll(t *testing.T) 
 	}
 
 	input := map[string]string{
-		"theme":            "mono",
-		"runner_workspace": "/tmp/ws",
-		"llm_model":        "gpt-4.1",
+		"theme":             "mono",
+		"runner_workspace":  "/tmp/ws",
+		"max_output_tokens": "4096",
 	}
 	model.persistCLISettingsValues(input)
 
@@ -1052,7 +1048,7 @@ func TestPersistCLISettingsValues_PersistsUserScopedAndAppliesAll(t *testing.T) 
 			t.Fatalf("unexpected target: channel=%q sender=%q", call.channelName, call.senderID)
 		}
 	}
-	if applied["llm_model"] != "gpt-4.1" || applied["theme"] != "mono" || applied["runner_workspace"] != "/tmp/ws" {
+	if applied["max_output_tokens"] != "4096" || applied["theme"] != "mono" || applied["runner_workspace"] != "/tmp/ws" {
 		t.Fatalf("ApplySettings did not receive full input: %#v", applied)
 	}
 }

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -372,14 +372,11 @@ func (m *cliModel) handleSlashCommand(cmd string) tea.Cmd {
 				// Get current values: config is the single source of truth for LLM settings.
 				// Only overlay non-LLM settings from SettingsService (e.g. theme, language).
 				currentValues := m.mergeCLISettingsValues()
-				// Inject model list into combo options
-				// ALL model dropdowns (llm_model + tiers) use ListAllModels() which includes
-				// default LLM models + all subscription Model fields, so newly added
-				// subscriptions are always visible without restart.
+				// Inject model list into combo options for tier model selectors.
 				if m.channel.modelLister != nil {
 					allModels := m.channel.modelLister.ListAllModels()
 					for i, s := range schema {
-						if (s.Key == "llm_model" || s.Key == "vanguard_model" || s.Key == "balance_model" || s.Key == "swift_model") && len(allModels) > 0 {
+						if (s.Key == "vanguard_model" || s.Key == "balance_model" || s.Key == "swift_model") && len(allModels) > 0 {
 							opts := make([]SettingOption, len(allModels))
 							for j, ml := range allModels {
 								opts[j] = SettingOption{Label: ml, Value: ml}

--- a/channel/cli_model.go
+++ b/channel/cli_model.go
@@ -809,9 +809,11 @@ func (m *cliModel) refreshCachedModelName() {
 	if m.channel == nil {
 		return
 	}
-	// Single source of truth: read from cfg.LLM.Model (derived from active subscription)
-	if m.channel.config.GetCurrentValues != nil {
-		m.cachedModelName = m.channel.config.GetCurrentValues()["llm_model"]
+	// Single source of truth: read from active subscription (not from settings values)
+	if m.channel.subscriptionMgr != nil {
+		if sub, err := m.channel.subscriptionMgr.GetDefault(m.senderID); err == nil && sub != nil {
+			m.cachedModelName = sub.Model
+		}
 	}
 	// Cache model count for View() (avoids ListAllModels RPC per frame)
 	if m.channel.modelLister != nil {

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -55,24 +55,9 @@ func (m *cliModel) openSettingsPanel(schema []SettingDefinition, values map[stri
 		if _, ok := m.panelValues[def.Key]; !ok && def.DefaultValue != "" {
 			m.panelValues[def.Key] = def.DefaultValue
 		}
-		// Inject model list as combo options for llm_model.
-		// Use ListAllModels so models from ALL subscriptions are visible,
-		// not just the current default LLM. This allows the user to switch
-		// to a model on a different subscription (e.g. glm-5.1) directly.
-		if def.Key == "llm_model" && m.channel.modelLister != nil && len(def.Options) == 0 {
-			models := m.channel.modelLister.ListAllModels()
-			if len(models) > 0 {
-				opts := make([]SettingOption, len(models))
-				for j, mdl := range models {
-					opts[j] = SettingOption{Label: mdl, Value: mdl}
-				}
-				def.Options = opts
-				def.Type = SettingTypeCombo
-			}
-		}
 		// Inject cross-subscription model list for tier model selectors.
 		if (def.Key == "vanguard_model" || def.Key == "balance_model" || def.Key == "swift_model") && m.channel.modelLister != nil && len(def.Options) == 0 {
-			models := m.channel.modelLister.ListAllModels()
+			models := m.channel.modelLister.ListModels()
 			if len(models) > 0 {
 				opts := make([]SettingOption, len(models))
 				for j, mdl := range models {
@@ -2295,13 +2280,13 @@ func (m *cliModel) editQuickSwitchEntry() {
 	editSchema := []SettingDefinition{
 		{Key: "sub_name", Label: "Name", Description: "Display name for this subscription", Type: SettingTypeText, DefaultValue: target.Name},
 		{Key: "sub_provider", Label: "Provider", Description: "LLM provider (openai, anthropic, deepseek, etc.)", Type: SettingTypeText, DefaultValue: target.Provider},
-		{Key: "sub_model", Label: "Model", Description: "Model name", Type: SettingTypeText, DefaultValue: target.Model},
+		{Key: "sub_model", Label: "Model", Description: "Model name", Type: SettingTypeCombo, DefaultValue: target.Model},
 		{Key: "sub_base_url", Label: "Base URL", Description: "API base URL (leave empty for provider default)", Type: SettingTypeText, DefaultValue: target.BaseURL},
 		{Key: "sub_api_key", Label: "API Key", Description: "API key (leave empty to use global key)", Type: SettingTypePassword, DefaultValue: target.APIKey},
 	}
 	// Inject model list into combo for model field
 	if m.channel.modelLister != nil {
-		models := m.channel.modelLister.ListModels()
+		models := m.channel.modelLister.ListAllModels()
 		if len(models) > 0 {
 			opts := make([]SettingOption, len(models))
 			for j, mdl := range models {

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -1038,6 +1038,8 @@ func (m *cliModel) viewSessionsDetail() string {
 			title = "👤 " + entry.Label
 		case "agent":
 			title = fmt.Sprintf("🤖 %s/%s", entry.Role, entry.Instance)
+		case "group":
+			title = "💬 " + entry.Label
 		}
 	}
 	help := s.PanelDesc.Render("Esc Back")

--- a/channel/cli_panel_test.go
+++ b/channel/cli_panel_test.go
@@ -85,7 +85,7 @@ func TestApplyQuickSwitch(t *testing.T) {
 				return nil
 			},
 			GetCurrentValues: func() map[string]string {
-				return map[string]string{"llm_model": "glm-4"}
+				return map[string]string{"theme": "midnight"}
 			},
 		},
 	}
@@ -198,9 +198,9 @@ func TestPanelBoxLeftAlign(t *testing.T) {
 	t.Error("could not find 'Name:' in panel output")
 }
 
-// TestSubscriptionGenerationGuard tests that stale per-subscription LLM values
-// are NEVER written back after a subscription switch. This is the structural guarantee
-// against the subscription overwrite bug.
+// TestSubscriptionGenerationGuard tests that stale per-subscription values
+// (max_output_tokens, thinking_mode) are NEVER written back after a subscription switch.
+// This is the structural guarantee against the subscription overwrite bug.
 func TestSubscriptionGenerationGuard(t *testing.T) {
 	model := newCLIModel()
 	model.subGeneration = 5
@@ -210,30 +210,27 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 
 	// Simulate: user edits some values
 	values := map[string]string{
-		"llm_provider":   "openai",
-		"llm_api_key":    "old-key-123",
-		"llm_model":      "gpt-4o",
-		"llm_base_url":   "https://api.openai.com/v1",
-		"vanguard_model": "claude-opus-4",
-		"balance_model":  "claude-sonnet-4",
-		"max_tokens":     "4096",
+		"max_output_tokens": "8192",
+		"thinking_mode":     "auto",
+		"vanguard_model":    "claude-opus-4",
+		"balance_model":     "claude-sonnet-4",
 	}
 
 	// Simulate: subscription switch happens (generation increments)
 	model.subGeneration = 6
 
 	// Simulate: the onSubmit callback runs (this is what the guard checks)
-	// After switch, stale LLM fields should be stripped
+	// After switch, stale subscription-scoped fields should be stripped
 	if model.panelSubGeneration != model.subGeneration {
-		for _, k := range []string{"llm_provider", "llm_model", "llm_base_url", "llm_api_key"} {
+		for _, k := range []string{"max_output_tokens", "thinking_mode"} {
 			delete(values, k)
 		}
 	}
 
-	// Verify: per-subscription LLM fields are GONE
-	for _, k := range []string{"llm_provider", "llm_api_key", "llm_model", "llm_base_url"} {
+	// Verify: per-subscription fields are GONE
+	for _, k := range []string{"max_output_tokens", "thinking_mode"} {
 		if _, exists := values[k]; exists {
-			t.Errorf("BUG: stale LLM field %q should have been deleted after subscription switch", k)
+			t.Errorf("BUG: stale subscription field %q should have been deleted after subscription switch", k)
 		}
 	}
 
@@ -244,36 +241,31 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 	if values["balance_model"] != "claude-sonnet-4" {
 		t.Errorf("global setting balance_model should be preserved, got %q", values["balance_model"])
 	}
-	if values["max_tokens"] != "4096" {
-		t.Errorf("global setting max_tokens should be preserved, got %q", values["max_tokens"])
-	}
 }
 
 // TestSubscriptionGenerationGuardNoSwitch tests that when subscription does NOT change,
-// all LLM fields are preserved (no false positives).
+// all subscription-scoped fields are preserved (no false positives).
 func TestSubscriptionGenerationGuardNoSwitch(t *testing.T) {
 	model := newCLIModel()
 	model.subGeneration = 5
 	model.panelSubGeneration = 5 // same generation = no switch
 
 	values := map[string]string{
-		"llm_provider": "anthropic",
-		"llm_api_key":  "key-456",
-		"llm_model":    "claude-sonnet-4",
-		"llm_base_url": "https://api.anthropic.com",
+		"max_output_tokens": "8192",
+		"thinking_mode":     "auto",
 	}
 
 	// Guard should NOT strip anything
 	if model.panelSubGeneration != model.subGeneration {
-		for _, k := range []string{"llm_provider", "llm_model", "llm_base_url", "llm_api_key"} {
+		for _, k := range []string{"max_output_tokens", "thinking_mode"} {
 			delete(values, k)
 		}
 	}
 
 	// All fields should still be present
-	for _, k := range []string{"llm_provider", "llm_api_key", "llm_model", "llm_base_url"} {
+	for _, k := range []string{"max_output_tokens", "thinking_mode"} {
 		if _, exists := values[k]; !exists {
-			t.Errorf("LLM field %q should NOT be deleted when subscription hasn't changed", k)
+			t.Errorf("subscription field %q should NOT be deleted when subscription hasn't changed", k)
 		}
 	}
 }

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -390,26 +390,7 @@ func localeZH() *UILocale {
 
 		// --- J. Settings schema ---
 		SetupSchema: []SettingDefinition{
-			{
-				Key: "llm_provider", Label: "LLM 提供商", Description: "选择 LLM 服务提供商",
-				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
-				Options: []SettingOption{
-					{Label: "OpenAI (及兼容 API)", Value: "openai"},
-					{Label: "Anthropic (Claude)", Value: "anthropic"},
-				},
-			},
-			{
-				Key: "llm_api_key", Label: "API Key", Description: "LLM 服务的 API Key（必填）",
-				Type: SettingTypePassword, Category: "LLM",
-			},
-			{
-				Key: "llm_base_url", Label: "Base URL", Description: "LLM API 地址",
-				Type: SettingTypeText, Category: "LLM", DefaultValue: "https://api.openai.com/v1",
-			},
-			{
-				Key: "llm_model", Label: "模型名称", Description: "选择或输入 LLM 模型名称",
-				Type: SettingTypeText, Category: "LLM", DefaultValue: "gpt-4o",
-			},
+
 			{
 				Key: "tavily_api_key", Label: "Tavily API Key", Description: "网络搜索服务密钥（可选，留空则无法使用 WebSearch）",
 				Type: SettingTypePassword, Category: "LLM",
@@ -447,26 +428,7 @@ func localeZH() *UILocale {
 			},
 		},
 		SettingsSchema: []SettingDefinition{
-			{
-				Key: "llm_provider", Label: "LLM 提供商", Description: "选择 LLM 服务提供商",
-				Type: SettingTypeSelect, Category: "LLM",
-				Options: []SettingOption{
-					{Label: "OpenAI (及兼容 API)", Value: "openai"},
-					{Label: "Anthropic (Claude)", Value: "anthropic"},
-				},
-			},
-			{
-				Key: "llm_api_key", Label: "API Key", Description: "LLM 服务的 API Key",
-				Type: SettingTypePassword, Category: "LLM",
-			},
-			{
-				Key: "llm_model", Label: "LLM 模型", Description: "选择或输入 LLM 模型名称",
-				Type: SettingTypeCombo, Category: "LLM",
-			},
-			{
-				Key: "llm_base_url", Label: "LLM Base URL", Description: "LLM API 地址（兼容 OpenAI 格式的第三方服务可修改此项）",
-				Type: SettingTypeText, Category: "LLM",
-			},
+
 			{
 				Key: "vanguard_model", Label: "Vanguard 模型", Description: "SubAgent 的高强度模型等级映射",
 				Type: SettingTypeCombo, Category: "LLM",
@@ -777,26 +739,7 @@ func localeEN() *UILocale {
 
 		// --- J. Settings schema ---
 		SetupSchema: []SettingDefinition{
-			{
-				Key: "llm_provider", Label: "LLM Provider", Description: "Select LLM service provider",
-				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
-				Options: []SettingOption{
-					{Label: "OpenAI (and compatible API)", Value: "openai"},
-					{Label: "Anthropic (Claude)", Value: "anthropic"},
-				},
-			},
-			{
-				Key: "llm_api_key", Label: "API Key", Description: "API key for LLM service (required)",
-				Type: SettingTypePassword, Category: "LLM",
-			},
-			{
-				Key: "llm_base_url", Label: "Base URL", Description: "LLM API endpoint",
-				Type: SettingTypeText, Category: "LLM", DefaultValue: "https://api.openai.com/v1",
-			},
-			{
-				Key: "llm_model", Label: "Model Name", Description: "Select or enter LLM model name",
-				Type: SettingTypeText, Category: "LLM", DefaultValue: "gpt-4o",
-			},
+
 			{
 				Key: "tavily_api_key", Label: "Tavily API Key", Description: "Web search service key (optional, leave empty to disable WebSearch)",
 				Type: SettingTypePassword, Category: "LLM",
@@ -834,26 +777,7 @@ func localeEN() *UILocale {
 			},
 		},
 		SettingsSchema: []SettingDefinition{
-			{
-				Key: "llm_provider", Label: "LLM Provider", Description: "Select LLM service provider",
-				Type: SettingTypeSelect, Category: "LLM",
-				Options: []SettingOption{
-					{Label: "OpenAI (and compatible API)", Value: "openai"},
-					{Label: "Anthropic (Claude)", Value: "anthropic"},
-				},
-			},
-			{
-				Key: "llm_api_key", Label: "API Key", Description: "LLM service API Key",
-				Type: SettingTypePassword, Category: "LLM",
-			},
-			{
-				Key: "llm_model", Label: "LLM Model", Description: "Select or enter LLM model name",
-				Type: SettingTypeCombo, Category: "LLM",
-			},
-			{
-				Key: "llm_base_url", Label: "LLM Base URL", Description: "LLM API endpoint (modify for OpenAI-compatible third-party services)",
-				Type: SettingTypeText, Category: "LLM",
-			},
+
 			{
 				Key: "vanguard_model", Label: "Vanguard Model", Description: "SubAgent tier mapping for high-power tasks",
 				Type: SettingTypeCombo, Category: "LLM",
@@ -1164,26 +1088,7 @@ func localeJA() *UILocale {
 
 		// --- J. Settings schema ---
 		SetupSchema: []SettingDefinition{
-			{
-				Key: "llm_provider", Label: "LLM プロバイダー", Description: "LLM サービスプロバイダーを選択",
-				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
-				Options: []SettingOption{
-					{Label: "OpenAI (および互換API)", Value: "openai"},
-					{Label: "Anthropic (Claude)", Value: "anthropic"},
-				},
-			},
-			{
-				Key: "llm_api_key", Label: "API Key", Description: "LLM サービスの API Key（必須）",
-				Type: SettingTypePassword, Category: "LLM",
-			},
-			{
-				Key: "llm_base_url", Label: "Base URL", Description: "LLM API エンドポイント",
-				Type: SettingTypeText, Category: "LLM", DefaultValue: "https://api.openai.com/v1",
-			},
-			{
-				Key: "llm_model", Label: "モデル名", Description: "LLM モデル名を選択または入力",
-				Type: SettingTypeText, Category: "LLM", DefaultValue: "gpt-4o",
-			},
+
 			{
 				Key: "tavily_api_key", Label: "Tavily API Key", Description: "Web検索サービスキー（オプション、空の場合 WebSearch は無効）",
 				Type: SettingTypePassword, Category: "LLM",
@@ -1221,26 +1126,7 @@ func localeJA() *UILocale {
 			},
 		},
 		SettingsSchema: []SettingDefinition{
-			{
-				Key: "llm_provider", Label: "LLM プロバイダー", Description: "LLM サービスプロバイダーを選択",
-				Type: SettingTypeSelect, Category: "LLM",
-				Options: []SettingOption{
-					{Label: "OpenAI (および互換 API)", Value: "openai"},
-					{Label: "Anthropic (Claude)", Value: "anthropic"},
-				},
-			},
-			{
-				Key: "llm_api_key", Label: "API Key", Description: "LLM サービスの API Key",
-				Type: SettingTypePassword, Category: "LLM",
-			},
-			{
-				Key: "llm_model", Label: "LLM モデル", Description: "LLM モデル名を選択または入力",
-				Type: SettingTypeCombo, Category: "LLM",
-			},
-			{
-				Key: "llm_base_url", Label: "LLM Base URL", Description: "LLM API エンドポイント（OpenAI 互換のサードパーティサービス用に変更可）",
-				Type: SettingTypeText, Category: "LLM",
-			},
+
 			{
 				Key: "vanguard_model", Label: "Vanguard モデル", Description: "SubAgent の高強度タスク向けモデル階層マッピング",
 				Type: SettingTypeCombo, Category: "LLM",

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -125,8 +125,7 @@ func saveCLIConfig(cfg *config.Config) error {
 
 func isCLISubscriptionSettingKey(key string) bool {
 	switch key {
-	case "llm_provider", "llm_api_key", "llm_model", "llm_base_url",
-		"max_output_tokens", "thinking_mode":
+	case "max_output_tokens", "thinking_mode":
 		return true
 	default:
 		return false
@@ -791,29 +790,23 @@ func main() {
 			if app.backend == nil {
 				return
 			}
-			_, llmChanged := values["llm_provider"]
-			_, keyChanged := values["llm_api_key"]
-			_, modelChanged := values["llm_model"]
-			_, urlChanged := values["llm_base_url"]
 			_, vanguardChanged := values["vanguard_model"]
 			_, balanceChanged := values["balance_model"]
 			_, swiftChanged := values["swift_model"]
 			_, maxOutputChanged := values["max_output_tokens"]
 			_, thinkingChanged := values["thinking_mode"]
 
-			llmFieldChanged := llmChanged || keyChanged || modelChanged || urlChanged || maxOutputChanged || thinkingChanged
-
-			// ── LLM fields: update via subscription manager (single source of truth) ──
-			if llmFieldChanged {
+			// ── Subscription-scoped fields: update via subscription manager ──
+			if maxOutputChanged || thinkingChanged {
 				if err := updateActiveSubscription(app.backend, app.cfg, values); err != nil {
 					log.Warnf("Failed to update active subscription: %v", err)
 				}
 			}
 
-			// ── Non-LLM settings: persist and apply runtime ──
+			// ── Non-subscription settings: persist and apply runtime ──
 			for k, v := range values {
 				if isCLISubscriptionSettingKey(k) {
-					continue // LLM fields handled above
+					continue // subscription fields handled above
 				}
 				_ = app.backend.SetSetting("cli", "cli_user", k, v)
 			}
@@ -841,7 +834,7 @@ func main() {
 						_ = ss.SetSetting("cli", "cli_user", "theme", theme)
 					}
 				}
-				if llmFieldChanged || maxOutputChanged || thinkingChanged {
+				if maxOutputChanged || thinkingChanged {
 					if newClient, err := createLLM(app.cfg.LLM, llm.DefaultRetryConfig()); err == nil {
 						app.llmClient = newClient
 						app.backend.LLMFactory().SetDefaults(newClient, app.cfg.LLM.Model)
@@ -1068,18 +1061,16 @@ func main() {
 				}
 			}
 			// Append group chats
-			for _, g := range tools.ListGroupSummaries() {
+			for _, g := range tools.ListGroups() {
 				status := ""
 				if g.Closed {
 					status = " [closed]"
-				} else {
-					status = fmt.Sprintf(" [round %d/%d]", g.Round, g.MaxRounds)
 				}
 				entries = append(entries, channel.SessionPanelEntry{
 					ID:          g.Name,
 					Type:        "group",
 					Label:       "💬 " + g.Name + status,
-					MessageHint: fmt.Sprintf("%d members, %d messages", len(g.Members), g.MsgCount),
+					MessageHint: fmt.Sprintf("%d members", len(g.Members)),
 				})
 			}
 			return entries

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -1067,6 +1067,21 @@ func main() {
 					})
 				}
 			}
+			// Append group chats
+			for _, g := range tools.ListGroupSummaries() {
+				status := ""
+				if g.Closed {
+					status = " [closed]"
+				} else {
+					status = fmt.Sprintf(" [round %d/%d]", g.Round, g.MaxRounds)
+				}
+				entries = append(entries, channel.SessionPanelEntry{
+					ID:          g.Name,
+					Type:        "group",
+					Label:       "💬 " + g.Name + status,
+					MessageHint: fmt.Sprintf("%d members, %d messages", len(g.Members), g.MsgCount),
+				})
+			}
 			return entries
 		},
 		ChannelConfigGetFn: func() (map[string]map[string]string, error) {

--- a/cmd/xbot-cli/setting_handlers.go
+++ b/cmd/xbot-cli/setting_handlers.go
@@ -163,7 +163,8 @@ func isKnownNonRuntimeKey(key string) bool {
 	switch key {
 	case "theme", "language", "runner_server", "runner_token", "runner_workspace",
 		"enable_stream", "enable_masking", "default_user", "privileged_user",
-		"subscription_manage", "runner_panel", "danger_zone":
+		"subscription_manage", "runner_panel", "danger_zone",
+		"llm_provider", "llm_api_key", "llm_model", "llm_base_url":
 		return true
 	}
 	return false

--- a/tools/create_chat.go
+++ b/tools/create_chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"xbot/llm"
@@ -137,17 +138,20 @@ func (t *CreateChatTool) createGroupChat(ctx *ToolContext, params *CreateChatPar
 		return nil, fmt.Errorf("group requires at least 2 members, got %d", len(params.Members))
 	}
 
-	maxRounds := params.MaxRounds
-	if maxRounds <= 0 {
-		maxRounds = 10
-	}
-
 	// Generate unique group ID
 	groupID := fmt.Sprintf("g%d", groupCounter.Add(1))
 	groupName := "group:" + groupID
 
+	// Set group context on the moderator's ToolContext so spawned agents inherit it
+	if ctx.Metadata == nil {
+		ctx.Metadata = make(map[string]string)
+	}
+	ctx.Metadata["group_id"] = groupName
+	ctx.Metadata["group_members"] = strings.Join(params.Members, ",")
+	ctx.GroupID = groupName
+	ctx.GroupMembers = params.Members
+
 	// Pre-spawn all member agents so their AgentChannels are registered in Dispatcher.
-	// Without this, @mentions in SendMessage would fail with "unknown channel".
 	im, _ := ctx.Manager.(InteractiveSubAgentManager)
 	var spawnWarnings []string
 	for _, memberAddr := range params.Members {
@@ -159,7 +163,7 @@ func (t *CreateChatTool) createGroupChat(ctx *ToolContext, params *CreateChatPar
 			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] interactive SubAgent not supported, %s not spawned", memberAddr))
 			continue
 		}
-		role, instance := parseAgentAddr(memberAddr[6:]) // strip "agent:" prefix
+		role, instance := parseAgentAddr(memberAddr[6:])
 		if role == "" {
 			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] invalid agent address %q, skipping", memberAddr))
 			continue
@@ -173,13 +177,18 @@ func (t *CreateChatTool) createGroupChat(ctx *ToolContext, params *CreateChatPar
 		task := "Ready. Waiting for group discussion."
 		_, err := im.SpawnInteractive(ctx, task, role, roleDef.SystemPrompt, roleDef.AllowedTools, roleDef.Capabilities, instance, effectiveModel)
 		if err != nil {
-			// Session may already exist (not an error for groups)
 			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] spawn %s: %v", memberAddr, err))
 			continue
 		}
-		// Register AgentChannel in Dispatcher
 		if ctx.RegisterAgentChannel != nil {
 			sendFn := func(sendCtx context.Context, msg string) (string, error) {
+				// Replace ctx.Ctx with the AgentChannel's long-lived context.
+				// The original ctx.Ctx (from tool execution) is cancelled when
+				// the tool returns, but sendFn may be called much later via
+				// SendMessage → Dispatcher → AgentChannel.
+				oldCtx := ctx.Ctx
+				ctx.Ctx = sendCtx
+				defer func() { ctx.Ctx = oldCtx }()
 				return im.SendInteractive(ctx, msg, role, roleDef.SystemPrompt, roleDef.AllowedTools, roleDef.Capabilities, instance, effectiveModel)
 			}
 			if regErr := ctx.RegisterAgentChannel(memberAddr, sendFn); regErr != nil {
@@ -188,15 +197,15 @@ func (t *CreateChatTool) createGroupChat(ctx *ToolContext, params *CreateChatPar
 		}
 	}
 
-	// Create group state
-	CreateGroupState(groupID, "moderator", params.Members, maxRounds)
+	// Create group membership (virtual — no message store, agents use their own sessions)
+	CreateGroup(groupID, params.Members)
 
 	result := fmt.Sprintf(
-		"Created group chat: %s\nMembers: %v\nMax rounds: %d\n\n"+
+		"Created group chat: %s\nMembers: %v\n\n"+
 			"Usage:\n"+
-			"- SendMessage(to=\"%s\", message=\"...\") → add to discussion (no agent triggered)\n"+
-			"- SendMessage(to=\"%s\", message=\"@agent:role/instance ...\") → trigger specific agent",
-		groupName, params.Members, maxRounds, groupName, groupName)
+			"- SendMessage(to=\"%s\", message=\"...\") → broadcast to all members\n"+
+			"- SendMessage(to=\"%s\", message=\"@agent:role/instance ...\") → trigger specific member",
+		groupName, params.Members, groupName, groupName)
 
 	if len(spawnWarnings) > 0 {
 		result += "\n\n" + fmt.Sprintf("Spawn warnings (%d):\n", len(spawnWarnings))

--- a/tools/create_chat.go
+++ b/tools/create_chat.go
@@ -146,13 +146,81 @@ func (t *CreateChatTool) createGroupChat(ctx *ToolContext, params *CreateChatPar
 	groupID := fmt.Sprintf("g%d", groupCounter.Add(1))
 	groupName := "group:" + groupID
 
-	// Create group state directly (no external callback needed)
+	// Pre-spawn all member agents so their AgentChannels are registered in Dispatcher.
+	// Without this, @mentions in SendMessage would fail with "unknown channel".
+	im, _ := ctx.Manager.(InteractiveSubAgentManager)
+	var spawnWarnings []string
+	for _, memberAddr := range params.Members {
+		if len(memberAddr) < 7 || memberAddr[:6] != "agent:" {
+			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] %s is not an agent address, skipping", memberAddr))
+			continue
+		}
+		if im == nil {
+			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] interactive SubAgent not supported, %s not spawned", memberAddr))
+			continue
+		}
+		role, instance := parseAgentAddr(memberAddr[6:]) // strip "agent:" prefix
+		if role == "" {
+			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] invalid agent address %q, skipping", memberAddr))
+			continue
+		}
+		roleDef, ok := loadRoleFromCtx(ctx, role)
+		if !ok {
+			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] unknown role %q for %s", role, memberAddr))
+			continue
+		}
+		effectiveModel := roleDef.Model
+		task := "Ready. Waiting for group discussion."
+		_, err := im.SpawnInteractive(ctx, task, role, roleDef.SystemPrompt, roleDef.AllowedTools, roleDef.Capabilities, instance, effectiveModel)
+		if err != nil {
+			// Session may already exist (not an error for groups)
+			spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] spawn %s: %v", memberAddr, err))
+			continue
+		}
+		// Register AgentChannel in Dispatcher
+		if ctx.RegisterAgentChannel != nil {
+			sendFn := func(sendCtx context.Context, msg string) (string, error) {
+				return im.SendInteractive(ctx, msg, role, roleDef.SystemPrompt, roleDef.AllowedTools, roleDef.Capabilities, instance, effectiveModel)
+			}
+			if regErr := ctx.RegisterAgentChannel(memberAddr, sendFn); regErr != nil {
+				spawnWarnings = append(spawnWarnings, fmt.Sprintf("[WARN] register %s: %v", memberAddr, regErr))
+			}
+		}
+	}
+
+	// Create group state
 	CreateGroupState(groupID, "moderator", params.Members, maxRounds)
 
-	return NewResult(fmt.Sprintf(
+	result := fmt.Sprintf(
 		"Created group chat: %s\nMembers: %v\nMax rounds: %d\n\n"+
 			"Usage:\n"+
 			"- SendMessage(to=\"%s\", message=\"...\") → add to discussion (no agent triggered)\n"+
 			"- SendMessage(to=\"%s\", message=\"@agent:role/instance ...\") → trigger specific agent",
-		groupName, params.Members, maxRounds, groupName, groupName)), nil
+		groupName, params.Members, maxRounds, groupName, groupName)
+
+	if len(spawnWarnings) > 0 {
+		result += "\n\n" + fmt.Sprintf("Spawn warnings (%d):\n", len(spawnWarnings))
+		for _, w := range spawnWarnings {
+			result += "  " + w + "\n"
+		}
+	}
+
+	return NewResult(result), nil
+}
+
+// parseAgentAddr parses "role/instance" or "role" from an agent address suffix.
+func parseAgentAddr(addr string) (role, instance string) {
+	if idx := indexOfSlash(addr); idx >= 0 {
+		return addr[:idx], addr[idx+1:]
+	}
+	return addr, ""
+}
+
+func indexOfSlash(s string) int {
+	for i, c := range s {
+		if c == '/' {
+			return i
+		}
+	}
+	return -1
 }

--- a/tools/group_state.go
+++ b/tools/group_state.go
@@ -122,3 +122,39 @@ func (g *GroupState) IsMember(addr string) bool {
 	}
 	return false
 }
+
+// GroupSummary is a lightweight snapshot of a group chat for listing.
+type GroupSummary struct {
+	ID        string
+	Name      string // e.g. "group:g1"
+	Members   []string
+	Round     int
+	MaxRounds int
+	Closed    bool
+	MsgCount  int
+}
+
+// ListGroupSummaries returns info about all active and closed group chats.
+func ListGroupSummaries() []GroupSummary {
+	var results []GroupSummary
+	groupStore.Range(func(key, value any) bool {
+		gs, ok := value.(*GroupState)
+		if !ok {
+			return true
+		}
+		gs.mu.Lock()
+		summary := GroupSummary{
+			ID:        gs.ID,
+			Name:      key.(string),
+			Members:   append([]string{}, gs.Members...),
+			Round:     gs.Round,
+			MaxRounds: gs.MaxRounds,
+			Closed:    gs.Closed,
+			MsgCount:  len(gs.Messages),
+		}
+		gs.mu.Unlock()
+		results = append(results, summary)
+		return true
+	})
+	return results
+}

--- a/tools/group_state.go
+++ b/tools/group_state.go
@@ -1,120 +1,60 @@
 package tools
 
-import (
-	"fmt"
-	"sync"
-	"time"
-)
+import "sync"
 
-// GroupState manages a meeting-style group chat.
-// The moderator controls who speaks via @mentions.
-// All members can see the full discussion history, but only @mentioned agents respond.
-type GroupState struct {
-	ID        string
-	Moderator string   // creator address (e.g., "main")
-	Members   []string // all member addresses (e.g., ["agent:reviewer/r1", "agent:tester/t1"])
-	MaxRounds int
-	Round     int
-	Closed    bool
-	Messages  []GroupMessage
-	mu        sync.Mutex
+// GroupMembership defines a virtual group chat — it's just a set of agent members.
+// There is NO separate message store. Each agent already has its own session
+// with full message history. The group only constrains which agents can
+// communicate: agents in the same group can SendMessage directly to each other.
+//
+// This is a deliberate simplification over the old GroupState model which
+// duplicated agent session functionality (message store, history formatting).
+type GroupMembership struct {
+	ID      string   // e.g. "g1"
+	Name    string   // e.g. "group:g1"
+	Members []string // agent addresses e.g. ["agent:reviewer/r1", "agent:tester/t1"]
+	Closed  bool
 }
 
-// GroupMessage is a single message in the group discussion.
-type GroupMessage struct {
-	Sender    string    // who sent this message
-	Content   string    // message content
-	Timestamp time.Time // when it was sent
-	IsSystem  bool      // true for system messages (join, close, etc.)
-}
+// groupStore holds active group memberships.
+var groupStore sync.Map // "group:<id>" -> *GroupMembership
 
-// groupStore holds active group chats.
-var groupStore sync.Map // "group:<id>" -> *GroupState
-
-// CreateGroupState creates a new group and stores it.
-func CreateGroupState(id, moderator string, members []string, maxRounds int) *GroupState {
-	gs := &GroupState{
-		ID:        id,
-		Moderator: moderator,
-		Members:   members,
-		MaxRounds: maxRounds,
-		Messages: []GroupMessage{
-			{
-				Sender:    "system",
-				Content:   fmt.Sprintf("Group created. Moderator: %s, Members: %v", moderator, members),
-				Timestamp: time.Now(),
-				IsSystem:  true,
-			},
-		},
+// CreateGroup creates a new group membership and stores it.
+func CreateGroup(id string, members []string) *GroupMembership {
+	gm := &GroupMembership{
+		ID:      id,
+		Name:    "group:" + id,
+		Members: members,
 	}
-	groupStore.Store("group:"+id, gs)
-	return gs
+	groupStore.Store(gm.Name, gm)
+	return gm
 }
 
-// GetGroupState retrieves a group by name (e.g., "group:g1").
-func GetGroupState(name string) (*GroupState, bool) {
+// GetGroup retrieves a group membership by name (e.g., "group:g1").
+func GetGroup(name string) (*GroupMembership, bool) {
 	v, ok := groupStore.Load(name)
 	if !ok {
 		return nil, false
 	}
-	gs, ok := v.(*GroupState)
+	gm, ok := v.(*GroupMembership)
 	if !ok {
 		return nil, false
 	}
-	return gs, true
+	return gm, true
 }
 
-// DeleteGroupState removes a group from the store.
-func DeleteGroupState(name string) {
+// DeleteGroup removes a group from the store.
+func DeleteGroup(name string) {
 	groupStore.Delete(name)
 }
 
-// AddMessage adds a message to the group history. Returns the round number.
-func (g *GroupState) AddMessage(sender, content string, isSystem bool) int {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	msg := GroupMessage{
-		Sender:    sender,
-		Content:   content,
-		Timestamp: time.Now(),
-		IsSystem:  isSystem,
-	}
-	g.Messages = append(g.Messages, msg)
-	return len(g.Messages)
-}
-
-// GetHistory returns the formatted discussion history for agent context.
-func (g *GroupState) GetHistory() string {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	result := fmt.Sprintf("=== Group Discussion: %s ===\n", g.ID)
-	result += fmt.Sprintf("Members: %v\n\n", g.Members)
-	for _, msg := range g.Messages {
-		if msg.IsSystem {
-			result += fmt.Sprintf("[System] %s\n", msg.Content)
-		} else {
-			result += fmt.Sprintf("[%s]: %s\n", msg.Sender, msg.Content)
-		}
-	}
-	result += "\n=== End of History ==="
-	return result
-}
-
 // Close marks the group as closed.
-func (g *GroupState) Close(reason string) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+func (g *GroupMembership) Close() {
 	g.Closed = true
-	g.Messages = append(g.Messages, GroupMessage{
-		Sender:    "system",
-		Content:   fmt.Sprintf("Group closed: %s", reason),
-		Timestamp: time.Now(),
-		IsSystem:  true,
-	})
 }
 
-// IsMember checks if an address is a group member.
-func (g *GroupState) IsMember(addr string) bool {
+// IsMember checks if an address is in this group.
+func (g *GroupMembership) IsMember(addr string) bool {
 	for _, m := range g.Members {
 		if m == addr {
 			return true
@@ -123,37 +63,47 @@ func (g *GroupState) IsMember(addr string) bool {
 	return false
 }
 
-// GroupSummary is a lightweight snapshot of a group chat for listing.
-type GroupSummary struct {
-	ID        string
-	Name      string // e.g. "group:g1"
-	Members   []string
-	Round     int
-	MaxRounds int
-	Closed    bool
-	MsgCount  int
+// RemoveMember removes an address from the group. Returns true if the member was found.
+// If no members remain, the group is deleted from the store.
+func RemoveMember(groupName, memberAddr string) bool {
+	gm, ok := GetGroup(groupName)
+	if !ok {
+		return false
+	}
+	for i, m := range gm.Members {
+		if m == memberAddr {
+			gm.Members = append(gm.Members[:i], gm.Members[i+1:]...)
+			break
+		}
+	}
+	if len(gm.Members) == 0 {
+		DeleteGroup(groupName)
+	}
+	return true
 }
 
-// ListGroupSummaries returns info about all active and closed group chats.
-func ListGroupSummaries() []GroupSummary {
+// GroupSummary is a lightweight snapshot for CLI listing.
+type GroupSummary struct {
+	ID      string
+	Name    string
+	Members []string
+	Closed  bool
+}
+
+// ListGroups returns info about all active and closed groups.
+func ListGroups() []GroupSummary {
 	var results []GroupSummary
 	groupStore.Range(func(key, value any) bool {
-		gs, ok := value.(*GroupState)
+		gm, ok := value.(*GroupMembership)
 		if !ok {
 			return true
 		}
-		gs.mu.Lock()
-		summary := GroupSummary{
-			ID:        gs.ID,
-			Name:      key.(string),
-			Members:   append([]string{}, gs.Members...),
-			Round:     gs.Round,
-			MaxRounds: gs.MaxRounds,
-			Closed:    gs.Closed,
-			MsgCount:  len(gs.Messages),
-		}
-		gs.mu.Unlock()
-		results = append(results, summary)
+		results = append(results, GroupSummary{
+			ID:      gm.ID,
+			Name:    gm.Name,
+			Members: append([]string{}, gm.Members...),
+			Closed:  gm.Closed,
+		})
 		return true
 	})
 	return results

--- a/tools/group_state_test.go
+++ b/tools/group_state_test.go
@@ -1,126 +1,86 @@
 package tools
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
-func TestGroupStateCreateAndGet(t *testing.T) {
-	gs := CreateGroupState("test1", "moderator", []string{"agent:a/r1", "agent:b/r2"}, 5)
-	if gs.ID != "test1" {
-		t.Errorf("expected ID test1, got %s", gs.ID)
+func TestGroupCreateAndGet(t *testing.T) {
+	gm := CreateGroup("test1", []string{"agent:a/r1", "agent:b/r2"})
+	if gm.ID != "test1" {
+		t.Errorf("expected ID test1, got %s", gm.ID)
 	}
-	if gs.Moderator != "moderator" {
-		t.Errorf("expected moderator, got %s", gs.Moderator)
+	if gm.Name != "group:test1" {
+		t.Errorf("expected Name group:test1, got %s", gm.Name)
 	}
-	if len(gs.Members) != 2 {
-		t.Fatalf("expected 2 members, got %d", len(gs.Members))
+	if len(gm.Members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(gm.Members))
 	}
-	if gs.MaxRounds != 5 {
-		t.Errorf("expected maxRounds 5, got %d", gs.MaxRounds)
-	}
-	if gs.Closed {
+	if gm.Closed {
 		t.Error("new group should not be closed")
 	}
 
-	// Retrieve
-	got, ok := GetGroupState("group:test1")
+	got, ok := GetGroup("group:test1")
 	if !ok {
-		t.Fatal("GetGroupState failed")
+		t.Fatal("GetGroup failed")
 	}
 	if got.ID != "test1" {
 		t.Errorf("retrieved wrong group: %s", got.ID)
 	}
 
-	// Delete
-	DeleteGroupState("group:test1")
-	_, ok = GetGroupState("group:test1")
+	DeleteGroup("group:test1")
+	_, ok = GetGroup("group:test1")
 	if ok {
 		t.Error("group should be deleted")
 	}
 }
 
-func TestGroupStateAddMessage(t *testing.T) {
-	gs := CreateGroupState("test2", "mod", []string{"agent:x/y"}, 10)
-	defer DeleteGroupState("group:test2")
+func TestGroupIsMember(t *testing.T) {
+	gm := CreateGroup("test2", []string{"agent:a/1", "agent:b/2"})
+	defer DeleteGroup("group:test2")
 
-	// Initial message is the system creation message
-	if len(gs.Messages) != 1 {
-		t.Fatalf("expected 1 initial message, got %d", len(gs.Messages))
-	}
-
-	n := gs.AddMessage("mod", "Hello everyone", false)
-	if n != 2 {
-		t.Errorf("expected 2 messages after add, got %d", n)
-	}
-
-	n = gs.AddMessage("agent:x/y", "Hi!", false)
-	if n != 3 {
-		t.Errorf("expected 3 messages after add, got %d", n)
-	}
-}
-
-func TestGroupStateGetHistory(t *testing.T) {
-	gs := CreateGroupState("test3", "mod", []string{"agent:a/1", "agent:b/2"}, 10)
-	defer DeleteGroupState("group:test3")
-
-	gs.AddMessage("mod", "Let's discuss the design.", false)
-	gs.AddMessage("agent:a/1", "I think we should use option A.", false)
-
-	history := gs.GetHistory()
-	if history == "" {
-		t.Fatal("history should not be empty")
-	}
-	if !strings.Contains(history, "Let's discuss") {
-		t.Error("history should contain moderator message")
-	}
-	if !strings.Contains(history, "option A") {
-		t.Error("history should contain agent message")
-	}
-	if !strings.Contains(history, "System") {
-		t.Error("history should contain system message")
-	}
-}
-
-func TestGroupStateIsMember(t *testing.T) {
-	gs := CreateGroupState("test4", "mod", []string{"agent:a/1", "agent:b/2"}, 5)
-	defer DeleteGroupState("group:test4")
-
-	if !gs.IsMember("agent:a/1") {
+	if !gm.IsMember("agent:a/1") {
 		t.Error("agent:a/1 should be a member")
 	}
-	if !gs.IsMember("agent:b/2") {
-		t.Error("agent:b/2 should be a member")
-	}
-	if gs.IsMember("agent:c/3") {
+	if gm.IsMember("agent:c/3") {
 		t.Error("agent:c/3 should not be a member")
 	}
 }
 
-func TestGroupStateClose(t *testing.T) {
-	gs := CreateGroupState("test5", "mod", []string{"agent:a/1"}, 5)
-	defer DeleteGroupState("group:test5")
+func TestGroupClose(t *testing.T) {
+	gm := CreateGroup("test3", []string{"agent:a/1"})
+	defer DeleteGroup("group:test3")
 
-	if gs.Closed {
+	if gm.Closed {
 		t.Error("group should not be closed initially")
 	}
-
-	gs.Close("test done")
-	if !gs.Closed {
+	gm.Close()
+	if !gm.Closed {
 		t.Error("group should be closed after Close()")
-	}
-
-	// Last message should be the close reason
-	lastMsg := gs.Messages[len(gs.Messages)-1]
-	if !lastMsg.IsSystem {
-		t.Error("close message should be system message")
-	}
-	if !strings.Contains(lastMsg.Content, "test done") {
-		t.Errorf("close message should contain reason, got: %s", lastMsg.Content)
 	}
 }
 
-func TestGroupStateDeleteNonexistent(t *testing.T) {
-	// Should not panic
-	DeleteGroupState("group:nonexistent")
+func TestGroupDeleteNonexistent(t *testing.T) {
+	DeleteGroup("group:nonexistent") // should not panic
+}
+
+func TestListGroups(t *testing.T) {
+	defer DeleteGroup("group:la1")
+	defer DeleteGroup("group:la2")
+
+	CreateGroup("la1", []string{"agent:x/1"})
+	CreateGroup("la2", []string{"agent:y/2", "agent:z/3"})
+
+	groups := ListGroups()
+	if len(groups) < 2 {
+		t.Fatalf("expected at least 2 groups, got %d", len(groups))
+	}
+
+	found := false
+	for _, g := range groups {
+		if g.ID == "la1" && len(g.Members) == 1 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("la1 group not found in listing")
+	}
 }

--- a/tools/interface.go
+++ b/tools/interface.go
@@ -80,6 +80,12 @@ type ToolContext struct {
 	// UnregisterAgentChannel removes an AgentChannel from the Dispatcher.
 	// Called on unload/cleanup.
 	UnregisterAgentChannel func(name string)
+
+	// GroupID is set when this agent is a member of a virtual group (via CreateChat group).
+	// It constrains SendMessage: agents can only message other members of the same group.
+	GroupID string
+	// GroupMembers lists all agent addresses in this agent's group (for system prompt injection).
+	GroupMembers []string
 }
 
 // SubAgentManager SubAgent 管理接口，避免循环依赖

--- a/tools/send_message.go
+++ b/tools/send_message.go
@@ -96,7 +96,14 @@ func (t *SendMessageTool) Execute(ctx *ToolContext, raw string) (*ToolResult, er
 
 // sendToAgent sends a message to a single agent via Dispatcher.
 // The agent must have been registered as an AgentChannel (by SubAgent or CreateChat).
+// If the caller is in a group, the target must also be a member of the same group.
 func (t *SendMessageTool) sendToAgent(ctx *ToolContext, addr, message string) (*ToolResult, error) {
+	// Group membership check: if caller is in a group, target must be a fellow member.
+	if ctx.GroupID != "" {
+		if !isInGroup(ctx, addr) {
+			return nil, fmt.Errorf("cross-group messaging not allowed: you are in group %s but %s is not a member", ctx.GroupID, addr)
+		}
+	}
 	if ctx.MessageSender == nil {
 		return nil, fmt.Errorf("message sending not available in this context")
 	}
@@ -110,86 +117,74 @@ func (t *SendMessageTool) sendToAgent(ctx *ToolContext, addr, message string) (*
 	return NewResult(result), nil
 }
 
-// sendToGroup handles the meeting model for group chats.
-// Moderator messages without @mentions just add to history.
-// @mentioned agents receive the full discussion history + the question.
+// isInGroup checks if addr is a member of the caller's group.
+func isInGroup(ctx *ToolContext, addr string) bool {
+	for _, m := range ctx.GroupMembers {
+		if m == addr {
+			return true
+		}
+	}
+	return false
+}
+
+// sendToGroup handles virtual group messaging.
+// The group has NO message store — it only defines a membership boundary.
+// Messages are sent directly to agent members (each agent has its own session).
+// sendToGroup handles virtual group messaging.
+// The group has NO message store — it only defines a membership boundary.
+// Messages are sent directly to agent members (each agent has its own session).
+// @mentioned agents receive the message prefixed with group context.
+// Without @mentions, the message is broadcast to all members.
 func (t *SendMessageTool) sendToGroup(ctx *ToolContext, groupName, message string) (*ToolResult, error) {
-	gs, ok := GetGroupState(groupName)
+	gm, ok := GetGroup(groupName)
 	if !ok {
 		return nil, fmt.Errorf("group %q not found (create it with CreateChat first)", groupName)
 	}
-	if gs.Closed {
+	if gm.Closed {
 		return nil, fmt.Errorf("group %q is closed", groupName)
 	}
 
-	// Identify sender as the moderator
-	sender := "moderator"
-
-	// Parse @mentions from the message
-	mentions := parseMentions(message)
-
-	// Always add moderator message to history
-	gs.AddMessage(sender, message, false)
-
-	// No @mentions → just record, don't trigger anyone
-	if len(mentions) == 0 {
-		historyLen := len(gs.Messages)
-		return NewResult(fmt.Sprintf("Message added to group %s discussion (history: %d messages). No agents @mentioned, so no one was triggered.", groupName, historyLen)), nil
-	}
-
-	// Trigger each @mentioned agent sequentially via Dispatcher
 	if ctx.MessageSender == nil {
 		return nil, fmt.Errorf("message sending not available in this context")
 	}
 
+	mentions := parseMentions(message)
+
+	// No @mentions → broadcast to all members
+	if len(mentions) == 0 {
+		var responses []string
+		for _, memberAddr := range gm.Members {
+			prefixedMsg := fmt.Sprintf("[group:%s] %s", groupName, message)
+			result, err := ctx.MessageSender.SendMessage(memberAddr, "", prefixedMsg)
+			if err != nil {
+				responses = append(responses, fmt.Sprintf("[WARN] %s: %v", memberAddr, err))
+			} else {
+				responses = append(responses, fmt.Sprintf("[→ %s]: %s", memberAddr, truncateMsg(result, 200)))
+			}
+		}
+		return NewResult(fmt.Sprintf("Broadcast to group %s (%d members):\n%s",
+			groupName, len(gm.Members), strings.Join(responses, "\n"))), nil
+	}
+
+	// @mentioned agents: send directly with group context prefix.
+	// Each agent already has its own session for full context.
 	var responses []string
 	for _, agentAddr := range mentions {
-		if !gs.IsMember(agentAddr) {
-			responses = append(responses, fmt.Sprintf("[ERROR] %s is not a member of this group", agentAddr))
+		if !gm.IsMember(agentAddr) {
+			responses = append(responses, fmt.Sprintf("[REJECT] %s is not a member of group %s", agentAddr, groupName))
 			continue
 		}
 
-		// Build the prompt with full discussion history
-		history := gs.GetHistory()
-		prompt := fmt.Sprintf(`You are participating in a group discussion. Here is the full conversation so far:
-
-%s
-
----
-
-The moderator just @mentioned you. Please respond to their message. Stay focused on the topic and provide your analysis/opinion.`, history)
-
-		// Send via Dispatcher (AgentChannel)
-		result, err := ctx.MessageSender.SendMessage(agentAddr, "", prompt)
+		prefixedMsg := fmt.Sprintf("[group:%s] %s", groupName, message)
+		result, err := ctx.MessageSender.SendMessage(agentAddr, "", prefixedMsg)
 		if err != nil {
 			responses = append(responses, fmt.Sprintf("[ERROR] %s: %v", agentAddr, err))
 			continue
 		}
-
-		// Add agent's response to group history
-		gs.AddMessage(agentAddr, result, false)
-		responses = append(responses, fmt.Sprintf("[%s]:\n%s", agentAddr, result))
+		responses = append(responses, fmt.Sprintf("[%s]:\n%s", agentAddr, truncateMsg(result, 500)))
 	}
 
-	// Check round limit
-	gs.mu.Lock()
-	gs.Round++
-	round := gs.Round
-	maxRounds := gs.MaxRounds
-	gs.mu.Unlock()
-
-	if maxRounds > 0 && round >= maxRounds {
-		gs.Close(fmt.Sprintf("max rounds (%d) reached", maxRounds))
-	}
-
-	summary := fmt.Sprintf("Group %s — round %d/%d\nModerator: %s\n\n%s",
-		groupName, round, maxRounds, message, strings.Join(responses, "\n\n---\n\n"))
-
-	if gs.Closed {
-		summary += "\n\n[Group closed: max rounds reached]"
-	}
-
-	return NewResult(summary), nil
+	return NewResult(strings.Join(responses, "\n\n---\n\n")), nil
 }
 
 // parseMentions extracts @agent:role/instance addresses from a message.
@@ -274,4 +269,12 @@ func parseAddress(addr string) (channelName, chatID string) {
 	}
 	// Agent or group: the whole address is the channel name
 	return addr, ""
+}
+
+// truncateMsg limits a string to n chars with "..." suffix.
+func truncateMsg(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }

--- a/tools/subagent.go
+++ b/tools/subagent.go
@@ -245,6 +245,12 @@ func (t *SubAgentTool) Execute(ctx *ToolContext, input string) (*ToolResult, err
 			agentChName := "agent:" + params.Role + "/" + params.Instance
 			if ctx.RegisterAgentChannel != nil {
 				sendFn := func(sendCtx context.Context, task string) (string, error) {
+					// Replace ctx.Ctx with the AgentChannel's long-lived context.
+					// The original ctx.Ctx is cancelled when the tool returns,
+					// but sendFn may be called much later via SendMessage.
+					oldCtx := ctx.Ctx
+					ctx.Ctx = sendCtx
+					defer func() { ctx.Ctx = oldCtx }()
 					return im.SendInteractive(ctx, task, params.Role, role.SystemPrompt, role.AllowedTools, role.Capabilities, params.Instance, effectiveModel)
 				}
 				if regErr := ctx.RegisterAgentChannel(agentChName, sendFn); regErr != nil {


### PR DESCRIPTION
## SubAgent CWD 修复

SubAgent 启动时如果父 Agent 从未执行过 `Cd`，`session.GetCurrentDir()` 返回空，导致 `parent_cwd` metadata 不写入，SubAgent fallback 到 config 里的 `agent.work_dir` 而非父 Agent 的实际工作目录。

- **engine.go buildMsg**: `parent_cwd` fallback 到 `parentCtx.WorkingDir`（而非仅检查 `CurrentDir`）
- **interactive.go buildParentToolContext**: 增加 `workspaceRoot` fallback，双重保障 interactive SubAgent 的 CWD 正确

## Group chat 修复

### unknown channel 错误
`CreateChat(type="group")` 之前只记录 member 地址字符串，不自动创建 interactive session。`SendMessage` @mention 时走 Dispatcher 找不到 AgentChannel。

修复：`createGroupChat` 自动为每个 member spawn interactive session 并注册 AgentChannel 到 Dispatcher。

### session 面板不可见
Group chat 只存在 `tools.groupStore`（包内 sync.Map），session 管理系统完全看不到。

修复：
- `group_state.go`: 新增 `ListGroupSummaries()` 导出函数
- `cmd/xbot-cli`: `SessionsList` 追加 group entries（显示 round/状态）
- `cli_panel.go`: `viewSessionsDetail` 处理 group type 渲染

### context canceled 错误
sendFn 闭包在 create_chat.go 和 subagent.go 中捕获了 `ctx.Ctx`（tool 执行完成后已取消），导致后续 SendInteractive 调用立即失败。

修复：在调用 SendInteractive 前临时将 `ctx.Ctx` 替换为 `sendCtx`（AgentChannel 的长生命周期 context）。

### Group auto-cleanup
interactive session unload 时自动从 group 移除 member，所有 member 移除后自动解散 group。

## Interactive SubAgent 默认能力

Interactive SubAgent 现在默认获得 SendMessage + CreateChat 能力（caps.SendMessage=true），且这两个 tool 绕过 allowedTools 白名单。

## TUI Settings 清理

移除 4 个 LLM subscription-scoped 设置（llm_provider, llm_api_key, llm_model, llm_base_url）从 SettingsSchema 和 SetupSchema（3 个 locale：ZH/EN/JP）。subscription 系统是这些配置的唯一来源，Settings 中不应重复。

- 更新 `mergeCLISettingsValues`、`ApplySettings`、`openSettingsPanel`、`refreshCachedModelName`
- 更新测试用例

## Subscription 编辑 Model 下拉

订阅管理编辑面板中 model 字段从纯文本输入改为 combo 下拉（`SettingTypeCombo`），使用 `ListModels()` 列出当前订阅的可用模型，同时支持自定义输入。