### PR TITLE
fix: subscription data corruption when switching active sub from settings panel

### DIFF
--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -82,6 +82,10 @@ var cliActionSettingKeys = map[string]struct{}{
 }
 
 var cliSubscriptionScopedSettingKeys = map[string]struct{}{
+	"llm_provider":      {},
+	"llm_api_key":       {},
+	"llm_base_url":      {},
+	"llm_model":         {},
 	"max_output_tokens": {},
 	"thinking_mode":     {},
 }

--- a/channel/cli_helpers_test.go
+++ b/channel/cli_helpers_test.go
@@ -21,6 +21,10 @@ func TestCLISettingScope_KnownKeys(t *testing.T) {
 		"theme":               "user",
 		"language":            "user",
 		"runner_server":       "user",
+		"llm_provider":        "subscription",
+		"llm_api_key":         "subscription",
+		"llm_base_url":        "subscription",
+		"llm_model":           "subscription",
 		"max_output_tokens":   "subscription",
 		"thinking_mode":       "subscription",
 		"default_user":        "global",
@@ -55,7 +59,7 @@ func TestCLISettingScope_SettingsSchemaKeysAreClassified(t *testing.T) {
 }
 
 func TestIsSubscriptionScopedSettingKey(t *testing.T) {
-	for _, key := range []string{"max_output_tokens", "thinking_mode"} {
+	for _, key := range []string{"llm_provider", "llm_api_key", "llm_base_url", "llm_model", "max_output_tokens", "thinking_mode"} {
 		if !isSubscriptionScopedSettingKey(key) {
 			t.Fatalf("expected %q to be subscription-scoped", key)
 		}

--- a/channel/cli_panel_test.go
+++ b/channel/cli_panel_test.go
@@ -199,7 +199,8 @@ func TestPanelBoxLeftAlign(t *testing.T) {
 }
 
 // TestSubscriptionGenerationGuard tests that stale per-subscription values
-// (max_output_tokens, thinking_mode) are NEVER written back after a subscription switch.
+// (provider, api_key, base_url, model, max_output_tokens, thinking_mode)
+// are NEVER written back after a subscription switch.
 // This is the structural guarantee against the subscription overwrite bug.
 func TestSubscriptionGenerationGuard(t *testing.T) {
 	model := newCLIModel()
@@ -210,6 +211,10 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 
 	// Simulate: user edits some values
 	values := map[string]string{
+		"llm_provider":      "openai",
+		"llm_api_key":       "sk-old-key",
+		"llm_base_url":      "https://old.example.com",
+		"llm_model":         "old-model",
 		"max_output_tokens": "8192",
 		"thinking_mode":     "auto",
 		"vanguard_model":    "claude-opus-4",
@@ -222,13 +227,15 @@ func TestSubscriptionGenerationGuard(t *testing.T) {
 	// Simulate: the onSubmit callback runs (this is what the guard checks)
 	// After switch, stale subscription-scoped fields should be stripped
 	if model.panelSubGeneration != model.subGeneration {
-		for _, k := range []string{"max_output_tokens", "thinking_mode"} {
-			delete(values, k)
+		for k := range values {
+			if isSubscriptionScopedSettingKey(k) {
+				delete(values, k)
+			}
 		}
 	}
 
 	// Verify: per-subscription fields are GONE
-	for _, k := range []string{"max_output_tokens", "thinking_mode"} {
+	for _, k := range []string{"llm_provider", "llm_api_key", "llm_base_url", "llm_model", "max_output_tokens", "thinking_mode"} {
 		if _, exists := values[k]; exists {
 			t.Errorf("BUG: stale subscription field %q should have been deleted after subscription switch", k)
 		}
@@ -251,19 +258,25 @@ func TestSubscriptionGenerationGuardNoSwitch(t *testing.T) {
 	model.panelSubGeneration = 5 // same generation = no switch
 
 	values := map[string]string{
+		"llm_provider":      "openai",
+		"llm_api_key":       "sk-test-key",
+		"llm_base_url":      "https://api.example.com",
+		"llm_model":         "gpt-4",
 		"max_output_tokens": "8192",
 		"thinking_mode":     "auto",
 	}
 
 	// Guard should NOT strip anything
 	if model.panelSubGeneration != model.subGeneration {
-		for _, k := range []string{"max_output_tokens", "thinking_mode"} {
-			delete(values, k)
+		for k := range values {
+			if isSubscriptionScopedSettingKey(k) {
+				delete(values, k)
+			}
 		}
 	}
 
 	// All fields should still be present
-	for _, k := range []string{"max_output_tokens", "thinking_mode"} {
+	for _, k := range []string{"llm_provider", "llm_api_key", "llm_base_url", "llm_model", "max_output_tokens", "thinking_mode"} {
 		if _, exists := values[k]; !exists {
 			t.Errorf("subscription field %q should NOT be deleted when subscription hasn't changed", k)
 		}

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -125,7 +125,7 @@ func saveCLIConfig(cfg *config.Config) error {
 
 func isCLISubscriptionSettingKey(key string) bool {
 	switch key {
-	case "max_output_tokens", "thinking_mode":
+	case "llm_provider", "llm_api_key", "llm_base_url", "llm_model", "max_output_tokens", "thinking_mode":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Bug

从 settings panel 打开 subscribe panel 切换 active subscription 后，新 sub 的数据被旧 sub 覆盖。

## 根因

`cliSubscriptionScopedSettingKeys` 只包含 `max_output_tokens` 和 `thinking_mode`，漏掉了 4 个核心 per-subscription 字段：`llm_provider`、`llm_api_key`、`llm_base_url`、`llm_model`。

导致两个防护机制同时失效：

1. **`openSettingsFromQuickSwitch`**（restore 阶段）：从 `panelValuesBackup`（旧 sub 数据）恢复非 subscription-scoped 字段时，LLM 4 字段被当作"全局字段"写回 → 旧 sub 的 provider/key/model/base_url 覆盖了新 sub 的值
2. **`onSubmit` 的 generation guard**（保存阶段）：检测到订阅切换后只删除 `max_output_tokens` 和 `thinking_mode` → LLM 4 字段带着旧值通过 → `updateActiveSubscription` 用旧 sub 的数据覆盖新 sub

## 修复

| 文件 | 修改 |
|------|------|
| `channel/cli_helpers.go` | `cliSubscriptionScopedSettingKeys` 补全 `llm_provider`/`llm_api_key`/`llm_base_url`/`llm_model` |
| `cmd/xbot-cli/main.go` | `isCLISubscriptionSettingKey` 同步补全（ApplySettings 的 skip 列表） |
| `channel/cli_helpers_test.go` + `channel/cli_panel_test.go` | 测试同步更新，覆盖全部 6 个 subscription-scoped key |
