### PR TITLE
fix: improve queue edit recall and cancel UX

### DIFF
--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -156,14 +156,17 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 			m.queueEditBuf = ""
 			m.textarea.SetValue("")
 		}
-		// 3. 如果 agent 正在处理：清空队列 + 发送取消
+		// 3. 如果 agent 正在处理：
+		//    - 有排队消息：只清空队列，不发 cancel（需要再按一次 Ctrl+C 才 cancel）
+		//    - 无排队消息：发送 cancel
 		if m.typing {
 			queueLen := len(m.messageQueue)
 			if queueLen > 0 {
 				m.messageQueue = nil
 				m.showSystemMsg(fmt.Sprintf(m.locale.QueueCleared, queueLen), feedbackInfo)
+			} else {
+				m.sendCancel()
 			}
-			m.sendCancel()
 			return m, nil
 		}
 		// 4. 空闲状态：清空输入

--- a/channel/cli_update_handlers.go
+++ b/channel/cli_update_handlers.go
@@ -112,19 +112,15 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			return m, nil, true
 		}
 
-	case msg.Code == tea.KeyUp:
-		// If textarea has content, let textarea own multiline vertical cursor movement.
-		// Otherwise long pasted input cannot navigate back to earlier lines because
-		// viewport/history steals Up before textarea sees it.
+	case msg.Code == tea.KeyUp && msg.Mod == tea.ModShift:
+		// Shift+Up: recall queued message for editing / browse input history.
 		if m.panelMode == "" && m.textarea.Value() != "" {
-			break
-		}
-		// Viewport 不在底部时，方向键优先滚动 viewport（不触发 input history）
-		if !m.viewport.AtBottom() {
-			m.viewport.ScrollUp(1)
 			return m, nil, true
 		}
-		// §Q 消息队列：typing 时 ↑ 追回最后一条排队消息编辑
+		if !m.viewport.AtBottom() {
+			return m, nil, true
+		}
+		// §Q 消息队列：typing 时 Shift+↑ 追回最后一条排队消息编辑
 		if m.panelMode == "" && m.typing && !m.inputReady && len(m.messageQueue) > 0 {
 			if !m.queueEditing && m.textarea.Value() == "" {
 				// 追回最后一条排队消息
@@ -136,8 +132,8 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			}
 		}
 		if m.panelMode == "" && !m.typing {
-			// 空输入时浏览历史：仅当有排队消息时才启用，避免误触覆盖输入。
-			if len(m.messageQueue) > 0 && m.textarea.Value() == "" && len(m.inputHistory) > 0 {
+			// 空输入时浏览历史
+			if m.textarea.Value() == "" && len(m.inputHistory) > 0 {
 				if m.inputHistoryIdx == -1 {
 					m.inputDraft = "" // 保存空草稿
 					m.inputHistoryIdx = 0
@@ -150,17 +146,27 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 			}
 		}
 
-	case msg.Code == tea.KeyDown:
+	case msg.Code == tea.KeyUp:
+		// Plain ArrowUp: only viewport scroll (no queue recall / history).
 		// If textarea has content, let textarea own multiline vertical cursor movement.
 		if m.panelMode == "" && m.textarea.Value() != "" {
 			break
 		}
-		// Viewport 不在底部时，方向键优先滚动 viewport
+		// Viewport 不在底部时，方向键滚动 viewport
 		if !m.viewport.AtBottom() {
-			m.viewport.ScrollDown(1)
+			m.viewport.ScrollUp(1)
 			return m, nil, true
 		}
-		if m.panelMode == "" && !m.typing && m.inputHistoryIdx >= 0 && len(m.messageQueue) > 0 {
+
+	case msg.Code == tea.KeyDown && msg.Mod == tea.ModShift:
+		// Shift+Down: browse input history backwards.
+		if m.panelMode == "" && m.textarea.Value() != "" {
+			return m, nil, true
+		}
+		if !m.viewport.AtBottom() {
+			return m, nil, true
+		}
+		if m.panelMode == "" && !m.typing && m.inputHistoryIdx >= 0 {
 			if m.inputHistoryIdx > 0 {
 				m.inputHistoryIdx--
 				m.textarea.SetValue(m.inputHistory[m.inputHistoryIdx])
@@ -169,6 +175,16 @@ func (m *cliModel) handleKeyPress(msg tea.KeyPressMsg, wasTyping bool) (tea.Mode
 				m.textarea.SetValue(m.inputDraft)
 			}
 			m.autoExpandInput()
+			return m, nil, true
+		}
+
+	case msg.Code == tea.KeyDown:
+		// Plain ArrowDown: only viewport scroll.
+		if m.panelMode == "" && m.textarea.Value() != "" {
+			break
+		}
+		if !m.viewport.AtBottom() {
+			m.viewport.ScrollDown(1)
 			return m, nil, true
 		}
 

--- a/channel/feishu_settings.go
+++ b/channel/feishu_settings.go
@@ -1106,9 +1106,10 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 			})
 		}
 
-		elements = append(elements, buildSettingRow(
-			"当前模型",
+		elements = append(elements, buildSelectFormRow(
+			"**当前模型**",
 			currentModel,
+			"model_select_form",
 			map[string]any{
 				"tag":            "select_static",
 				"name":           "settings_model_select",
@@ -1121,7 +1122,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 					}),
 				},
 			},
-		))
+		)...)
 	}
 
 	// Max context setting (unit: k, stored as k*1000)
