### PR TITLE
fix: stream_options DeepSeek 400 error + RPC permission vulnerabilities

### DIFF
--- a/llm/openai.go
+++ b/llm/openai.go
@@ -551,7 +551,7 @@ func modelMaxOutputTokens(model string) int {
 	return 0
 }
 
-func (o *OpenAILLM) buildParams(model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string) openai.ChatCompletionNewParams {
+func (o *OpenAILLM) buildParams(model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string, stream bool) openai.ChatCompletionNewParams {
 	openaiMessages := toOpenAIMessages(messages, thinkingMode)
 
 	p := openai.ChatCompletionNewParams{
@@ -587,9 +587,12 @@ func (o *OpenAILLM) buildParams(model string, messages []ChatMessage, tools []To
 	if len(tools) > 0 {
 		p.Tools = toOpenAITools(tools)
 	}
-	// Match opencode's stream_options: {include_usage: true}
-	p.StreamOptions = openai.ChatCompletionStreamOptionsParam{
-		IncludeUsage: param.Opt[bool]{Value: true},
+	// Only set StreamOptions for streaming requests — some providers
+	// (e.g. DeepSeek) reject stream_options when stream=false.
+	if stream {
+		p.StreamOptions = openai.ChatCompletionStreamOptionsParam{
+			IncludeUsage: param.Opt[bool]{Value: true},
+		}
 	}
 	return p
 }
@@ -696,7 +699,7 @@ func (o *OpenAILLM) Generate(ctx context.Context, model string, messages []ChatM
 	}).Info("[LLM] Starting non-stream request")
 
 	startTime := time.Now()
-	params := o.buildParams(model, messages, tools, thinkingMode)
+	params := o.buildParams(model, messages, tools, thinkingMode, false)
 
 	// 构建 thinking mode 相关的 request options
 	opts := o.buildThinkingOptions(thinkingMode)
@@ -715,7 +718,7 @@ func (o *OpenAILLM) Generate(ctx context.Context, model string, messages []ChatM
 				o.maxTokensUpgrade.Delete(model)
 				log.Ctx(ctx).WithField("model", model).Info("[LLM] Model requires legacy max_tokens, retrying")
 			}
-			params = o.buildParams(model, messages, tools, thinkingMode)
+			params = o.buildParams(model, messages, tools, thinkingMode, false)
 			completion, err = o.client.Chat.Completions.New(ctx, params, opts...)
 		}
 	}
@@ -847,7 +850,7 @@ func (o *OpenAILLM) GenerateStream(ctx context.Context, model string, messages [
 }
 
 func (o *OpenAILLM) newStreamingWithRetry(ctx context.Context, model string, messages []ChatMessage, tools []ToolDefinition, thinkingMode string, opts []option.RequestOption) (*ssestream.Stream[openai.ChatCompletionChunk], error) {
-	params := o.buildParams(model, messages, tools, thinkingMode)
+	params := o.buildParams(model, messages, tools, thinkingMode, true)
 	stream := o.client.Chat.Completions.NewStreaming(ctx, params, opts...)
 	if err := stream.Err(); err != nil {
 		if verdict := isMaxTokensParamError(err); verdict != "" {
@@ -859,7 +862,7 @@ func (o *OpenAILLM) newStreamingWithRetry(ctx context.Context, model string, mes
 				log.Ctx(ctx).WithField("model", model).Info("[LLM] Stream: model requires legacy max_tokens, retrying")
 			}
 			stream.Close()
-			params = o.buildParams(model, messages, tools, thinkingMode)
+			params = o.buildParams(model, messages, tools, thinkingMode, true)
 			stream = o.client.Chat.Completions.NewStreaming(ctx, params, opts...)
 			if retryErr := stream.Err(); retryErr != nil {
 				stream.Close()

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -173,6 +173,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 	case "get_context_mode":
 		return json.Marshal(backend.GetContextMode())
 	case "set_context_mode":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("admin only")
+		}
 		var p struct {
 			Mode string `json:"mode"`
 		}
@@ -188,6 +191,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, err
+		}
+		if !isAdmin(senderID) && p.ChatID != "" && p.ChatID != bizID {
+			return nil, fmt.Errorf("access denied")
 		}
 		return nil, backend.SetCWD(p.Channel, p.ChatID, p.Dir)
 	case "get_settings":
@@ -250,6 +256,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 
 	// --- Max iterations / concurrency / context tokens ---
 	case "set_max_iterations":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("admin only")
+		}
 		var p struct {
 			N int `json:"n"`
 		}
@@ -259,6 +268,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		backend.SetMaxIterations(p.N)
 		return nil, nil
 	case "set_max_concurrency":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("admin only")
+		}
 		var p struct {
 			N int `json:"n"`
 		}
@@ -268,6 +280,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		backend.SetMaxConcurrency(p.N)
 		return nil, nil
 	case "set_max_context_tokens":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("admin only")
+		}
 		var p struct {
 			N int `json:"n"`
 		}
@@ -357,6 +372,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		return nil, backend.SetLLMConcurrency(bizID, p.Personal)
 	case "set_default_thinking_mode":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("admin only")
+		}
 		var p struct {
 			Mode string `json:"mode"`
 		}
