### PR TITLE
fix: linux installer not showing mode selection when piped

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,10 +60,11 @@ ask_mode() {
         esac
         return
     fi
-    # When piped (curl | bash), stdin is not a terminal.
-    # Default to standalone in that case.
-    if [ ! -t 0 ]; then
-        info "Non-interactive mode (stdin is pipe). Defaulting to standalone."
+    # When piped (curl | bash), stdin is not a terminal but the user may still
+    # be at an interactive shell. Try /dev/tty first — it bypasses the pipe
+    # and connects directly to the user's terminal.
+    if [ ! -e /dev/tty ]; then
+        info "Non-interactive mode (no /dev/tty). Defaulting to standalone."
         info "Use MODE=server-client or run interactively to change."
         echo "standalone"
         return
@@ -401,8 +402,8 @@ main() {
     MODE=$(ask_mode)
     TOKEN=$(random_token)
     PORT="$DEFAULT_PORT"
-    if [ "$MODE" = "server-client" ] && [ -z "${NONINTERACTIVE:-}" ]; then
-        printf "Server port (HTTP + WebSocket + Web UI) [${DEFAULT_PORT}]: " >&2
+    if [ "$MODE" = "server-client" ] && [ -z "${NONINTERACTIVE:-}" ] && [ -e /dev/tty ]; then
+        printf "Server port (HTTP + WebSocket + Web UI) [${DEFAULT_PORT}]: "
         read -r input_port </dev/tty
         PORT="${input_port:-$DEFAULT_PORT}"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,37 +52,34 @@ resolve_version() {
 }
 
 # Non-interactive: use MODE env var. Interactive: prompt user.
-# IMPORTANT: all prompt output goes to stderr (>&2) because this function
-# is called via command substitution: MODE=$(ask_mode). $() captures stdout,
-# so any echo/printf to stdout would be swallowed — the user would never see
-# the prompt but read would block waiting for input.
+# Sets MODE variable directly (no command substitution) so that prompts
+# always reach the user's terminal, even when piped (curl | bash).
 ask_mode() {
+    # Env var takes priority (for non-interactive / CI usage)
     if [ -n "${MODE:-}" ]; then
         case "$MODE" in
-            standalone|server-client) echo "$MODE" ;;
+            standalone|server-client) ;;
             *) error "Invalid MODE='${MODE}'. Use 'standalone' or 'server-client'." ;;
         esac
         return
     fi
-    # Try /dev/tty — bypasses the curl pipe on stdin so we can read user input.
-    # Check readability: -c (char device) + -r (readable) is more reliable than -e.
-    if ! [ -c /dev/tty ] || ! [ -r /dev/tty ]; then
+    # In piped mode, stdin is the curl pipe. We need /dev/tty to talk to the user.
+    if ! [ -c /dev/tty ] 2>/dev/null || ! [ -r /dev/tty ] 2>/dev/null; then
         info "Non-interactive mode (no /dev/tty). Defaulting to standalone."
         info "Set MODE=server-client to install server-client mode."
-        echo "standalone"
+        MODE=standalone
         return
     fi
-    echo "" >&2
-    echo "Choose install mode:" >&2
-    echo "  1) standalone      - CLI runs locally in-process" >&2
-    echo "  2) server-client   - install local server service, CLI connects remotely" >&2
-    printf "Select [1/2] (default 1): " >&2
-    local mode
-    read -r mode </dev/tty || mode=1
-    case "${mode:-1}" in
-        1) echo "standalone" ;;
-        2) echo "server-client" ;;
-        *) echo "standalone" ;;
+    echo ""
+    echo "Choose install mode:"
+    echo "  1) standalone      - CLI runs locally in-process"
+    echo "  2) server-client   - install local server service, CLI connects remotely"
+    printf "Select [1/2] (default 1): "
+    local choice
+    read -r choice </dev/tty || choice=1
+    case "${choice:-1}" in
+        2) MODE=server-client ;;
+        *) MODE=standalone ;;
     esac
 }
 
@@ -403,7 +400,7 @@ main() {
     info "Config:    ${CONFIG_PATH}"
     echo ""
 
-    MODE=$(ask_mode)
+    ask_mode
     TOKEN=$(random_token)
     PORT="$DEFAULT_PORT"
     if [ "$MODE" = "server-client" ] && [ -z "${NONINTERACTIVE:-}" ] && [ -e /dev/tty ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,6 +52,10 @@ resolve_version() {
 }
 
 # Non-interactive: use MODE env var. Interactive: prompt user.
+# IMPORTANT: all prompt output goes to stderr (>&2) because this function
+# is called via command substitution: MODE=$(ask_mode). $() captures stdout,
+# so any echo/printf to stdout would be swallowed — the user would never see
+# the prompt but read would block waiting for input.
 ask_mode() {
     if [ -n "${MODE:-}" ]; then
         case "$MODE" in
@@ -60,25 +64,25 @@ ask_mode() {
         esac
         return
     fi
-    # When piped (curl | bash), stdin is not a terminal but the user may still
-    # be at an interactive shell. Try /dev/tty first — it bypasses the pipe
-    # and connects directly to the user's terminal.
-    if [ ! -e /dev/tty ]; then
+    # Try /dev/tty — bypasses the curl pipe on stdin so we can read user input.
+    # Check readability: -c (char device) + -r (readable) is more reliable than -e.
+    if ! [ -c /dev/tty ] || ! [ -r /dev/tty ]; then
         info "Non-interactive mode (no /dev/tty). Defaulting to standalone."
-        info "Use MODE=server-client or run interactively to change."
+        info "Set MODE=server-client to install server-client mode."
         echo "standalone"
         return
     fi
-    echo ""
-    echo "Choose install mode:"
-    echo "  1) standalone      - CLI runs locally in-process"
-    echo "  2) server-client   - install local server service, CLI connects remotely"
-    printf "Select [1/2] (default 1): "
-    read -r mode </dev/tty
+    echo "" >&2
+    echo "Choose install mode:" >&2
+    echo "  1) standalone      - CLI runs locally in-process" >&2
+    echo "  2) server-client   - install local server service, CLI connects remotely" >&2
+    printf "Select [1/2] (default 1): " >&2
+    local mode
+    read -r mode </dev/tty || mode=1
     case "${mode:-1}" in
         1) echo "standalone" ;;
         2) echo "server-client" ;;
-        *) error "Invalid selection: ${mode}" ;;
+        *) echo "standalone" ;;
     esac
 }
 


### PR DESCRIPTION
## Bug Fix

When running `curl -fsSL ... | bash`, the installer's `ask_mode()` function checked `[ ! -t 0 ]` (stdin is not a terminal). Since stdin is the pipe from curl, this is always true, causing the installer to silently default to `standalone` mode without giving the user a choice.

## Fix

Changed the check from `[ ! -t 0 ]` (stdin is terminal?) to `[ ! -e /dev/tty ]` (is /dev/tty available?). The `read` command already uses `/dev/tty` to get user input, so checking `/dev/tty` availability is the correct test — it works even when stdin is piped.

Also added the same `/dev/tty` guard to the port prompt for server-client mode.

## Test

```bash
# Before fix: silently picks standalone, no prompt
echo "" | bash scripts/install.sh

# After fix: shows mode selection prompt via /dev/tty
```