@@ -1153,11 +1154,18 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 				"placeholder":   map[string]any{"tag": "plain_text", "content": "如 400 = 400k"},
 				"initial_value": maxCtxInitial,
 			},
-		},
-		"value": map[string]string{
-			"action_data": mustMapToJSON(map[string]string{
-				"action": "settings_set_max_context",
-			}),
+			{
+				"tag":         "button",
+				"name":        "max_context_submit",
+				"text":        map[string]any{"tag": "plain_text", "content": "保存"},
+				"type":        "primary",
+				"action_type": "form_submit",
+				"value": map[string]string{
+					"action_data": mustMapToJSON(map[string]string{
+						"action": "settings_set_max_context",
+					}),
+				},
+			},
 		},
 	})
 
@@ -1190,11 +1198,18 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 				"placeholder":   map[string]any{"tag": "plain_text", "content": "如 16 = 16k，0 = 默认"},
 				"initial_value": maxOutInitial,
 			},
-		},
-		"value": map[string]string{
-			"action_data": mustMapToJSON(map[string]string{
-				"action": "settings_set_max_output_tokens",
-			}),
+			{
+				"tag":         "button",
+				"name":        "max_output_submit",
+				"text":        map[string]any{"tag": "plain_text", "content": "保存"},
+				"type":        "primary",
+				"action_type": "form_submit",
+				"value": map[string]string{
+					"action_data": mustMapToJSON(map[string]string{
+						"action": "settings_set_max_output_tokens",
+					}),
+				},
+			},
 		},
 	})
 
@@ -1219,9 +1234,10 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		"tag":     "markdown",
 		"content": "**个人 LLM 并发限制**",
 	})
-	elements = append(elements, buildSettingRow(
+	elements = append(elements, buildSelectFormRow(
 		"并发上限",
 		fmt.Sprintf("%d", personalConc),
+		"concurrency_form",
 		map[string]any{
 			"tag":            "select_static",
 			"name":           "settings_llm_conc_personal",
@@ -1234,7 +1250,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 				}),
 			},
 		},
-	))
+	)...)
 
 	// Thinking mode setting
 	currentThinkingMode := ""
@@ -1246,9 +1262,10 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		thinkingModeDisplay = thinkingModeLabel(currentThinkingMode)
 	}
 