@@ -581,6 +599,18 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, err
 		}
+		// Security: verify the caller owns this session (or is admin).
+		// full_key format: "channel:chatID/roleName[:instance]"
+		// Extract chatID (before '/') and verify it belongs to the caller.
+		{
+			keyParts := strings.SplitN(p.FullKey, ":", 2)
+			if len(keyParts) >= 2 {
+				chatIDPart := strings.SplitN(keyParts[1], "/", 2)[0]
+				if !isAdmin(senderID) && chatIDPart != bizID {
+					return nil, fmt.Errorf("access denied")
+				}
+			}
+		}
 		dump, _ := backend.GetAgentSessionDumpByFullKey(p.FullKey)
 		if dump == nil {
 			dump = &agent.AgentSessionDump{}
@@ -649,6 +679,19 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		if backend.BgTaskManager() == nil {
 			return nil, fmt.Errorf("background tasks not available")
 		}
+		// Security: verify the task belongs to the caller's session (or is admin).
+		if !isAdmin(senderID) {
+			if task, err := backend.BgTaskManager().Status(p.TaskID); err == nil {
+				sk := task.SessionKey()
+				skParts := strings.SplitN(sk, ":", 2)
+				if len(skParts) >= 2 {
+					skOwner := strings.SplitN(skParts[1], "/", 2)[0]
+					if skOwner != bizID {
+						return nil, fmt.Errorf("access denied")
+					}
+				}
+			}
+		}
 		return nil, backend.BgTaskManager().Kill(p.TaskID)
 	case "cleanup_completed_bg_tasks":
 		var p struct {
@@ -675,6 +718,16 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		tenants, err := tenantSvc.ListTenants()
 		if err != nil {
 			return nil, err
+		}
+		// Security: non-admin users only see their own sessions.
+		if !isAdmin(senderID) {
+			var userTenants []sqlite.TenantInfo
+			for _, t := range tenants {
+				if t.ChatID == bizID {
+					userTenants = append(userTenants, t)
+				}
+			}
+			tenants = userTenants
 		}
 		// Filter: skip agent tenants — they are internal bookkeeping for
 		// interactive SubAgent persistence and listed separately via
@@ -1024,6 +1077,9 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		return nil, nil
 
 	case "reset_token_state":
+		if !isAdmin(senderID) {
+			return nil, fmt.Errorf("admin only")
+		}
 		backend.ResetTokenState()
 		return nil, nil
 

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -601,14 +601,12 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		// Security: verify the caller owns this session (or is admin).
 		// full_key format: "channel:chatID/roleName[:instance]"
-		// Extract chatID (before '/') and verify it belongs to the caller.
-		{
-			keyParts := strings.SplitN(p.FullKey, ":", 2)
-			if len(keyParts) >= 2 {
-				chatIDPart := strings.SplitN(keyParts[1], "/", 2)[0]
-				if !isAdmin(senderID) && chatIDPart != bizID {
-					return nil, fmt.Errorf("access denied")
-				}
+		if p.FullKey == "" {
+			return nil, fmt.Errorf("full_key is required")
+		}
+		if owner := sessionKeyOwner(p.FullKey); owner != "" {
+			if !isAdmin(senderID) && owner != bizID {
+				return nil, fmt.Errorf("access denied")
 			}
 		}
 		dump, _ := backend.GetAgentSessionDumpByFullKey(p.FullKey)
@@ -625,6 +623,11 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, err
 		}
+		if !isAdmin(senderID) && p.SessionKey != "" {
+			if owner := sessionKeyOwner(p.SessionKey); owner != "" && owner != bizID {
+				return nil, fmt.Errorf("access denied")
+			}
+		}
 		if backend.BgTaskManager() == nil {
 			return json.Marshal(0)
 		}
@@ -635,6 +638,11 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, err
+		}
+		if !isAdmin(senderID) && p.SessionKey != "" {
+			if owner := sessionKeyOwner(p.SessionKey); owner != "" && owner != bizID {
+				return nil, fmt.Errorf("access denied")
+			}
 		}
 		if backend.BgTaskManager() == nil {
 			return json.Marshal([]struct{}{})
@@ -681,15 +689,12 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		// Security: verify the task belongs to the caller's session (or is admin).
 		if !isAdmin(senderID) {
-			if task, err := backend.BgTaskManager().Status(p.TaskID); err == nil {
-				sk := task.SessionKey()
-				skParts := strings.SplitN(sk, ":", 2)
-				if len(skParts) >= 2 {
-					skOwner := strings.SplitN(skParts[1], "/", 2)[0]
-					if skOwner != bizID {
-						return nil, fmt.Errorf("access denied")
-					}
-				}
+			task, err := backend.BgTaskManager().Status(p.TaskID)
+			if err != nil {
+				return nil, fmt.Errorf("access denied: task not found")
+			}
+			if owner := sessionKeyOwner(task.SessionKey()); owner != "" && owner != bizID {
+				return nil, fmt.Errorf("access denied")
 			}
 		}
 		return nil, backend.BgTaskManager().Kill(p.TaskID)
@@ -699,6 +704,11 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, err
+		}
+		if !isAdmin(senderID) && p.SessionKey != "" {
+			if owner := sessionKeyOwner(p.SessionKey); owner != "" && owner != bizID {
+				return nil, fmt.Errorf("access denied")
+			}
 		}
 		if backend.BgTaskManager() != nil {
 			backend.BgTaskManager().RemoveCompletedTasks(p.SessionKey)
@@ -2569,6 +2579,17 @@ const cliSenderID = "cli_user"
 // isAdmin checks if the given WS auth senderID has admin privileges.
 // Admin is a ROLE (authorization), not a business identity.
 func isAdmin(authSenderID string) bool { return authSenderID == adminSenderID }
+
+// sessionKeyOwner extracts the chatID (owner) from a session/full key.
+// Key format: "channel:chatID/roleName[:instance]"
+// Returns empty string if the format is invalid.
+func sessionKeyOwner(key string) string {
+	parts := strings.SplitN(key, ":", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.SplitN(parts[1], "/", 2)[0]
+}
 
 // senderIDFromParams extracts the business sender_id from RPC params.
 // For admin users (WS auth identity "admin"), if params don't specify a sender_id,

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -509,10 +509,13 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, err
 		}
-		// Empty chatID = list all for this channel (cross-session).
+		// Empty chatID = list all for this channel (cross-session, admin only).
 		// Non-admin with specific chatID must own it.
 		if !isAdmin(senderID) && p.ChatID != "" && p.ChatID != bizID {
 			return nil, fmt.Errorf("access denied")
+		}
+		if !isAdmin(senderID) && p.ChatID == "" {
+			p.ChatID = bizID
 		}
 		return json.Marshal(backend.CountInteractiveSessions(p.Channel, p.ChatID))
 	case "list_interactive_sessions":
@@ -525,6 +528,11 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		}
 		if !isAdmin(senderID) && p.ChatID != "" && p.ChatID != bizID {
 			return nil, fmt.Errorf("access denied")
+		}
+		// Non-admin with empty chatID: restrict to their own sessions only.
+		// Admin sees all (cross-session listing for CLI session panel).
+		if !isAdmin(senderID) && p.ChatID == "" {
+			p.ChatID = bizID
 		}
 		return json.Marshal(backend.ListInteractiveSessions(p.Channel, p.ChatID))
 	case "inspect_interactive_session":
@@ -730,6 +738,10 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 			return nil, err
 		}
 		// Security: non-admin users only see their own sessions.
+		// CLI users are always admin (isAdmin bypass), so this filter never
+		// fires for CLI — they see all tenants and their SubAgent sessions.
+		// SubAgent sessions are listed separately via ListInteractiveSessions,
+		// which also restricts non-admin to their own chatID.
 		if !isAdmin(senderID) {
 			var userTenants []sqlite.TenantInfo
 			for _, t := range tenants {


### PR DESCRIPTION
## Summary

Two bug fixes in a single PR:

### 1. Fix stream_options causing DeepSeek 400 error on non-streaming requests
- `llm/openai.go`: `buildParams()` unconditionally set `StreamOptions` even when `stream=false`
- DeepSeek API rejects `stream_options` parameter on non-streaming requests with 400
- Added `stream bool` parameter to `buildParams()`, only set `StreamOptions` when `stream=true`
- Updated all 4 call sites (2 in `Generate()`, 2 in `newStreamingWithRetry()`)

### 2. Fix RPC permission vulnerabilities in serverapp/server.go

**Critical:**
- `get_agent_session_dump_by_full_key`: any authenticated user could read arbitrary agent sessions by constructing a `full_key`. Added owner check by parsing `chatID` from the key.

**Medium (admin-only checks added):**
- `set_context_mode`, `set_max_iterations`, `set_max_concurrency`, `set_max_context_tokens`, `set_default_thinking_mode`, `reset_token_state`: these global operations now require admin

**Medium (owner checks added):**
- `set_cwd`: non-admin users can only set CWD for their own session
- `kill_bg_task`: non-admin users can only kill tasks belonging to their session
- `list_tenants`: non-admin users only see their own sessions

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` all green
- [ ] Manual test: DeepSeek non-streaming requests no longer return 400
- [ ] Manual test: non-admin user cannot access other users sessions via RPC