### PR TITLE
feat: context display, /compress always allowed, web UI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ cmd-output-*.md
 mermaid-ascii
 ultraviolet
 .VSCodeCounter/
+.config/

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -939,12 +939,6 @@ func (a *Agent) getGlobalSem() chan struct{} {
 	return a.globalSem
 }
 
-func (a *Agent) getMaxContextTokens() int {
-	a.contextManagerMu.RLock()
-	defer a.contextManagerMu.RUnlock()
-	return a.contextManagerConfig.MaxContextTokens
-}
-
 // SetSandbox replaces the sandbox instance and mode at runtime (e.g. when user
 // switches from docker to none in the settings panel).
 func (a *Agent) SetSandbox(sb tools.Sandbox, mode string) {

--- a/agent/compress.go
+++ b/agent/compress.go
@@ -240,14 +240,7 @@ func (a *Agent) handleCompress(ctx context.Context, msg bus.InboundMessage, tena
 		log.Ctx(ctx).WithError(err).Warn("Failed to count tokens for compression")
 	}
 
-	threshold := int(float64(a.getMaxContextTokens()) * a.contextManagerConfig.CompressionThreshold)
-	if err == nil && tokenCount < threshold {
-		return &bus.OutboundMessage{
-			Channel: msg.Channel,
-			ChatID:  msg.ChatID,
-			Content: fmt.Sprintf("当前上下文 token 数 (%d) 未达到压缩阈值 (%d)，无需压缩。", tokenCount, threshold),
-		}, nil
-	}
+	// Always allow manual /compress regardless of threshold — user explicitly requested it.
 
 	_ = a.sendMessage(msg.Channel, msg.ChatID, "🔄 开始压缩上下文...")
 

--- a/channel/web.go
+++ b/channel/web.go
@@ -811,6 +811,7 @@ func (wc *WebChannel) Start() error {
 	mux.HandleFunc("/api/chats", wc.authMiddleware(wc.handleChats))
 	mux.HandleFunc("/api/chats/{chatID}/switch", wc.authMiddleware(wc.handleChatSwitch))
 	mux.HandleFunc("/api/chats/{chatID}", wc.authMiddleware(wc.handleChatDelete))
+	mux.HandleFunc("/api/context-info", wc.authMiddleware(wc.handleContextInfo))
 
 	// Static files
 	if wc.staticDir != "" {

--- a/channel/web_api.go
+++ b/channel/web_api.go
@@ -81,10 +81,13 @@ func (wc *WebChannel) handleHistory(w http.ResponseWriter, r *http.Request) {
 // handleHistoryGet returns the message history for the current user.
 func (wc *WebChannel) handleHistoryGet(w http.ResponseWriter, r *http.Request, senderID string) {
 
+	// Use the currently active chatID (respects chat switching)
+	chatID := wc.getCurrentChatID(senderID)
+
 	// Find tenant ID for this web user
 	var tenantID int64
 	err := wc.db.QueryRow(
-		"SELECT id FROM tenants WHERE channel = 'web' AND chat_id = ?", senderID,
+		"SELECT id FROM tenants WHERE channel = 'web' AND chat_id = ?", chatID,
 	).Scan(&tenantID)
 	if err != nil {
 		// No tenant yet = no history
@@ -1489,6 +1492,69 @@ func (wc *WebChannel) handleChatDelete(w http.ResponseWriter, r *http.Request) {
 	wc.userCurrentChatMu.Unlock()
 
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleContextInfo handles GET /api/context-info — returns structured token usage data.
+func (wc *WebChannel) handleContextInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonErrorResponse(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	senderID := senderIDFromContext(r.Context())
+	if senderID == "" {
+		jsonErrorResponse(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	// Use the currently active chatID (respects chat switching)
+	chatID := wc.getCurrentChatID(senderID)
+
+	// Find tenant ID for this web user
+	var tenantID int64
+	err := wc.db.QueryRow(
+		"SELECT id FROM tenants WHERE channel = 'web' AND chat_id = ?", chatID,
+	).Scan(&tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"ok":            true,
+			"prompt_tokens": 0,
+			"max_tokens":    0,
+			"usage_pct":     0,
+			"source":        "none",
+		})
+		return
+	}
+
+	// Get persisted token state (from last LLM API response)
+	var promptTokens int64
+	wc.db.QueryRow(
+		"SELECT COALESCE(last_prompt_tokens, 0) FROM tenant_state WHERE tenant_id = ?",
+		tenantID,
+	).Scan(&promptTokens)
+
+	// Get max context tokens from user config
+	maxTokens := 0
+	if wc.callbacks.LLMGetMaxContext != nil {
+		maxTokens = wc.callbacks.LLMGetMaxContext(senderID)
+	}
+
+	usagePct := float64(0)
+	if maxTokens > 0 && promptTokens > 0 {
+		usagePct = float64(promptTokens) / float64(maxTokens) * 100
+	}
+
+	source := "none"
+	if promptTokens > 0 {
+		source = "api" // Always API since we persist from LLM responses
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":            true,
+		"prompt_tokens": promptTokens,
+		"max_tokens":    maxTokens,
+		"usage_pct":     usagePct,
+		"source":        source,
+	})
 }
 
 // getCurrentChatID returns the currently active chatID for a user.

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -370,6 +370,41 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
       .catch(() => {})
   }, [])
 
+  const wsRef = useRef<WebSocket | null>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const reconnectDelayRef = useRef(1000)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const serverStopped = useRef(false)
+  const intentionalClose = useRef(false)
+
+  // --- Scroll management ---
+  const isNearBottom = useCallback(() => {
+    const el = messagesContainerRef.current
+    if (!el) return true
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= 150
+  }, [])
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'instant') => {
+    const el = messagesContainerRef.current
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight, behavior })
+  }, [])
+
+  const handleContainerScroll = useCallback(() => {
+    setAutoScroll(isNearBottom())
+  }, [isNearBottom])
+
+  // Auto-scroll during streaming/progress updates — throttled to avoid layout thrashing.
+  // Only follows when user is already at the bottom (autoScroll=true).
+  const scrollRafRef = useRef<number>(0)
+  useEffect(() => {
+    if (!autoScroll) return
+    if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
+    scrollRafRef.current = requestAnimationFrame(() => scrollToBottom('instant'))
+    return () => { if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current) }
+  }, [messages, progress, autoScroll, scrollToBottom])
+
   // --- Fetch context info ---
   const fetchContextInfo = useCallback(() => {
     fetch('/api/context-info')
@@ -530,42 +565,6 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [searchOpen])
-
-  const wsRef = useRef<WebSocket | null>(null)
-  const messagesContainerRef = useRef<HTMLDivElement>(null)
-  const messagesEndRef = useRef<HTMLDivElement>(null)
-  const reconnectDelayRef = useRef(1000)
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const serverStopped = useRef(false)
-  const intentionalClose = useRef(false)
-
-
-  // --- Scroll management ---
-  const isNearBottom = useCallback(() => {
-    const el = messagesContainerRef.current
-    if (!el) return true
-    return el.scrollHeight - el.scrollTop - el.clientHeight <= 150
-  }, [])
-
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'instant') => {
-    const el = messagesContainerRef.current
-    if (!el) return
-    el.scrollTo({ top: el.scrollHeight, behavior })
-  }, [])
-
-  const handleContainerScroll = useCallback(() => {
-    setAutoScroll(isNearBottom())
-  }, [isNearBottom])
-
-  // Auto-scroll during streaming/progress updates — throttled to avoid layout thrashing.
-  // Only follows when user is already at the bottom (autoScroll=true).
-  const scrollRafRef = useRef<number>(0)
-  useEffect(() => {
-    if (!autoScroll) return
-    if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
-    scrollRafRef.current = requestAnimationFrame(() => scrollToBottom('instant'))
-    return () => { if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current) }
-  }, [messages, progress, autoScroll, scrollToBottom])
 
   // --- WebSocket connection with reconnect ---
   const connectWS = useCallback(() => {

--- a/web/src/ChatPage.tsx
+++ b/web/src/ChatPage.tsx
@@ -322,6 +322,8 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
   const [currentModel, setCurrentModel] = useState('')
   const [availableModels, setAvailableModels] = useState<string[]>([])
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false)
+  const [currentChatID, setCurrentChatID] = useState<string>('')
+  const [contextInfo, setContextInfo] = useState<{ prompt_tokens: number; max_tokens: number; usage_pct: number; source: string } | null>(null)
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState<Array<{ id: number; role: string; snippet: string; created_at: string }>>([])
@@ -367,6 +369,117 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
       })
       .catch(() => {})
   }, [])
