### PR TITLE
fix: reset token state on /new and support DeepSeek reasoning_effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1 | iex
 ```
 
 指定版本或安装路径：
@@ -154,7 +154,7 @@ xbot-cli
 ## 从源码构建
 
 ```bash
-git clone https://github.com/CjiW/xbot.git && cd xbot
+git clone https://github.com/ai-pivot/xbot.git && cd xbot
 make build          # 构建 xbot (server + runner)
 make run            # 构建并运行 server
 ```

--- a/agent/backend_remote.go
+++ b/agent/backend_remote.go
@@ -120,6 +120,7 @@ type wsIncomingMessage struct {
 	Error           string                     `json:"error,omitempty"`
 	Channel         string                     `json:"channel,omitempty"`
 	ChatID          string                     `json:"chat_id,omitempty"`
+	SessionReset    bool                       `json:"session_reset,omitempty"`
 }
 
 // wsOutgoingMessage represents a message sent to the server.
@@ -466,6 +467,9 @@ func (b *RemoteBackend) readPump(ctx context.Context) {
 			}
 			if msg.ProgressHistory != "" {
 				outMsg.Metadata["progress_history"] = msg.ProgressHistory
+			}
+			if msg.SessionReset {
+				outMsg.Metadata["session_reset"] = "true"
 			}
 			b.outboundMu.RLock()
 			cb := b.outboundCb

--- a/agent/llm_config_handler.go
+++ b/agent/llm_config_handler.go
@@ -22,6 +22,7 @@ const setLLMUsage = `用法: /set-llm provider=<provider> base_url=<url> api_key
                   DeepSeek/OpenAI reasoning:
                     - enabled: 强制开启
                     - disabled: 强制关闭
+                    - {"thinking":{"type":"enabled"},"reasoning_effort":"high"}: 指定思考强度 (high/max)
                   智谱 GLM:
                     - {"type":"enabled","clear_thinking":false}: 保留式思考（多轮推理连贯）
                   Anthropic Claude:
