### PR TITLE
fix(cli): show model name in remote TUI status bar on startup

### DIFF
--- a/agent/backend_remote.go
+++ b/agent/backend_remote.go
@@ -966,7 +966,10 @@ func (b *RemoteBackend) SetLLMConcurrency(senderID string, personal int) error {
 // ---------------------------------------------------------------------------
 
 func (b *RemoteBackend) GetDefaultModel() string {
-	s, _ := b.callRPCString("get_default_model", nil)
+	s, err := b.callRPCString("get_default_model", nil)
+	if err != nil {
+		log.WithError(err).Warn("RemoteBackend: GetDefaultModel RPC failed")
+	}
 	return s
 }
 

--- a/channel/cli_update.go
+++ b/channel/cli_update.go
@@ -425,6 +425,10 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 
 	case idleTickMsg:
 		// Low-frequency idle tick: rotate placeholder and keep alive
+		// Remote mode: keep retrying model name fetch until we get one.
+		if m.cachedModelName == "" && m.remoteMode {
+			m.refreshCachedModelName()
+		}
 		if !m.typing && m.progress == nil {
 			m.updatePlaceholder()
 			cmds = append(cmds, idleTickCmd())
@@ -471,6 +475,11 @@ func (m *cliModel) Update(msg tea.Msg) (model tea.Model, retCmd tea.Cmd) {
 	case splashDoneMsg:
 		// §14 启动画面结束确认
 		m.splashDone = true
+		// Remote mode: retry model name fetch — the initial call in cli.go:76
+		// may have failed if the WS RPC wasn't fully ready yet.
+		if m.cachedModelName == "" && m.remoteMode {
+			m.refreshCachedModelName()
+		}
 		if m.typing && m.progress != nil && !m.fastTickActive {
 			m.fastTickActive = true
 			cmds = append(cmds, tickCmd())


### PR DESCRIPTION
## Problem

In remote TUI mode, the status bar model indicator (e.g. `· glm-5.5 [Ctrl+N]`) did not appear until the user manually switched models via Ctrl+N. The status bar only showed `● ready · 30 msgs`.

## Root Cause

`refreshCachedModelName()` was called once during channel init (`cli.go:76`). If the `GetDefaultModel()` RPC failed (e.g. WS not fully ready), `cachedModelName` stayed empty with **no retry mechanism**. Additionally, `GetDefaultModel()` silently swallowed RPC errors (`s, _ :=`), making failures invisible.

## Fix

1. **Retry after splash ends** (`cli_update.go`): The splash runs for ~1s, giving the WS connection time to stabilize. After splash ends, if `cachedModelName` is still empty, retry the fetch.

2. **Retry on idle tick** (`cli_update.go`): Every 3s idle tick, retry `refreshCachedModelName()` while `cachedModelName` is empty in remote mode. Stops retrying once a model name is obtained.

3. **Log RPC failures** (`backend_remote.go`): `GetDefaultModel()` now logs RPC errors instead of silently discarding them.

## Files Changed

- `channel/cli_update.go`: Added retry logic in `splashDoneMsg` and `idleTickMsg` handlers
- `agent/backend_remote.go`: Added error logging in `GetDefaultModel()`