+
+  // --- Fetch context info ---
+  const fetchContextInfo = useCallback(() => {
+    fetch('/api/context-info')
+      .then(r => r.json())
+      .then(data => {
+        if (data.ok) {
+          setContextInfo({
+            prompt_tokens: data.prompt_tokens || 0,
+            max_tokens: data.max_tokens || 0,
+            usage_pct: data.usage_pct || 0,
+            source: data.source || 'none',
+          })
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  // --- Load history (extracted for reuse on chat switch) ---
+  const loadHistory = useCallback(() => {
+    fetch('/api/history')
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.ok && data.messages) {
+          const hist: Message[] = data.messages
+            .filter((m: { role: string; content?: string; tool_calls?: string; detail?: string; display_only?: number }) => {
+              if (m.role === 'tool') return false
+              if (m.role === 'assistant' && m.tool_calls && !m.detail) return false
+              if (m.role === 'assistant' && m.display_only && !m.content && !m.detail) return false
+              return true
+            })
+            .map((m: { id: number; role: string; content: string; detail?: string; created_at?: string }) => {
+              const msg: Message = {
+                id: `hist-${m.id}`,
+                type: m.role === 'user' ? 'user' : m.role === 'assistant' ? 'assistant' : 'system',
+                content: m.content,
+                ts: m.created_at ? Math.floor(new Date(m.created_at).getTime() / 1000) : undefined,
+              }
+              if (m.detail) {
+                try {
+                  msg.iterationHistory = normalizeIterationHistory(JSON.parse(m.detail))
+                } catch { /* ignore */ }
+              }
+              return msg
+            })
+          setMessages(hist)
+          const isProcessing = data.processing === true
+          const lastIsUser = hist.length > 0 && hist[hist.length - 1].type === 'user'
+          if (isProcessing && lastIsUser) {
+            setLoading(true)
+          }
+          if (isProcessing && data.active_progress) {
+            const ap = data.active_progress
+            progressRef.current = {
+              phase: ap.phase || 'running',
+              iteration: ap.iteration || 0,
+              thinking: ap.thinking || '',
+              active_tools: (ap.active_tools || []).map((t: { name: string; label: string; status: string; summary: string }) => ({
+                name: t.name, label: t.label, status: t.status, summary: t.summary,
+              })),
+              completed_tools: (ap.completed_tools || []).map((t: { name: string; label: string; status: string; summary: string }) => ({
+                name: t.name, label: t.label, status: t.status, summary: t.summary,
+              })),
+            }
+            prevIterationRef.current = ap.iteration || 0
+            if (ap.thinking) {
+              reasoningRef.current = ap.thinking
+            }
+            setProgress(progressRef.current)
+            if (ap.stream_content) {
+              streamingContentRef.current = ap.stream_content
+              setMessages(prev => [...prev, {
+                id: '__streaming__',
+                type: 'assistant' as const,
+                content: ap.stream_content,
+              }])
+            }
+            if (ap.iteration_history && ap.iteration_history.length > 0) {
+              const restoredIterations: IterationSnapshot[] = ap.iteration_history.map(
+                (iter: { iteration: number; thinking?: string; reasoning?: string; completed_tools?: { name: string; label?: string; status: string; summary?: string }[] }) => ({
+                  iteration: iter.iteration,
+                  thinking: iter.thinking || '',
+                  reasoning: iter.reasoning || '',
+                  tools: (iter.completed_tools || []).map(t => ({
+                    name: t.name,
+                    label: t.label,
+                    status: t.status,
+                    summary: t.summary,
+                  })),
+                })
+              )
+              setLiveIterationsSync(restoredIterations)
+            }
+          }
+          if (data.last_seq) {
+            lastSeqRef.current = data.last_seq
+          }
+          setTimeout(() => {
+            scrollToBottom('instant')
+            requestAnimationFrame(() => scrollToBottom('instant'))
+          }, 100)
+        }
+      })
+      .catch(() => {})
+    fetchContextInfo()
+  }, [scrollToBottom, fetchContextInfo])
+
+  // --- Load history on mount ---
+  useEffect(() => {
+    loadHistory()
+  }, [loadHistory])
 
   // --- Search: debounce 300ms ---
   useEffect(() => {
@@ -444,120 +557,15 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
     setAutoScroll(isNearBottom())
   }, [isNearBottom])
 
-  // Auto-scroll during streaming/progress updates — instant, no animation.
+  // Auto-scroll during streaming/progress updates — throttled to avoid layout thrashing.
   // Only follows when user is already at the bottom (autoScroll=true).
+  const scrollRafRef = useRef<number>(0)
   useEffect(() => {
-    if (autoScroll) {
-      scrollToBottom('instant')
-    }
+    if (!autoScroll) return
+    if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
+    scrollRafRef.current = requestAnimationFrame(() => scrollToBottom('instant'))
+    return () => { if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current) }
   }, [messages, progress, autoScroll, scrollToBottom])
-
-  // --- Load history on mount ---
-  useEffect(() => {
-    fetch('/api/history')
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.ok && data.messages) {
-          const hist: Message[] = data.messages
-            .filter((m: { role: string; content?: string; tool_calls?: string; detail?: string; display_only?: number }) => {
-              if (m.role === 'tool') return false
-              // Skip intermediate assistant(tool_calls) messages that have no detail.
-              // These were saved for LLM context continuity; the final assistant message's
-              // detail field contains the full iteration history that covers these.
-              if (m.role === 'assistant' && m.tool_calls && !m.detail) return false
-              // Skip display-only assistant messages without content (cancelled placeholders)
-              // when there's no iteration history to show.
-              if (m.role === 'assistant' && m.display_only && !m.content && !m.detail) return false
-              return true
-            })
-            .map((m: { id: number; role: string; content: string; detail?: string; created_at?: string }) => {
-              const msg: Message = {
-                id: `hist-${m.id}`,
-                type: m.role === 'user' ? 'user' : m.role === 'assistant' ? 'assistant' : 'system',
-                content: m.content,
-                ts: m.created_at ? Math.floor(new Date(m.created_at).getTime() / 1000) : undefined,
-              }
-              // Parse iteration history from detail field
-              if (m.detail) {
-                try {
-                  msg.iterationHistory = normalizeIterationHistory(JSON.parse(m.detail))
-                } catch {
-                  // ignore parse errors
-                }
-              }
-              return msg
-            })
-          setMessages(hist)
-          // If the backend reports it's actively processing, set loading.
-          // Also check if the last message is from the user (legacy detection).
-          const isProcessing = data.processing === true
-          const lastIsUser = hist.length > 0 && hist[hist.length - 1].type === 'user'
-          if (isProcessing && lastIsUser) {
-            setLoading(true)
-          }
-          // Restore active progress from server (mid-session refresh recovery).
-          // This allows the frontend to immediately show iteration state and
-          // streaming content without waiting for WS reconnect.
-          if (isProcessing && data.active_progress) {
-            const ap = data.active_progress
-            progressRef.current = {
-              phase: ap.phase || 'running',
-              iteration: ap.iteration || 0,
-              thinking: ap.thinking || '',
-              active_tools: (ap.active_tools || []).map((t: { name: string; label: string; status: string; summary: string }) => ({
-                name: t.name, label: t.label, status: t.status, summary: t.summary,
-              })),
-              completed_tools: (ap.completed_tools || []).map((t: { name: string; label: string; status: string; summary: string }) => ({
-                name: t.name, label: t.label, status: t.status, summary: t.summary,
-              })),
-            }
-            prevIterationRef.current = ap.iteration || 0
-            if (ap.thinking) {
-              reasoningRef.current = ap.thinking
-            }
-            setProgress(progressRef.current)
-            // If there's stream content, create/update a streaming message
-            if (ap.stream_content) {
-              streamingContentRef.current = ap.stream_content
-              setMessages(prev => [...prev, {
-                id: '__streaming__',
-                type: 'assistant' as const,
-                content: ap.stream_content,
-              }])
-            }
-            // Restore iteration history (completed iterations 1..N-1)
-            if (ap.iteration_history && ap.iteration_history.length > 0) {
-              const restoredIterations: IterationSnapshot[] = ap.iteration_history.map(
-	                (iter: { iteration: number; thinking?: string; reasoning?: string; completed_tools?: { name: string; label?: string; status: string; summary?: string }[] }) => ({
-	                  iteration: iter.iteration,
-	                  thinking: iter.thinking || '',
-	                  reasoning: iter.reasoning || '',
-	                  tools: (iter.completed_tools || []).map(t => ({
-	                    name: t.name,
-	                    label: t.label,
-	                    status: t.status,
-	                    summary: t.summary,
-	                  })),
-	                })
-	              )
-              setLiveIterationsSync(restoredIterations)
-            }
-          }
-          // Store last_seq for WS sync handshake
-          if (data.last_seq) {
-            lastSeqRef.current = data.last_seq
-          }
-          // Scroll to bottom after initial history load.
-          // Two-phase: first instant scroll after DOM settles, then a re-scroll
-          // after one frame to catch any lazy-loaded content that expanded.
-          setTimeout(() => {
-            scrollToBottom('instant')
-            requestAnimationFrame(() => scrollToBottom('instant'))
-          }, 100)
-        }
-      })
-      .catch(() => {})
-  }, [scrollToBottom])
 
   // --- WebSocket connection with reconnect ---
   const connectWS = useCallback(() => {
@@ -747,6 +755,8 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
                 // Find or create a streaming placeholder message at the end
                 const last = prev[prev.length - 1]
                 if (last && last.id === '__streaming__') {
+                  // Only update if content actually changed to reduce re-renders
+                  if (last.content === content) return prev
                   return [...prev.slice(0, -1), { ...last, content: content }]
                 }
                 return [...prev, {
@@ -846,6 +856,8 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
               }
               return [...filtered, msg]
             })
+            // Update context info after receiving final message
+            fetchContextInfo()
             break
           }
 