@@ -37,6 +38,9 @@ const setLLMUsage = `用法: /set-llm provider=<provider> base_url=<url> api_key
 
   # DeepSeek R1 (Thinking Mode)
   /set-llm provider=deepseek base_url=https://api.deepseek.com/v1 api_key=sk-xxx model=deepseek-reasoner thinking_mode=enabled
+
+  # DeepSeek R1 with reasoning_effort (控制思考强度)
+  /set-llm provider=deepseek base_url=https://api.deepseek.com/v1 api_key=sk-xxx model=deepseek-reasoner thinking_mode={"thinking":{"type":"enabled"},"reasoning_effort":"high"}
 
   # 智谱 GLM-5/GLM-4.7 (深度思考)
   /set-llm provider=openai base_url=https://open.bigmodel.cn/api/paas/v4 api_key=xxx model=glm-5 thinking_mode=enabled

--- a/agent/prompt_handler.go
+++ b/agent/prompt_handler.go
@@ -139,9 +139,21 @@ func (a *Agent) handleNewSession(ctx context.Context, msg bus.InboundMessage, te
 		a.maskStore.Clear()
 	}
 
+	// Clear token state so the context usage bar resets on /new.
+	// Without this, the next Run() would restore stale token counts from DB
+	// and the CLI progress bar would show the old session's usage.
+	if memSvc := tenantSession.MemoryService(); memSvc != nil {
+		if err := memSvc.SetTokenState(ctx, tenantSession.TenantID(), 0, 0); err != nil {
+			log.Ctx(ctx).WithError(err).WithField("tenant_id", tenantSession.TenantID()).Warn("Failed to clear token state on /new")
+		}
+	}
+
 	return &bus.OutboundMessage{
 		Channel: msg.Channel,
 		ChatID:  msg.ChatID,
 		Content: "会话已重置，记忆已归档。",
+		Metadata: map[string]string{
+			"session_reset": "true",
+		},
 	}, nil
 }

--- a/channel/cli_message.go
+++ b/channel/cli_message.go
@@ -702,6 +702,13 @@ func (m *cliModel) handleAgentMessage(msg bus.OutboundMessage) {
 		m.renderCacheValid = false
 		m.updateViewportContent()
 
+		// §11.5 Session reset: clear token usage bar after /new
+		if msg.Metadata != nil && msg.Metadata["session_reset"] == "true" {
+			m.lastTokenUsage = nil
+			m.ctxBarCacheKey = ""
+			m.ctxBarCache = ""
+		}
+
 		// §12 AskUser panel: detect WaitingUser and open interactive panel
 		if msg.WaitingUser {
 			var items []askItem

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -201,7 +201,7 @@ func localeZH() *UILocale {
 		AskCancelled:   "已取消提问",
 		SetupComplete:  "✅ 初始配置完成，可以开始使用了。随时用 /settings 修改配置，/setup 重新引导。",
 		SetupLettaNote: "\n\n[!] letta 记忆模式需要嵌入服务:\n  1. 安装 Ollama: https://ollama.ai\n  2. 拉取嵌入模型: `ollama pull nomic-embed-text`\n  3. 在配置或环境变量中设置嵌入端点",
-		UpdateFound:    "发现新版本: %s → %s\n升级命令: curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash\n%s",
+		UpdateFound:    "发现新版本: %s → %s\n升级命令: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
 		UpdateCurrent:  "当前版本 %s 已是最新",
 		UpdateFailed:   "更新检查失败（网络超时或无法连接 GitHub API）",
 
@@ -580,7 +580,7 @@ func localeEN() *UILocale {
 		AskCancelled:   "Question cancelled",
 		SetupComplete:  "✅ Initial setup complete. Use /settings to configure, /setup to re-run.",
 		SetupLettaNote: "\n\n[!] letta memory mode requires embedding service:\n  1. Install Ollama: https://ollama.ai\n  2. Pull embedding model: `ollama pull nomic-embed-text`\n  3. Set embedding endpoint in config or env",
-		UpdateFound:    "New version available: %s → %s\nUpdate command: curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash\n%s",
+		UpdateFound:    "New version available: %s → %s\nUpdate command: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
 		UpdateCurrent:  "Current version %s is up to date",
 		UpdateFailed:   "Update check failed (network timeout or unable to connect to GitHub API)",
 
@@ -959,7 +959,7 @@ func localeJA() *UILocale {
 		AskCancelled:   "質問をキャンセルしました",
 		SetupComplete:  "✅ 初期設定が完了しました。/settings で設定変更、/setup で再設定。",
 		SetupLettaNote: "\n\n[!] letta メモリモードには埋め込みサービスが必要です:\n  1. Ollama をインストール: https://ollama.ai\n  2. 埋め込みモデルを取得: `ollama pull nomic-embed-text`\n  3. 設定または環境変数で埋め込みエンドポイントを設定",
-		UpdateFound:    "新しいバージョン: %s → %s\nアップデート: curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash\n%s",
+		UpdateFound:    "新しいバージョン: %s → %s\nアップデート: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash\n%s",
 		UpdateCurrent:  "現在のバージョン %s は最新です",
 		UpdateFailed:   "アップデート確認に失敗（ネットワークタイムアウトまたは GitHub API に接続できません）",
 

--- a/channel/i18n.go
+++ b/channel/i18n.go
@@ -506,6 +506,8 @@ func localeZH() *UILocale {
 					{Label: "开启", Value: "enabled"},
 					{Label: "开启（保留历史推理）", Value: `{"type":"enabled","clear_thinking":false}`},
 					{Label: "关闭", Value: "disabled"},
+					{Label: "DeepSeek: effort=high", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"high"}`},
+					{Label: "DeepSeek: effort=max", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"max"}`},
 				},
 			},
 			{
@@ -885,6 +887,8 @@ func localeEN() *UILocale {
 					{Label: "Enabled", Value: "enabled"},
 					{Label: "Enabled (Preserved)", Value: `{"type":"enabled","clear_thinking":false}`},
 					{Label: "Disabled", Value: "disabled"},
+					{Label: "DeepSeek: effort=high", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"high"}`},
+					{Label: "DeepSeek: effort=max", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"max"}`},
 				},
 			},
 			{
@@ -1264,6 +1268,8 @@ func localeJA() *UILocale {
 					{Label: "有効", Value: "enabled"},
 					{Label: "有効（推論保持）", Value: `{"type":"enabled","clear_thinking":false}`},
 					{Label: "無効", Value: "disabled"},
+					{Label: "DeepSeek: effort=high", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"high"}`},
+					{Label: "DeepSeek: effort=max", Value: `{"thinking":{"type":"enabled"},"reasoning_effort":"max"}`},
 				},
 			},
 			{

--- a/channel/web.go
+++ b/channel/web.go
@@ -463,6 +463,7 @@ type wsMessage struct {
 	SenderID        string             `json:"sender_id,omitempty"`
 	SenderName      string             `json:"sender_name,omitempty"`
 	ChatType        string             `json:"chat_type,omitempty"`
+	SessionReset    bool               `json:"session_reset,omitempty"` // signals /new — CLI should clear context usage bar
 	// RPC response fields (used when Type == "rpc_response")
 	Result json.RawMessage `json:"result,omitempty"`
 	Error  string          `json:"error,omitempty"`
@@ -903,6 +904,7 @@ func (wc *WebChannel) Send(msg bus.OutboundMessage) (string, error) {
 		ProgressHistory: msg.Metadata["progress_history"],
 		Channel:         msg.Channel,
 		ChatID:          msg.ChatID,
+		SessionReset:    msg.Metadata != nil && msg.Metadata["session_reset"] == "true",
 	}
 
 	targetClientID := msg.ChatID

--- a/cmd/xbot-cli/main.go
+++ b/cmd/xbot-cli/main.go
@@ -676,7 +676,7 @@ func main() {
 		switch os.Args[1] {
 		case "install":
 			fmt.Println("install 子命令已不再主推，请使用 scripts/install.sh")
-			fmt.Println("例如: curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash")
+			fmt.Println("例如: curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash")
 			return
 		case "serve":
 			if err := serverapp.Run(os.Args[2:]); err != nil {

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -32,10 +32,10 @@ weight: 0
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1 | iex
 ```
 
 安装完成后运行 `xbot-cli`，首次会弹出 Setup 向导引导你配置 API Key。

--- a/docs-site/content/installation.md
+++ b/docs-site/content/installation.md
@@ -11,10 +11,10 @@ weight: 5
 
 ```bash
 # Linux / macOS (amd64, arm64)
-curl -fsSL https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.sh | bash
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1 | iex
 ```
 
 指定版本或安装路径：
@@ -27,7 +27,7 @@ INSTALL_PATH=~/.local/bin curl -fsSL ... | bash  # 自定义安装路径
 ### 从源码构建
 
 ```bash
-git clone https://github.com/CjiW/xbot.git && cd xbot
+git clone https://github.com/ai-pivot/xbot.git && cd xbot
 make build          # 构建 xbot (server + runner)
 make run            # 构建并运行 server
 ```

--- a/docs-site/hugo.toml
+++ b/docs-site/hugo.toml
@@ -13,7 +13,7 @@ pygmentsCodeFences = true
 
 [params]
   geekdocToC = 3
-  geekdocRepo = "https://github.com/CjiW/xbot"
+  geekdocRepo = "https://github.com/ai-pivot/xbot"
   geekdocEditPath = "edit/master/docs-site"
 
 [markup]

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -657,12 +657,28 @@ func (o *OpenAILLM) buildThinkingOptions(thinkingMode string) []option.RequestOp
 		// 不发送任何 thinking 参数，让模型自己决定
 	default:
 		// JSON 格式的 thinking 参数
+		// Supports two formats:
+		//   1. Flat thinking object: {"type": "enabled"} → set as "thinking" param
+		//   2. Nested with extras:   {"thinking": {"type": "enabled"}, "reasoning_effort": "high"}
+		//      → "thinking" object goes to "thinking" param, other keys become top-level params
+		//   3. Arbitrary key-values: {"reasoning_effort": "high"} → each key is a top-level param
 		if len(thinkingMode) > 0 && thinkingMode[0] == '{' {
 			var customParams map[string]any
 			if err := json.Unmarshal([]byte(thinkingMode), &customParams); err == nil {
-				if _, hasType := customParams["type"]; hasType {
+				if thinkingObj, hasThinking := customParams["thinking"]; hasThinking {
+					// Format 2: explicit "thinking" key + optional top-level params
+					opts = append(opts, option.WithJSONSet("thinking", thinkingObj))
+					for key, value := range customParams {
+						if key == "thinking" {
+							continue
+						}
+						opts = append(opts, option.WithJSONSet(key, value))
+					}
+				} else if _, hasType := customParams["type"]; hasType {
+					// Format 1: flat thinking object
 					opts = append(opts, option.WithJSONSet("thinking", customParams))
 				} else {
+					// Format 3: arbitrary key-values
 					for key, value := range customParams {
 						opts = append(opts, option.WithJSONSet(key, value))
 					}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -33,6 +33,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 $REPO = "ai-pivot/xbot"
+$FALLBACK_REPO = "CjiW/xbot"
 $BINARY = "xbot-cli.exe"
 $SERVICE_NAME = "xbot-server"
 $DEFAULT_PORT = 8082
@@ -91,8 +92,13 @@ function Get-LatestVersion {
     try {
         $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -Headers @{"User-Agent"="PowerShell"}
         return $response.tag_name
+    } catch {}
+    try {
+        Write-Warn "No releases found on $REPO, trying fallback $FALLBACK_REPO..."
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/$FALLBACK_REPO/releases/latest" -Headers @{"User-Agent"="PowerShell"}
+        return $response.tag_name
     } catch {
-        Write-Err "Failed to determine latest version. Set -Version explicitly."
+        Write-Err "Failed to determine latest version from both repos. Set -Version explicitly."
     }
 }
 
@@ -469,7 +475,14 @@ $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-cli-download.exe"
 try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
 } catch {
-    Write-Err "Download failed: $_"
+    Write-Warn "Download from $REPO failed, trying fallback $FALLBACK_REPO..."
+    $fallbackUrl = "https://github.com/$FALLBACK_REPO/releases/download/$tag/xbot-cli-$platform.exe"
+    $downloadUrl = $fallbackUrl
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tmpFile -UseBasicParsing
+    } catch {
+        Write-Err "Download failed from both repos: $_"
+    }
 }
 
 $checksumUrl = "https://github.com/$REPO/releases/download/$tag/checksums.txt"
@@ -488,7 +501,25 @@ try {
     }
     Remove-Item $checksumFile -Force -ErrorAction SilentlyContinue
 } catch {
-    Write-Warn "Checksum verification skipped"
+    # Try fallback repo for checksum
+    try {
+        $fallbackChecksumUrl = "https://github.com/$FALLBACK_REPO/releases/download/$tag/checksums.txt"
+        $checksumFile = Join-Path ([System.IO.Path]::GetTempPath()) "xbot-checksums.txt"
+        Invoke-WebRequest -Uri $fallbackChecksumUrl -OutFile $checksumFile -UseBasicParsing
+        $expectedLine = Get-Content $checksumFile | Where-Object { $_ -match "xbot-cli-$platform" }
+        if ($expectedLine) {
+            $expectedHash = ($expectedLine -split "\s+")[0]
+            $actualHash = (Get-FileHash -Path $tmpFile -Algorithm SHA256).Hash.ToLower()
+            if ($expectedHash -ne $actualHash) {
+                Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+                Write-Err "Checksum mismatch! Expected: $expectedHash, Got: $actualHash"
+            }
+            Write-Info "Checksum verified (from fallback repo)"
+        }
+        Remove-Item $checksumFile -Force -ErrorAction SilentlyContinue
+    } catch {
+        Write-Warn "Checksum verification skipped"
+    }
 }
 
 # Stop running xbot-cli processes and scheduled task before overwriting the binary

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,7 +15,7 @@
 .PARAMETER Port
     Server port for server-client mode (default 8082).
 .EXAMPLE
-    irm https://raw.githubusercontent.com/CjiW/xbot/master/scripts/install.ps1 | iex
+    irm https://raw.githubusercontent.com/ai-pivot/xbot/master/scripts/install.ps1 | iex
 .EXAMPLE
     .\install.ps1 -Version v0.1.0
 .EXAMPLE
@@ -32,7 +32,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$REPO = "CjiW/xbot"
+$REPO = "ai-pivot/xbot"
 $BINARY = "xbot-cli.exe"
 $SERVICE_NAME = "xbot-server"
 $DEFAULT_PORT = 8082

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REPO="ai-pivot/xbot"
+FALLBACK_REPO="CjiW/xbot"
 BINARY="xbot-cli"
 # Default to user-local install (no sudo required)
 INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin}"
@@ -47,6 +48,9 @@ resolve_version() {
     fi
     local tag
     tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ -z "$tag" ]; then
+        tag=$(curl -fsSL "https://api.github.com/repos/${FALLBACK_REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    fi
     [ -n "$tag" ] || error "Failed to determine latest version. Set VERSION env var explicitly."
     echo "$tag"
 }
@@ -255,6 +259,9 @@ download_web_dist() {
     fi
     if curl -fSL ${curl_progress} "$dist_url" | tar xzf - -C "$target_dir" 2>/dev/null; then
         info "Web UI installed to ${target_dir} ✓"
+    elif curl -fSL ${curl_progress} "https://github.com/${FALLBACK_REPO}/releases/download/${version}/xbot-web-dist.tar.gz" | tar xzf - -C "$target_dir" 2>/dev/null; then
+        warn "Web UI downloaded from fallback repo ${FALLBACK_REPO}"
+        info "Web UI installed to ${target_dir} ✓"
     else
         warn "Failed to download Web UI frontend. The server will run in API-only mode."
         warn "You can manually download it later from: ${dist_url}"
@@ -416,13 +423,22 @@ main() {
     if [ -t 2 ]; then
         curl_progress="--progress-bar"
     fi
-    if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$DOWNLOAD_URL"; then
-        error "Download failed. Check the version and platform."
+    # Try new repo first; fall back to old repo if release not found
+    # (during migration from CjiW/xbot → ai-pivot/xbot)
+    if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$DOWNLOAD_URL" 2>/dev/null; then
+        FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/xbot-cli-${PLATFORM}"
+        warn "Release not found on ${REPO}, trying fallback ${FALLBACK_REPO}..."
+        DOWNLOAD_URL="$FALLBACK_URL"
+        if ! curl -fSL ${curl_progress} -o "${TMPDIR}/${BINARY}" "$DOWNLOAD_URL"; then
+            error "Download failed from both repos. Check the version and platform."
+        fi
     fi
 
     if command -v shasum >/dev/null 2>&1; then
         info "Verifying checksum..."
-        curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt" -o "${TMPDIR}/checksums.txt" 2>/dev/null || warn "Checksum file not found, skipping verification."
+        curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt" -o "${TMPDIR}/checksums.txt" 2>/dev/null \
+            || curl -fsSL "https://github.com/${FALLBACK_REPO}/releases/download/${VERSION}/checksums.txt" -o "${TMPDIR}/checksums.txt" 2>/dev/null \
+            || warn "Checksum file not found, skipping verification."
         if [ -f "${TMPDIR}/checksums.txt" ]; then
             expected=$(grep "xbot-cli-${PLATFORM}" "${TMPDIR}/checksums.txt" | awk '{print $1}')
             actual=$(shasum -a 256 "${TMPDIR}/${BINARY}" | awk '{print $1}')

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="CjiW/xbot"
+REPO="ai-pivot/xbot"
 BINARY="xbot-cli"
 # Default to user-local install (no sudo required)
 INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin}"

--- a/tools/fetch.go
+++ b/tools/fetch.go
@@ -149,7 +149,7 @@ func (t *FetchTool) fetchURL(ctx *ToolContext, targetURL string) (*http.Response
 	}
 
 	// 设置合理的 User-Agent
-	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; xbot/1.0; +https://github.com/CjiW/xbot)")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; xbot/1.0; +https://github.com/ai-pivot/xbot)")
 
 	// 不发送 Authorization header
 	req.Header.Del("Authorization")

--- a/version/check.go
+++ b/version/check.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	githubAPIURL = "https://api.github.com/repos/CjiW/xbot/releases/latest"
-	checkTimeout = 10 * time.Second
+	newRepoAPIURL = "https://api.github.com/repos/ai-pivot/xbot/releases/latest"
+	oldRepoAPIURL = "https://api.github.com/repos/CjiW/xbot/releases/latest"
+	checkTimeout  = 10 * time.Second
 )
 
 // githubRelease represents the GitHub API response for a release.
@@ -70,6 +71,10 @@ func isNewer(a, b string) bool {
 // CheckUpdate queries GitHub Releases API for the latest version and compares
 // with the local build version. Returns nil if the check fails or version is a
 // dev build (in which case the caller should silently ignore).
+//
+// Migration: tries the new repo (ai-pivot/xbot) first. If the new repo has no
+// releases yet, falls back to the old repo (CjiW/xbot) so existing users don't
+// lose update notifications during the transition.
 func CheckUpdate(ctx context.Context) *UpdateInfo {
 	// Skip if version is completely empty
 	if Version == "" {
@@ -79,7 +84,27 @@ func CheckUpdate(ctx context.Context) *UpdateInfo {
 	ctx, cancel := context.WithTimeout(ctx, checkTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIURL, nil)
+	release := fetchLatestRelease(ctx, newRepoAPIURL)
+	if release == nil {
+		release = fetchLatestRelease(ctx, oldRepoAPIURL)
+	}
+	if release == nil || release.TagName == "" {
+		return nil
+	}
+
+	hasUpdate := isNewer(Version, release.TagName)
+	return &UpdateInfo{
+		Current:   Version,
+		Latest:    release.TagName,
+		URL:       release.HTMLURL,
+		HasUpdate: hasUpdate,
+	}
+}
+
+// fetchLatestRelease queries a single GitHub repo's latest release API.
+// Returns nil on any error (network, non-200, parse failure).
+func fetchLatestRelease(ctx context.Context, apiURL string) *githubRelease {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil
 	}
@@ -106,15 +131,5 @@ func CheckUpdate(ctx context.Context) *UpdateInfo {
 		return nil
 	}
 
-	if release.TagName == "" {
-		return nil
-	}
-
-	hasUpdate := isNewer(Version, release.TagName)
-	return &UpdateInfo{
-		Current:   Version,
-		Latest:    release.TagName,
-		URL:       release.HTMLURL,
-		HasUpdate: hasUpdate,
-	}
+	return &release
 }


### PR DESCRIPTION

## Bug Fix: `/new` 后上下文进度条没重置

**根因**: `handleNewSession` 清空了消息和记忆，但没有清理 DB 中的 token state (`SetTokenState(0,0)`)，也没有通知 CLI 端清除 `lastTokenUsage`。下次 `Run()` 恢复了旧 token 数据，进度条显示上一轮的值。

**修复**:
1. `handleNewSession` 中调用 `SetTokenState(0,0)` 清 DB token state
2. `/new` 回复通过 `Metadata["session_reset"]` 通知客户端
3. CLI `handleAgentMessage` 检测 `session_reset` 后清除 `lastTokenUsage` 和 context bar 缓存
4. Remote mode: `wsMessage`/`wsIncomingMessage` 新增 `SessionReset` 字段通过 WS 传递

## Feature: DeepSeek reasoning_effort 参数支持

根据 [DeepSeek 思考模式文档](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)，工具调用场景支持 `reasoning_effort` 参数控制思考强度。

**实现**:
- `buildThinkingOptions` 支持三种 JSON 格式:
  1. Flat thinking object: `{"type":"enabled"}`
  2. Nested with extras: `{"thinking":{"type":"enabled"},"reasoning_effort":"high"}`
  3. Arbitrary key-values: `{"reasoning_effort":"high"}`
- `reasoning_content` 回传逻辑已正确处理（无需改动）
- 更新 `/set-llm` usage 文档

**示例**:
```
/set-llm provider=deepseek base_url=https://api.deepseek.com/v1 api_key=sk-xxx model=deepseek-reasoner thinking_mode={"thinking":{"type":"enabled"},"reasoning_effort":"high"}
```

## 测试
- ✅ `go build ./...`
- ✅ `go test ./...` (all packages pass)
- ✅ Pre-push hooks passed (vet + build + test)
