### PR TITLE
fix: model tab form structure causes silent card rejection

### DIFF
--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -1143,7 +1143,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		"content": fmt.Sprintf("**最大上下文 (k)**　当前: %s", maxContextDisplay),
 	})
 	elements = append(elements, map[string]any{
-		"tag": "form",
+		"tag":  "form",
 		"name": "max_context_form",
 		"elements": []map[string]any{
 			{
@@ -1180,7 +1180,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		"content": fmt.Sprintf("**最大输出 Token (k)**　当前: %s", maxOutputDisplay),
 	})
 	elements = append(elements, map[string]any{
-		"tag": "form",
+		"tag":  "form",
 		"name": "max_output_form",
 		"elements": []map[string]any{
 			{

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -1144,7 +1144,8 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 	})
 	elements = append(elements, map[string]any{
 		"tag": "form",
-		"name": []map[string]any{
+		"name": "max_context_form",
+		"elements": []map[string]any{
 			{
 				"tag":           "input",
 				"name":          "max_context_k",
@@ -1180,7 +1181,8 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 	})
 	elements = append(elements, map[string]any{
 		"tag": "form",
-		"name": []map[string]any{
+		"name": "max_output_form",
+		"elements": []map[string]any{
 			{
 				"tag":           "input",
 				"name":          "max_output_k",


### PR DESCRIPTION
## Bug
飞书设置中模型 tab 点击无反应、无报错、无日志。

## Root Cause
`buildModelTabContent` 中 max_context 和 max_output_tokens 的 `form` 元素结构错误：

```go
// 错误: name 设为 input 数组，elements 缺失
{"tag": "form", "name": [{"tag": "input", "name": "max_context_k", ...}]}

// 正确: name 为字符串，input 放在 elements 里
{"tag": "form", "name": "max_context_form", "elements": [{"tag": "input", "name": "max_context_k", ...}]}
```

飞书 card form 规范要求 `name` 是 form 的标识字符串，`elements` 才是输入控件数组。当 `name` 收到数组时，飞书静默拒绝渲染该卡片，导致点击 tab 后无任何响应。

## Fix
将两个 form 的 `"name"` 从 `[]map` 改为字符串标识符，并将输入控件移到 `"elements"` 键下。

| Form | name (before) | name (after) | elements (after) |
|------|---------------|--------------|------------------|
| max_context | `[]map{input...}` | `"max_context_form"` | `[]map{input...}` |
| max_output | `[]map{input...}` | `"max_output_form"` | `[]map{input...}` |