@@ -1126,6 +1138,19 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
           }`}>
             {connected ? '● Connected' : reconnecting ? '◐ Connecting...' : '○ Disconnected'}
           </span>
+          {/* Context indicator */}
+          {contextInfo && contextInfo.max_tokens > 0 && (
+            <span
+              className={`text-xs px-2 py-0.5 rounded-full ${
+                contextInfo.usage_pct > 80 ? 'bg-red-900/50 text-red-400' :
+                contextInfo.usage_pct > 50 ? 'bg-yellow-900/50 text-yellow-400' :
+                'bg-green-900/50 text-green-400'
+              }`}
+              title={`上下文使用: ${contextInfo.prompt_tokens.toLocaleString()} / ${contextInfo.max_tokens.toLocaleString()} tokens`}
+            >
+              📊 {(contextInfo.prompt_tokens / 1000).toFixed(1)}K/{(contextInfo.max_tokens / 1000).toFixed(0)}K ({contextInfo.usage_pct.toFixed(1)}%)
+            </span>
+          )}
           {/* Model selector */}
           {availableModels.length > 0 && (
             <div className="relative">
@@ -1248,9 +1273,31 @@ export default function ChatPage({ onLogout }: ChatPageProps) {
       {/* Main content: ChatSidebar + messages */}
       <div className="flex flex-1 min-h-0">
         <ChatSidebar
-          onSwitchChat={() => { setMessages([]) }}
-          onNewChat={() => { setMessages([]) }}
-          currentChatID=""
+          onSwitchChat={(chatID: string) => {
+            setCurrentChatID(chatID)
+            setMessages([])
+            setProgress(null)
+            setLiveIterationsSync([])
+            prevIterationRef.current = -1
+            progressRef.current = null
+            reasoningRef.current = ''
+            streamingContentRef.current = ''
+            setLoading(false)
+            // Reload history for the new chat after switch
+            setTimeout(() => loadHistory(), 100)
+          }}
+          onNewChat={() => {
+            setMessages([])
+            setProgress(null)
+            setLiveIterationsSync([])
+            prevIterationRef.current = -1
+            progressRef.current = null
+            reasoningRef.current = ''
+            streamingContentRef.current = ''
+            setLoading(false)
+            setContextInfo(null)
+          }}
+          currentChatID={currentChatID}
         />
         <div className="flex flex-col flex-1 min-w-0">
 


### PR DESCRIPTION
## Changes

### Issue #506: Context Display in Chat Dialog
- **New `/api/context-info` endpoint**: Returns real token usage (prompt_tokens, max_tokens, usage_pct, source) directly from DB
- **Context indicator in header**: Shows `📊 12.5K/128K (9.8%)` with color coding (green <50%, yellow 50-80%, red >80%)
- **Auto-refresh**: Fetches context info after each assistant response

### /compress Always Allowed
- Removed threshold check in `handleCompress` — `/compress` can now be triggered at any time regardless of current token count

### Token Persistence Verification
- ✅ Confirmed: `SaveTokenState` is called in `engine_run.go` after each `Run()` that had an LLM call with `promptTokens > 0`
- ✅ Data is persisted to `tenant_state` table via `MemoryService.SetTokenState`
- ✅ `handleContextInfo` reads from DB (API values), never falls back to estimation when API data exists
- ✅ The `source` field in `/api/context-info` is always `"api"` when data exists (only `"none"` before first LLM call)

### Web UI Fixes

#### Session Switching Bug (Critical)
- **Root cause**: `ChatSidebar` passed `currentChatID=""` hardcoded, and `onSwitchChat` only called `setMessages([])` without reloading history
- **Backend fix**: `handleHistoryGet` now uses `getCurrentChatID(senderID)` instead of raw `senderID`, so it returns the correct tenant's history after chat switch
- **Frontend fix**: Added `currentChatID` state, pass it to `ChatSidebar`, and `onSwitchChat` now reloads history for the new chat

#### Stream Performance (Weak Network)
- **Optimization**: Skip `setMessages` call when streaming content hasn't changed (reduces React re-renders)
- **Scroll throttling**: Auto-scroll now uses `requestAnimationFrame` to avoid layout thrashing during rapid stream updates

#### Stream Cursor Position
- RAF-based scroll throttling prevents cursor jump issues caused by synchronous scroll operations competing with rendering

## Files Changed
- `agent/compress.go` — Remove threshold check
- `channel/web.go` — Add `/api/context-info` route
- `channel/web_api.go` — New `handleContextInfo` handler + fix `handleHistoryGet` to use `getCurrentChatID`
- `web/src/ChatPage.tsx` — Context indicator, chat switching fix, stream optimization

Closes #506