### PR TITLE
fix: sandbox_mode DB override on startup + runtime reinit

### DIFF
--- a/channel/cli_helpers.go
+++ b/channel/cli_helpers.go
@@ -102,7 +102,7 @@ func isUserScopedSettingKey(key string) bool {
 	return ok
 }
 
-func isGlobalScopedSettingKey(key string) bool {
+func IsGlobalScopedSettingKey(key string) bool {
 	_, ok := cliGlobalScopedSettingKeys[key]
 	return ok
 }
@@ -121,7 +121,7 @@ func cliSettingScope(key string) string {
 	if isUserScopedSettingKey(key) {
 		return "user"
 	}
-	if isGlobalScopedSettingKey(key) {
+	if IsGlobalScopedSettingKey(key) {
 		return "global"
 	}
 	if isSubscriptionScopedSettingKey(key) {

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -899,6 +899,9 @@ func main() {
 				if isCLISubscriptionSettingKey(k) {
 					continue // subscription fields handled above
 				}
+				if channel.IsGlobalScopedSettingKey(k) {
+					continue // global-scoped keys not stored in DB
+				}
 				_ = app.backend.SetSetting("cli", "cli_user", k, v)
 			}
 			applyCLISettingsToBackend(app.backend, "cli_user", values)

--- a/serverapp/rpc_table.go
+++ b/serverapp/rpc_table.go
@@ -153,6 +153,15 @@ func registerSettingsHandlers(t rpcTable, h *rpcContext) {
 		case "llm_provider", "llm_api_key", "llm_model", "llm_base_url":
 			return nil
 		}
+		// Global-scoped keys (sandbox_mode) are server-level config, not per-user.
+		// Apply runtime effect but don't persist to user_settings DB —
+		// the source of truth is config.json.
+		if channel.IsGlobalScopedSettingKey(p.Key) {
+			if isAdmin(rpcAuthID(ctx)) {
+				applyRuntimeSetting(h.cfg, h.backend, bizID, p.Key, p.Value)
+			}
+			return nil
+		}
 		if h.backend.SettingsService() == nil {
 			return errSettingsUnavailable
 		}

--- a/serverapp/server.go
+++ b/serverapp/server.go
@@ -437,9 +437,19 @@ func Run(args []string) error {
 
 	// Sync Agent runtime settings from DB (admin user).
 	// DB is the source of truth — config.json may be stale after user changes.
+	// Exception: sandbox_mode is a server-level config initialized from config.json
+	// by InitSandbox above. DB should NOT override it on startup.
 	if ss := backend.SettingsService(); ss != nil {
 		if vals, err := ss.GetSettings("cli", cliSenderID); err == nil {
+			// Preserve config.json sandbox_mode — it was already used by InitSandbox.
+			// Remove from vals so applyRuntimeSettings doesn't override it.
+			sandboxFromConfig := cfg.Sandbox.Mode
+			delete(vals, "sandbox_mode")
 			applyRuntimeSettings(cfg, backend, cliSenderID, vals)
+			// Ensure sandbox_mode stays as config.json set it.
+			if sandboxFromConfig != "" {
+				cfg.Sandbox.Mode = sandboxFromConfig
+			}
 			log.Info("Agent runtime settings synced from DB")
 		}
 	}

--- a/serverapp/server_test.go
+++ b/serverapp/server_test.go
@@ -155,7 +155,6 @@ func (b fakeBackend) SetMaxIterations(_ int)                                    
 func (b fakeBackend) SetMaxConcurrency(_ int)                                        {}
 func (b fakeBackend) SetMaxContextTokens(_ int)                                      {}
 func (b fakeBackend) SetSandbox(_ tools.Sandbox, _ string)                           {}
-func (b fakeBackend) CallRPC(_ string, _ any) (json.RawMessage, error)               { return nil, nil }
 func (b fakeBackend) GetCardBuilder() *tools.CardBuilder                             { return nil }
 func (b fakeBackend) SetEventRouter(_ *event.Router)                                 {}
 func (b fakeBackend) RegisterTool(_ tools.Tool)                                      {}

--- a/serverapp/server_test.go
+++ b/serverapp/server_test.go
@@ -155,6 +155,7 @@ func (b fakeBackend) SetMaxIterations(_ int)                                    
 func (b fakeBackend) SetMaxConcurrency(_ int)                                        {}
 func (b fakeBackend) SetMaxContextTokens(_ int)                                      {}
 func (b fakeBackend) SetSandbox(_ tools.Sandbox, _ string)                           {}
+func (b fakeBackend) CallRPC(_ string, _ any) (json.RawMessage, error)               { return nil, nil }
 func (b fakeBackend) GetCardBuilder() *tools.CardBuilder                             { return nil }
 func (b fakeBackend) SetEventRouter(_ *event.Router)                                 {}
 func (b fakeBackend) RegisterTool(_ tools.Tool)                                      {}

--- a/serverapp/setting_handlers.go
+++ b/serverapp/setting_handlers.go
@@ -8,6 +8,7 @@ import (
 	"xbot/channel"
 	"xbot/config"
 	log "xbot/logger"
+	"xbot/tools"
 )
 
 // settingHandler defines how a setting key updates runtime state.
@@ -18,6 +19,10 @@ type settingHandler struct {
 	// ApplyBackend applies runtime side effects via the backend.
 	// Called after ApplyConfig. Both backend and senderID are non-nil/non-empty.
 	ApplyBackend func(backend agent.AgentBackend, senderID, value string)
+	// ApplyFull is called with both cfg and backend. Used when the side effect
+	// needs config context (e.g. sandbox reinit needs cfg.Agent.WorkDir).
+	// If set, called instead of the ApplyConfig+ApplyBackend pair.
+	ApplyFull func(cfg *config.Config, backend agent.AgentBackend, senderID, value string)
 }
 
 // settingHandlerRegistry is the single source of truth for server-side runtime
@@ -52,6 +57,14 @@ var settingHandlerRegistry = map[string]settingHandler{
 	// --- Agent settings ---
 	"sandbox_mode": {
 		ApplyConfig: func(cfg *config.Config, value string) { cfg.Sandbox.Mode = value },
+		ApplyFull: func(cfg *config.Config, backend agent.AgentBackend, senderID, value string) {
+			workDir := cfg.Agent.WorkDir
+			if workDir == "" {
+				workDir = "."
+			}
+			tools.ReinitSandbox(cfg.Sandbox, workDir)
+			backend.SetSandbox(tools.GetSandbox(), value)
+		},
 	},
 	"memory_provider": {
 		ApplyConfig: func(cfg *config.Config, value string) { cfg.Agent.MemoryProvider = value },
@@ -136,11 +149,15 @@ func applyRuntimeSetting(cfg *config.Config, backend agent.AgentBackend, senderI
 		}
 		return
 	}
-	if handler.ApplyConfig != nil {
-		handler.ApplyConfig(cfg, value)
-	}
-	if handler.ApplyBackend != nil && backend != nil {
-		handler.ApplyBackend(backend, senderID, value)
+	if handler.ApplyFull != nil && backend != nil {
+		handler.ApplyFull(cfg, backend, senderID, value)
+	} else {
+		if handler.ApplyConfig != nil {
+			handler.ApplyConfig(cfg, value)
+		}
+		if handler.ApplyBackend != nil && backend != nil {
+			handler.ApplyBackend(backend, senderID, value)
+		}
 	}
 	if backend != nil && backend.LLMFactory() != nil {
 		backend.LLMFactory().SetModelTiers(cfg.LLM)
@@ -165,21 +182,29 @@ func applyRuntimeSettings(cfg *config.Config, backend agent.AgentBackend, sender
 			}
 			continue
 		}
-		if handler.ApplyConfig != nil {
-			handler.ApplyConfig(cfg, v)
-		}
-		if handler.ApplyBackend != nil && backend != nil {
-			handler.ApplyBackend(backend, senderID, v)
+		if handler.ApplyFull != nil && backend != nil {
+			handler.ApplyFull(cfg, backend, senderID, v)
+		} else {
+			if handler.ApplyConfig != nil {
+				handler.ApplyConfig(cfg, v)
+			}
+			if handler.ApplyBackend != nil && backend != nil {
+				handler.ApplyBackend(backend, senderID, v)
+			}
 		}
 	}
 	// Process context_mode last so it overrides enable_auto_compress
 	if v, ok := values["context_mode"]; ok && v != "" {
 		handler := settingHandlerRegistry["context_mode"]
-		if handler.ApplyConfig != nil {
-			handler.ApplyConfig(cfg, v)
-		}
-		if handler.ApplyBackend != nil && backend != nil {
-			handler.ApplyBackend(backend, senderID, v)
+		if handler.ApplyFull != nil && backend != nil {
+			handler.ApplyFull(cfg, backend, senderID, v)
+		} else {
+			if handler.ApplyConfig != nil {
+				handler.ApplyConfig(cfg, v)
+			}
+			if handler.ApplyBackend != nil && backend != nil {
+				handler.ApplyBackend(backend, senderID, v)
+			}
 		}
 	}
 	// SetModelTiers and config save: once after all keys


### PR DESCRIPTION
## Bug Fix

用户反馈：在 config.json 设置 `"sandbox": {"mode": "none"}`，重启服务器后飞书仍使用 docker sandbox。

### 根因分析

两个问题：

**1. 运行时 sandbox_mode 修改无效**
`sandbox_mode` 的 setting handler 只有 `ApplyConfig`（更新 cfg.Sandbox.Mode），没有 `ApplyBackend`/`ApplyFull`。通过飞书 settings 面板修改 sandbox_mode 后，`cfg.Sandbox.Mode` 虽然改了，但 sandbox 实例（全局 `tools.GetSandbox()`）没有重新初始化。

**2. 启动时 DB 值覆盖 config.json**
启动流程中 `applyRuntimeSettings` 从 DB `user_settings` 表读取 settings，无差别覆盖 `cfg.Sandbox.Mode`。如果 DB 里有旧的 `sandbox_mode = "docker"`（之前通过 settings RPC 保存的），会覆盖 config.json 里的 `"none"`。

### 修复内容

1. **`setting_handlers.go`**：
   - 给 `settingHandler` 新增 `ApplyFull` 字段（带 cfg + backend 参数）
   - `sandbox_mode` handler 使用 `ApplyFull` 调用 `tools.ReinitSandbox` + `backend.SetSandbox`
   - `applyRuntimeSetting` 和 `applyRuntimeSettings` 中优先调用 `ApplyFull`

2. **`server.go`**：
   - 启动同步时从 vals 中删除 `sandbox_mode`，防止 DB 覆盖 config.json
   - 在 `applyRuntimeSettings` 之后恢复 `cfg.Sandbox.Mode` 为 config.json 的值

3. **`server_test.go`**：
   - `fakeBackend` 添加 `CallRPC` stub 方法（接口新增方法）

### 测试
- `go build ./...` ✅
- `go test ./serverapp/...` ✅
- `gofmt` clean ✅