### PR TITLE
fix: prevent masked API keys from overwriting real keys in storage

### DIFF
--- a/agent/backend_local.go
+++ b/agent/backend_local.go
@@ -597,6 +597,10 @@ func (b *LocalBackend) UpdateSubscription(id string, sub channel.Subscription) e
 		ThinkingMode:    existing.ThinkingMode,
 		IsDefault:       sub.Active,
 	}
+	// Never overwrite with a masked key from server RPC transport.
+	if strings.HasSuffix(dbSub.APIKey, "****") && len(dbSub.APIKey) <= 20 {
+		dbSub.APIKey = existing.APIKey
+	}
 	if err := svc.Update(dbSub); err != nil {
 		return err
 	}

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -140,9 +140,13 @@ func (m *cliModel) mergeCLISettingsValues() map[string]string {
 			values[k] = v
 		}
 	}
-	// Subscription-scoped settings (max_output_tokens, thinking_mode) from active subscription.
+	// Subscription-scoped settings from active subscription.
 	if m.channel.subscriptionMgr != nil {
 		if sub, err := m.channel.subscriptionMgr.GetDefault(m.senderID); err == nil && sub != nil {
+			values["llm_provider"] = sub.Provider
+			values["llm_api_key"] = sub.APIKey
+			values["llm_base_url"] = sub.BaseURL
+			values["llm_model"] = sub.Model
 			values["max_output_tokens"] = strconv.Itoa(sub.MaxOutputTokens)
 			values["thinking_mode"] = sub.ThinkingMode
 		}

--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -86,6 +86,13 @@ var cliSubscriptionScopedSettingKeys = map[string]struct{}{
 	"thinking_mode":     {},
 }
 
+// isMaskedAPIKey detects API keys that were masked by the server for safe transport.
+// Server masks keys as "<prefix>****" (e.g. "sk-a****"). Writing masked keys
+// back to storage would destroy the real key — this function prevents that.
+func isMaskedAPIKey(key string) bool {
+	return strings.HasSuffix(key, "****") && len(key) <= 20
+}
+
 func isUserScopedSettingKey(key string) bool {
 	_, ok := cliUserScopedSettingKeys[key]
 	return ok

--- a/channel/cli_panel.go
+++ b/channel/cli_panel.go
@@ -2307,13 +2307,18 @@ func (m *cliModel) editQuickSwitchEntry() {
 		if m.subscriptionMgr == nil {
 			return
 		}
+		apiKey := values["sub_api_key"]
+		// Never write back a masked API key — it would destroy the real key in storage.
+		if isMaskedAPIKey(apiKey) {
+			apiKey = target.APIKey
+		}
 		updated := &Subscription{
 			ID:       target.ID,
 			Name:     values["sub_name"],
 			Provider: values["sub_provider"],
 			Model:    values["sub_model"],
 			BaseURL:  values["sub_base_url"],
-			APIKey:   values["sub_api_key"],
+			APIKey:   apiKey,
 			Active:   target.Active,
 		}
 		if err := m.subscriptionMgr.Update(target.ID, updated); err != nil {

--- a/channel/cli_types.go
+++ b/channel/cli_types.go
@@ -542,6 +542,7 @@ type CLIChannelConfig struct {
 	ClearMemory          func(targetType string) error                                                                                  // 清空记忆（danger zone）
 	GetMemoryStats       func() map[string]string                                                                                       // 获取记忆统计（danger zone）
 	SwitchLLM            func(provider, baseURL, apiKey, model string) error                                                            // 切换活跃 LLM（config + factory + save）
+	RefreshValuesCache   func()                                                                                                         // 刷新 GetCurrentValues 缓存（sub 切换后调用）
 	UsageQuery           func(senderID string, days int) (cumulative *sqlite.UserTokenUsage, daily []sqlite.DailyTokenUsage, err error) // 查询 token 用量
 	AgentCount           func() int                                                                                                     // 获取活跃的 interactive agent 数量
 	AgentList            func() []AgentPanelEntry                                                                                       // 列出活跃 interactive agents（用于 panel 展示）

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -45,6 +45,10 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 			} else {
 				m.subGeneration++ // subscription actually changed
 				m.showTempStatus(fmt.Sprintf("Switched to: %s (%s)", done.subName, done.subModel))
+				// Refresh values cache so GetCurrentValues() reflects the new subscription.
+				if m.channel != nil && m.channel.config.RefreshValuesCache != nil {
+					m.channel.config.RefreshValuesCache()
+				}
 			}
 			// Update cached model name directly from the switch result
 			// (same pattern as model-switch case — avoids stale config/RPC reads)

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -392,6 +392,31 @@ func localeZH() *UILocale {
 		SetupSchema: []SettingDefinition{
 
 			{
+				Key: "llm_provider", Label: "LLM 供应商", Description: "大模型服务提供商",
+				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
+				Options: []SettingOption{
+					{Label: "OpenAI", Value: "openai"},
+					{Label: "Anthropic", Value: "anthropic"},
+					{Label: "OpenRouter", Value: "openrouter"},
+					{Label: "Ollama", Value: "ollama"},
+					{Label: "Azure OpenAI", Value: "azure"},
+					{Label: "Google AI (Gemini)", Value: "google"},
+					{Label: "自定义 (OpenAI 兼容)", Value: "custom"},
+				},
+			},
+			{
+				Key: "llm_api_key", Label: "API Key", Description: "模型服务的 API 密钥",
+				Type: SettingTypePassword, Category: "LLM",
+			},
+			{
+				Key: "llm_model", Label: "模型", Description: "使用的模型名称",
+				Type: SettingTypeText, Category: "LLM",
+			},
+			{
+				Key: "llm_base_url", Label: "Base URL", Description: "API 端点地址（自定义供应商时填写）",
+				Type: SettingTypeText, Category: "LLM",
+			},
+			{
 				Key: "tavily_api_key", Label: "Tavily API Key", Description: "网络搜索服务密钥（可选，留空则无法使用 WebSearch）",
 				Type: SettingTypePassword, Category: "LLM",
 			},
@@ -741,6 +766,31 @@ func localeEN() *UILocale {
 		SetupSchema: []SettingDefinition{
 
 			{
+				Key: "llm_provider", Label: "LLM Provider", Description: "Large language model service provider",
+				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
+				Options: []SettingOption{
+					{Label: "OpenAI", Value: "openai"},
+					{Label: "Anthropic", Value: "anthropic"},
+					{Label: "OpenRouter", Value: "openrouter"},
+					{Label: "Ollama", Value: "ollama"},
+					{Label: "Azure OpenAI", Value: "azure"},
+					{Label: "Google AI (Gemini)", Value: "google"},
+					{Label: "Custom (OpenAI-compatible)", Value: "custom"},
+				},
+			},
+			{
+				Key: "llm_api_key", Label: "API Key", Description: "API key for the model service",
+				Type: SettingTypePassword, Category: "LLM",
+			},
+			{
+				Key: "llm_model", Label: "Model", Description: "Model name to use",
+				Type: SettingTypeText, Category: "LLM",
+			},
+			{
+				Key: "llm_base_url", Label: "Base URL", Description: "API endpoint URL (for custom providers)",
+				Type: SettingTypeText, Category: "LLM",
+			},
+			{
 				Key: "tavily_api_key", Label: "Tavily API Key", Description: "Web search service key (optional, leave empty to disable WebSearch)",
 				Type: SettingTypePassword, Category: "LLM",
 			},
@@ -1089,6 +1139,31 @@ func localeJA() *UILocale {
 		// --- J. Settings schema ---
 		SetupSchema: []SettingDefinition{
 
+			{
+				Key: "llm_provider", Label: "LLM プロバイダー", Description: "大規模言語モデルサービスプロバイダー",
+				Type: SettingTypeSelect, Category: "LLM", DefaultValue: "openai",
+				Options: []SettingOption{
+					{Label: "OpenAI", Value: "openai"},
+					{Label: "Anthropic", Value: "anthropic"},
+					{Label: "OpenRouter", Value: "openrouter"},
+					{Label: "Ollama", Value: "ollama"},
+					{Label: "Azure OpenAI", Value: "azure"},
+					{Label: "Google AI (Gemini)", Value: "google"},
+					{Label: "カスタム (OpenAI 互換)", Value: "custom"},
+				},
+			},
+			{
+				Key: "llm_api_key", Label: "API Key", Description: "モデルサービスのAPIキー",
+				Type: SettingTypePassword, Category: "LLM",
+			},
+			{
+				Key: "llm_model", Label: "モデル", Description: "使用するモデル名",
+				Type: SettingTypeText, Category: "LLM",
+			},
+			{
+				Key: "llm_base_url", Label: "Base URL", Description: "APIエンドポイントURL（カスタムプロバイダー用）",
+				Type: SettingTypeText, Category: "LLM",
+			},
 			{
 				Key: "tavily_api_key", Label: "Tavily API Key", Description: "Web検索サービスキー（オプション、空の場合 WebSearch は無効）",
 				Type: SettingTypePassword, Category: "LLM",

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -795,14 +795,20 @@ func main() {
 			if app.backend == nil {
 				return
 			}
+			_, llmChanged := values["llm_provider"]
+			_, keyChanged := values["llm_api_key"]
+			_, modelChanged := values["llm_model"]
+			_, urlChanged := values["llm_base_url"]
 			_, vanguardChanged := values["vanguard_model"]
 			_, balanceChanged := values["balance_model"]
 			_, swiftChanged := values["swift_model"]
 			_, maxOutputChanged := values["max_output_tokens"]
 			_, thinkingChanged := values["thinking_mode"]
 
+			llmFieldChanged := llmChanged || keyChanged || modelChanged || urlChanged || maxOutputChanged || thinkingChanged
+
 			// ── Subscription-scoped fields: update via subscription manager ──
-			if maxOutputChanged || thinkingChanged {
+			if llmFieldChanged {
 				if err := updateActiveSubscription(app.backend, app.cfg, values); err != nil {
 					log.Warnf("Failed to update active subscription: %v", err)
 				}

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -329,7 +329,12 @@ func updateActiveSubscription(backend agent.AgentBackend, cfg *config.Config, va
 		sub.Provider = strings.TrimSpace(v)
 	}
 	if v, ok := values["llm_api_key"]; ok && strings.TrimSpace(v) != "" {
-		sub.APIKey = strings.TrimSpace(v)
+		key := strings.TrimSpace(v)
+		// Never overwrite with a masked key (e.g. "sk-a****") from server RPC.
+		// This would destroy the real API key in storage.
+		if !strings.HasSuffix(key, "****") || len(key) > 20 {
+			sub.APIKey = key
+		}
 	}
 	if v, ok := values["llm_model"]; ok && strings.TrimSpace(v) != "" {
 		sub.Model = strings.TrimSpace(v)
@@ -1879,7 +1884,10 @@ func (m *configSubscriptionManager) Update(id string, sub *channel.Subscription)
 			m.cfg.Subscriptions[i].Name = sub.Name
 			m.cfg.Subscriptions[i].Provider = sub.Provider
 			m.cfg.Subscriptions[i].BaseURL = sub.BaseURL
-			m.cfg.Subscriptions[i].APIKey = sub.APIKey
+			// Never overwrite with a masked API key from server RPC.
+			if !strings.HasSuffix(sub.APIKey, "****") || len(sub.APIKey) > 20 {
+				m.cfg.Subscriptions[i].APIKey = sub.APIKey
+			}
 			m.cfg.Subscriptions[i].Model = sub.Model
 			// If modifying active subscription, sync cfg.LLM
 			if m.cfg.Subscriptions[i].Active {

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -889,6 +889,9 @@ func main() {
 			}
 			return nil
 		},
+		RefreshValuesCache: func() {
+			app.refreshRemoteValuesCache()
+		},
 		UsageQuery: func(senderID string, days int) (*sqlite.UserTokenUsage, []sqlite.DailyTokenUsage, error) {
 			if app.backend == nil {
 				return nil, nil, fmt.Errorf("agent not initialized")


### PR DESCRIPTION
## 根因

服务端 RPC 返回 Subscription 列表和默认订阅时，APIKey 被 mask（如 `sk-a****`）以避免明文传输。但客户端多个写回路径没有做防御，直接把 masked key 写回 DB，覆盖了真实 key。

## 受影响路径

1. **editQuickSwitchEntry** — 编辑订阅面板保存时，从 `List()` 拿到的 masked APIKey 直接写回
2. **updateActiveSubscription** — /settings 保存时，从 `GetDefaultSubscription()` 拿到的 sub 包含 masked key
3. **configSubscriptionManager.Update** — config.json 模式下直接写 masked key
4. **backend_local.UpdateSubscription** — 本地模式直接写 masked key（远程模式服务端已有防御）

## 修复

所有写回 APIKey 的路径增加防御：如果 APIKey 以 `****` 结尾且长度 <= 20，视为 masked，跳过不写。

这是纵深防御（defense-in-depth）——即使某个路径忘记处理，也不会破坏存储中的真实 key。