### PR TITLE
fix: compress token state fallback + masked key diagnostics

### DIFF
--- a/agent/engine_run.go
+++ b/agent/engine_run.go
@@ -749,15 +749,31 @@ func (s *runState) maybeCompress(ctx context.Context) {
 		totalTokens = s.lastPromptTokens
 		tokenSource = "restored"
 	} else {
-		// No API token data available. This should never happen in production:
-		// - First Run: no need to compress (few messages)
-		// - Subsequent Runs: API call always sets lastPromptTokens
-		// - After restart: DB restoration sets lastPromptTokens via SaveTokenState
-		if len(s.messages) > 3 {
-			log.Ctx(ctx).Error("maybeCompress: no API token data available, skipping compress check")
+		// No API token data available. This can happen when:
+		// - First Run after upgrade (no SaveTokenState was ever called)
+		// - GetOrCreateSession failed during buildToolContextExtras (TenantID=0)
+		// - SaveTokenState callback is nil
+		// Use local estimation with 1.5x safety margin as fallback.
+		// This is less accurate than API token counts but infinitely better
+		// than totalTokens=0 which never compresses (→ context_window_exceeded).
+		estimated, estErr := llm.CountMessagesTokens(s.messages, s.cfg.Model)
+		if estErr == nil && estimated > 0 {
+			totalTokens = int64(float64(estimated) * 1.5)
+			tokenSource = "local_estimate_fallback"
+			if len(s.messages) > 3 {
+				log.Ctx(ctx).WithFields(log.Fields{
+					"estimated": estimated,
+					"adjusted":  totalTokens,
+					"msg_count": len(s.messages),
+				}).Warn("maybeCompress: no API token data, using local estimation with 1.5x margin")
+			}
+		} else {
+			if len(s.messages) > 3 {
+				log.Ctx(ctx).WithError(estErr).Error("maybeCompress: no API token data and local estimation failed, skipping compress check")
+			}
+			totalTokens = 0
+			tokenSource = "no_data"
 		}
-		totalTokens = 0
-		tokenSource = "no_data"
 	}
 
 	needCompress := len(s.messages) > 3 && shouldCompact(int(totalTokens), promptBudget) && (s.lastCompressIter == 0 || s.compressAttempts-s.lastCompressIter >= 5)

--- a/agent/llm_factory.go
+++ b/agent/llm_factory.go
@@ -102,6 +102,16 @@ func (f *LLMFactory) GetLLM(senderID string) (llm.LLM, string, int, string) {
 	if f.subscriptionSvc != nil {
 		sub, err := f.subscriptionSvc.GetDefault(senderID)
 		if err == nil && sub != nil && sub.BaseURL != "" && sub.APIKey != "" {
+			// Diagnostic: detect masked keys that would cause API auth failures
+			if strings.HasSuffix(sub.APIKey, "****") && len(sub.APIKey) <= 20 {
+				log.WithFields(log.Fields{
+					"sender_id": senderID,
+					"sub_id":    sub.ID,
+					"base_url":  sub.BaseURL,
+					"api_key":   sub.APIKey,
+					"provider":  sub.Provider,
+				}).Error("[LLMFactory] GetLLM: subscription has masked API key — real key was lost!")
+			}
 			client := f.createClientFromSub(sub, sub.Model)
 			if client != nil {
 				model := sub.Model

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -961,7 +961,8 @@ func handleCLIRPC(cfg *config.Config, backend agent.AgentBackend, disp *channel.
 		p.Sub.ID = p.ID
 		p.Sub.SenderID = existing.SenderID
 		p.Sub.IsDefault = existing.IsDefault // preserve is_default (client sends zero)
-		if strings.HasSuffix(p.Sub.APIKey, "****") {
+		if strings.HasSuffix(p.Sub.APIKey, "****") && len(p.Sub.APIKey) <= 20 {
+			log.WithField("sub_id", p.ID).Warn("[RPC] update_subscription: preserving existing API key (received masked)")
 			p.Sub.APIKey = existing.APIKey
 		}
 		if err := svc.Update(&p.Sub); err != nil {


### PR DESCRIPTION
## Changes

### 1. maybeCompress "no_data" fallback
**问题**: `maybeCompress` 在 `lastPromptTokens == 0` 时直接 `totalTokens=0`，永不压缩。消息无限增长直到 `context_window_exceeded`。

**修复**: 使用 `CountMessagesTokens` 本地估算 + 1.5x 安全余量作为 fallback。虽然不如 API 精确值准确，但比 `totalTokens=0` 永远跳过要好得多。

### 2. Masked API Key 诊断
**问题**: `list_models` 和某些操作报 "unauthorized"，但正常对话可以。怀疑订阅的 API key 被替换成了 masked 版本（`sk-a****`）。

**修复**: 
- `LLMFactory.GetLLM` 加诊断日志：检测订阅中是否有 masked key
- `update_subscription` RPC 的 masked key 检测加上长度条件（与 `backend_local.go` 一致）

### Files
- `agent/engine_run.go` — maybeCompress fallback
- `agent/llm_factory.go` — masked key 诊断
- `serverapp/server.go` — update_subscription 长度检查