-	elements = append(elements, buildSettingRow(
+	elements = append(elements, buildSelectFormRow(
 		"思考模式",
 		thinkingModeDisplay,
+		"thinking_mode_form",
 		map[string]any{
 			"tag":            "select_static",
 			"name":           "settings_thinking_mode_select",
@@ -1261,7 +1278,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 				}),
 			},
 		},
-	))
+	)...)
 
 	// --- Model tier section ---
 	elements = append(elements, map[string]any{"tag": "hr"})
@@ -1315,9 +1332,10 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 		}
 		// Always render — even with only one option (the current value).
 		// Previously the section was entirely hidden when allModels was empty.
-		elements = append(elements, buildSettingRow(
+		elements = append(elements, buildSelectFormRow(
 			tier.label,
 			tierDisplay,
+			"tier_"+tier.key+"_form",
 			map[string]any{
 				"tag":            "select_static",
 				"name":           "settings_tier_" + tier.key + "_select",
@@ -1331,7 +1349,7 @@ func (f *FeishuChannel) buildModelTabContent(ctx context.Context, senderID strin
 					}),
 				},
 			},
-		))
+		)...)
 	}
 
 	// --- Subscription management section ---
@@ -1965,37 +1983,24 @@ func parsePageOpts(parsed map[string]string) SettingsCardOpts {
 
 // --- Layout helpers ---
 
-func buildSettingRow(label, currentDisplay string, control map[string]any) map[string]any {
+// buildSelectFormRow wraps a select_static component inside a form so that
+// Feishu card callbacks work correctly. select_static MUST be inside a form
+// to trigger callbacks — placing it in column_set silently breaks interaction.
+// The label is rendered as a markdown element before the form.
+func buildSelectFormRow(label, currentDisplay, formName string, selectControl map[string]any) []map[string]any {
 	leftContent := label
 	if currentDisplay != "" {
 		leftContent = fmt.Sprintf("%s　**%s**", label, currentDisplay)
 	}
-	return map[string]any{
-		"tag":                "column_set",
-		"flex_mode":          "none",
-		"horizontal_spacing": "default",
-		"columns": []map[string]any{
-			{
-				"tag":            "column",
-				"width":          "weighted",
-				"weight":         1,
-				"vertical_align": "center",
-				"elements": []map[string]any{
-					{
-						"tag":     "markdown",
-						"content": leftContent,
-					},
-				},
-			},
-			{
-				"tag":            "column",
-				"width":          "weighted",
-				"weight":         1,
-				"vertical_align": "center",
-				"elements": []map[string]any{
-					control,
-				},
-			},
+	return []map[string]any{
+		{
+			"tag":     "markdown",
+			"content": leftContent,
+		},
+		{
+			"tag":      "form",
+			"name":     formName,
+			"elements": []map[string]any{selectControl},
 		},
 	}
 }


### PR DESCRIPTION
## Changes

### 1. 追回编辑和历史浏览改用 Shift+方向键
- **Shift+Up**：追回排队消息编辑（typing 时）/ 浏览输入历史（idle 时）
- **Shift+Down**：反向浏览输入历史
- **ArrowUp/Down**：只滚动 viewport，不再触发追回/历史，防止误触

### 2. Ctrl+C 取消逻辑分步化
- typing 时有排队消息：第一次 Ctrl+C 只清空队列，不发 cancel
- 第二次 Ctrl+C（队列已空）：才发送 cancel
- 之前一个 Ctrl+C 同时清空队列 + 发 cancel，容易误操作

### 3. 输入历史浏览不再依赖排队消息
- 去掉了 \`len(m.messageQueue) > 0\` 条件限制
- idle 时 Shift+Up/Down 随时可以浏览历史

## Files
- `channel/cli_update_handlers.go` — Shift+Up/Down 替代 ArrowUp/Down
- `channel/cli_update.go` — Ctrl+C 分步取消逻辑