### PR TITLE
ci: fix release artifact paths for merge-multiple download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,11 @@ jobs:
           mkdir -p dist
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
             -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/xbot-cli ./cmd/xbot-cli
+            -o dist/xbot-cli-linux-amd64 ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
           name: xbot-cli-linux-amd64
-          path: dist/xbot-cli
+          path: dist/xbot-cli-linux-amd64
 
   build-linux-arm64:
     name: Build linux/arm64
@@ -69,11 +69,11 @@ jobs:
           mkdir -p dist
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
             -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/xbot-cli ./cmd/xbot-cli
+            -o dist/xbot-cli-linux-arm64 ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
           name: xbot-cli-linux-arm64
-          path: dist/xbot-cli
+          path: dist/xbot-cli-linux-arm64
 
   build-darwin-arm64:
     name: Build darwin/arm64
@@ -88,11 +88,11 @@ jobs:
           mkdir -p dist
           CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build \
             -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/xbot-cli ./cmd/xbot-cli
+            -o dist/xbot-cli-darwin-arm64 ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
           name: xbot-cli-darwin-arm64
-          path: dist/xbot-cli
+          path: dist/xbot-cli-darwin-arm64
 
   build-windows-amd64:
     name: Build windows/amd64
@@ -108,11 +108,11 @@ jobs:
           mkdir -p dist
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build \
             -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/xbot-cli.exe ./cmd/xbot-cli
+            -o dist/xbot-cli-windows-amd64.exe ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
           name: xbot-cli-windows-amd64
-          path: dist/xbot-cli.exe
+          path: dist/xbot-cli-windows-amd64.exe
 
   build-windows-arm64:
     name: Build windows/arm64
@@ -128,11 +128,11 @@ jobs:
           mkdir -p dist
           CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build \
             -ldflags "-X xbot/version.Version=${VERSION} -X xbot/version.Commit=${COMMIT} -X xbot/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/xbot-cli.exe ./cmd/xbot-cli
+            -o dist/xbot-cli-windows-arm64.exe ./cmd/xbot-cli
       - uses: actions/upload-artifact@v4
         with:
           name: xbot-cli-windows-arm64
-          path: dist/xbot-cli.exe
+          path: dist/xbot-cli-windows-arm64.exe
 
   release:
     name: Release


### PR DESCRIPTION
download-artifact@v4 with merge-multiple 按 artifact name 建子目录，导致 release job 找不到文件。

修复：build 输出文件名直接带平台后缀（如 xbot-cli-linux-amd64），不再依赖 artifact name 映射路径。